### PR TITLE
Only display nav option when graphql is pinged

### DIFF
--- a/packages/web-cli/src/commands/create/questions.js
+++ b/packages/web-cli/src/commands/create/questions.js
@@ -87,7 +87,7 @@ module.exports = ({ path, npmOrg }) => [
     name: 'withNavItems',
     message: 'Add example website section navigation?',
     default: true,
-    when: ({ proceed }) => proceed === true,
+    when: ({ proceed, graphql }) => proceed === true && graphql.pinged === true,
   },
   {
     type: 'checkbox',


### PR DESCRIPTION
Only display the `Add example website section navigation?` question when the GraphQL URL has been successfully pinged. If the API cannot be pinged (and the user still proceeds) skip directly to the Bootstrap question.

![image](https://user-images.githubusercontent.com/3289485/54050473-e55c8a80-41a4-11e9-8291-797cad161de5.png)
