### PR TITLE
CLI: install dependencies using yarn or npm during create

### DIFF
--- a/packages/web-cli/src/commands/create.js
+++ b/packages/web-cli/src/commands/create.js
@@ -8,9 +8,15 @@ const clear = require('../utils/clear');
 const cwd = require('../utils/get-cwd');
 const exit = require('../utils/print-and-exit');
 const generateProject = require('../generator');
+const installDeps = require('../generator/install');
 const loadQuestions = require('./create/questions');
 
-module.exports = ({ _, npmOrg }) => {
+module.exports = ({
+  _,
+  npmOrg,
+  yarn,
+  skipInstall,
+}) => {
   const [, path] = _;
   if (!path) {
     exit('A project directory is required.');
@@ -33,7 +39,11 @@ module.exports = ({ _, npmOrg }) => {
     if (!proceed) {
       exit(chalk`Installation {red stopped}`, 0);
     }
-    return generateProject(dir, answers);
+    await generateProject(dir, answers);
+    if (!skipInstall) {
+
+      await installDeps(dir, yarn);
+    }
   };
 
   execute().then(() => {

--- a/packages/web-cli/src/commands/index.js
+++ b/packages/web-cli/src/commands/index.js
@@ -36,6 +36,14 @@ module.exports = (program) => {
       }).option('npm-org', {
         describe: 'Your NPM org name. Will prefix the package name.',
         type: 'string',
+      }).option('yarn', {
+        describe: 'Whether to use Yarn instead of NPM for installing dependencies.',
+        type: 'boolean',
+        default: true,
+      }).option('skip-install', {
+        describe: 'Whether to skip installing dependencies.',
+        type: 'boolean',
+        default: false,
       });
     }, argv => require('./create')(argv));
 };

--- a/packages/web-cli/src/generator/install.js
+++ b/packages/web-cli/src/generator/install.js
@@ -1,0 +1,25 @@
+const log = require('fancy-log');
+const chalk = require('chalk');
+const { spawn } = require('child_process');
+
+module.exports = async (dir, useYarn) => {
+  const cmd = useYarn ? 'yarn install' : 'npm install';
+  log(chalk`Installing dependencies via {magenta ${cmd}}...`);
+  const installer = await spawn(cmd, {
+    stdio: 'inherit',
+    shell: true,
+    cwd: dir,
+  });
+  return new Promise((resolve, reject) => {
+    installer.on('error', reject);
+    installer.on('close', (code, signal) => {
+      if (code) {
+        reject(new Error(`Installer exited with code ${code}`));
+      } else if (signal) {
+        reject(new Error(`Installer exited with signal ${signal}`));
+      } else {
+        resolve();
+      }
+    });
+  });
+};


### PR DESCRIPTION
Once files are generated and copied to the destination project directory, install the dependencies using either Yarn or NPM.

To skip install, set the `--skip-install` flag when running the `create` command
To use npm instead of Yarn, set the `--yarn false` flag when running the `create` command

![image](https://user-images.githubusercontent.com/3289485/54049885-729edf80-41a3-11e9-974d-564f2a90bff1.png)
