### PR TITLE
Error handling and error page templating

### DIFF
--- a/packages/marko-web/src/components/document/components/error.marko
+++ b/packages/marko-web/src/components/document/components/error.marko
@@ -1,0 +1,11 @@
+$ const isDevelopment = process.env.NODE_ENV === 'development';
+$ const error = input.error || {};
+
+<cms-document>
+  <h1>An Error Occurred</h1>
+  <h2>${input.statusCode} ${input.statusMessage}</h2>
+  <h3>${error.message}</h3>
+  <if(isDevelopment)>
+    <pre>${error.stack}</pre>
+  </if>
+</cms-document>

--- a/packages/marko-web/src/express/error-handlers.js
+++ b/packages/marko-web/src/express/error-handlers.js
@@ -1,0 +1,21 @@
+const { STATUS_CODES } = require('http');
+const createError = require('http-errors');
+const errorTemplate = require('../components/document/components/error');
+
+module.exports = (app, { template }) => {
+  // Force Express to throw an error on 404s.
+  app.use((req, res, next) => { // eslint-disable-line no-unused-vars
+    throw createError(404, `No page found for '${req.path}'`);
+  });
+
+  // Error handler.
+  app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
+    const statusCode = err.status || err.statusCode || 500;
+    res.status(statusCode);
+    res.marko(template || errorTemplate, {
+      statusCode,
+      statusMessage: STATUS_CODES[statusCode],
+      error: err,
+    });
+  });
+};

--- a/packages/marko-web/src/express/marko.js
+++ b/packages/marko-web/src/express/marko.js
@@ -1,4 +1,3 @@
-require('marko/node-require');
 const marko = require('marko/express');
 
 module.exports = (app) => {

--- a/packages/web-cli/src/generator/templates/core/server/routes/website-section.js
+++ b/packages/web-cli/src/generator/templates/core/server/routes/website-section.js
@@ -2,7 +2,7 @@ const { withWebsiteSection } = require('@base-cms/marko-web/middleware');
 const section = require('../templates/website-section');
 
 module.exports = (app) => {
-  app.get('/:alias(*)', withWebsiteSection({
+  app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({
     template: section,
   }));
 };

--- a/services/marko-example-website/index.js
+++ b/services/marko-example-website/index.js
@@ -1,4 +1,5 @@
 const { startServer } = require('@base-cms/marko-web');
+const errorTemplate = require('./server/templates/error');
 const routes = require('./server/routes');
 const coreConfig = require('./config/core');
 const siteConfig = require('./config/site');
@@ -8,4 +9,5 @@ startServer({
   coreConfig,
   siteConfig,
   routes,
+  errorTemplate,
 });

--- a/services/marko-example-website/server/routes/website-section.js
+++ b/services/marko-example-website/server/routes/website-section.js
@@ -7,7 +7,7 @@ module.exports = (app) => {
     template: applications,
   }));
 
-  app.get('/:alias(*)', withWebsiteSection({
+  app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({
     template: section,
   }));
 };

--- a/services/marko-example-website/server/templates/error.marko
+++ b/services/marko-example-website/server/templates/error.marko
@@ -1,0 +1,16 @@
+$ const isDevelopment = process.env.NODE_ENV === 'development';
+$ const error = input.error || {};
+
+<document>
+  <cms-page-container class="container-fluid-max">
+    <div class="row">
+      <div class="col">
+        <h2>${input.statusCode} ${input.statusMessage}</h2>
+        <h3>${error.message}</h3>
+        <if(isDevelopment)>
+          <pre>${error.stack}</pre>
+        </if>
+      </div>
+    </div>
+  </cms-page-container>
+</document>


### PR DESCRIPTION
Express errors will now display a "pretty" error page.

This can overridden per site as follows:

Send the `errorTemplate` option to `startServer`...
```js
// [project-root]/index.js
const { startServer } = require('@base-cms/marko-web');
const errorTemplate = require('./server/templates/error');
const routes = require('./server/routes');
const coreConfig = require('./config/core');
const siteConfig = require('./config/site');
startServer({
  coreConfig,
  siteConfig,
  routes,
  errorTemplate,
});
```

Example overridden error page template...
```marko
<!-- [project-root]/server/templates/error.marko -->

$ const isDevelopment = process.env.NODE_ENV === 'development';
$ const error = input.error || {};

<document>
  <cms-page-container class="container-fluid-max">
    <div class="row">
      <div class="col">
        <h2>${input.statusCode} ${input.statusMessage}</h2>
        <h3>${error.message}</h3>
        <if(isDevelopment)>
          <pre>${error.stack}</pre>
        </if>
      </div>
    </div>
  </cms-page-container>
</document>

```