### PR TITLE
CLI Updates

### DIFF
--- a/packages/web-cli/src/commands/build.js
+++ b/packages/web-cli/src/commands/build.js
@@ -2,8 +2,7 @@ const build = require('../gulp/build');
 const logCmd = require('../utils/log-command');
 const cwd = require('../utils/get-cwd');
 
-module.exports = ({ _ }) => {
-  const [, path] = _;
+module.exports = ({ path }) => {
   const dir = cwd(path);
   logCmd('build', dir);
   build(dir)();

--- a/packages/web-cli/src/commands/create.js
+++ b/packages/web-cli/src/commands/create.js
@@ -12,12 +12,11 @@ const installDeps = require('../generator/install');
 const loadQuestions = require('./create/questions');
 
 module.exports = ({
-  _,
+  path,
   npmOrg,
   yarn,
   skipInstall,
 }) => {
-  const [, path] = _;
   if (!path) {
     exit('A project directory is required.');
   }
@@ -41,7 +40,6 @@ module.exports = ({
     }
     await generateProject(dir, answers);
     if (!skipInstall) {
-
       await installDeps(dir, yarn);
     }
   };

--- a/packages/web-cli/src/commands/create.js
+++ b/packages/web-cli/src/commands/create.js
@@ -16,6 +16,8 @@ module.exports = ({
   npmOrg,
   yarn,
   skipInstall,
+  siteName,
+  graphqlUri,
 }) => {
   if (!path) {
     exit('A project directory is required.');
@@ -25,7 +27,12 @@ module.exports = ({
     exit(`The selected project directory is not empty. Tried installing in ${chalk.gray(dir)}`);
   }
 
-  const questions = loadQuestions({ path, npmOrg });
+  const questions = loadQuestions({
+    path,
+    npmOrg,
+    siteName,
+    graphqlUri,
+  });
 
   clear();
 

--- a/packages/web-cli/src/commands/create.js
+++ b/packages/web-cli/src/commands/create.js
@@ -16,6 +16,7 @@ module.exports = ({
   npmOrg,
   yarn,
   skipInstall,
+  templateDir,
   siteName,
   graphqlUri,
 }) => {
@@ -30,6 +31,7 @@ module.exports = ({
   const questions = loadQuestions({
     path,
     npmOrg,
+    templateDir,
     siteName,
     graphqlUri,
   });

--- a/packages/web-cli/src/commands/create/query-root-sections.js
+++ b/packages/web-cli/src/commands/create/query-root-sections.js
@@ -14,7 +14,7 @@ module.exports = async (client) => {
       }
     }
   `;
-  const input = { sort: { field: 'name', order: 'asc' } };
+  const input = { sort: { field: 'name', order: 'asc' }, pagination: { limit: 100 } };
   const variables = { input };
   const { data } = await client.query({ query, variables });
   return data.rootWebsiteSections.edges

--- a/packages/web-cli/src/commands/create/questions.js
+++ b/packages/web-cli/src/commands/create/questions.js
@@ -1,6 +1,7 @@
 const validatePackage = require('validate-npm-package-name');
 const chalk = require('chalk');
 const { isURL } = require('validator');
+const { existsSync } = require('fs');
 const { createClient } = require('@base-cms/express-apollo');
 const gql = require('graphql-tag');
 const querySections = require('./query-root-sections');
@@ -9,6 +10,7 @@ module.exports = ({
   path,
   npmOrg,
   siteName,
+  templateDir,
   graphqlUri,
 }) => [
   {
@@ -112,6 +114,17 @@ module.exports = ({
     message: 'Install Bootstrap design components?',
     default: true,
     when: ({ proceed }) => proceed === true,
+  },
+  {
+    type: 'input',
+    name: 'templateDir',
+    default: templateDir,
+    message: chalk`Custom template directory {reset [enter relative path or leave blank for none]}:`,
+    validate: (v) => {
+      if (!v) return true;
+      return existsSync(v) ? true : `Path ${v} does not exist!`;
+    },
+    filter: v => (v ? String(v).trim() : v),
   },
   {
     type: 'confirm',

--- a/packages/web-cli/src/commands/create/questions.js
+++ b/packages/web-cli/src/commands/create/questions.js
@@ -5,7 +5,12 @@ const { createClient } = require('@base-cms/express-apollo');
 const gql = require('graphql-tag');
 const querySections = require('./query-root-sections');
 
-module.exports = ({ path, npmOrg }) => [
+module.exports = ({
+  path,
+  npmOrg,
+  siteName,
+  graphqlUri,
+}) => [
   {
     type: 'input',
     name: 'projectName',
@@ -25,6 +30,7 @@ module.exports = ({ path, npmOrg }) => [
   {
     type: 'input',
     name: 'siteName',
+    default: siteName,
     message: chalk`Site Name {reset [used in {blue <title>} and {blue <meta>} elements]}:`,
     validate: v => (v ? true : 'The site name is required.'),
     filter: v => (v ? String(v).trim() : v),
@@ -53,6 +59,7 @@ module.exports = ({ path, npmOrg }) => [
   {
     type: 'input',
     name: 'graphqlUri',
+    default: graphqlUri,
     message: chalk`GraphQL URL {reset [used to retrieve your BaseCMS website data]}:`,
     validate: async (v, answers) => {
       if (!v) return 'The GraphQL URL is required.';

--- a/packages/web-cli/src/commands/dev.js
+++ b/packages/web-cli/src/commands/dev.js
@@ -5,8 +5,7 @@ const { resolve, parse } = require('path');
 const exit = require('../utils/print-and-exit');
 const serve = require('../gulp/serve');
 
-module.exports = ({ _ }) => {
-  const [, file] = _;
+module.exports = ({ file }) => {
   const server = resolve(process.cwd(), file);
 
   if (!existsSync(server)) {

--- a/packages/web-cli/src/commands/index.js
+++ b/packages/web-cli/src/commands/index.js
@@ -32,6 +32,9 @@ const createOptions = yargs => yargs
     type: 'boolean',
     default: false,
   })
+  .option('template-dir', {
+    describe: 'Custom skeleton template directory',
+  })
   .option('site-name', {
     describe: 'Whether to skip installing dependencies.',
   })

--- a/packages/web-cli/src/commands/index.js
+++ b/packages/web-cli/src/commands/index.js
@@ -31,6 +31,12 @@ const createOptions = yargs => yargs
     describe: 'Whether to skip installing dependencies.',
     type: 'boolean',
     default: false,
+  })
+  .option('site-name', {
+    describe: 'Whether to skip installing dependencies.',
+  })
+  .option('graphql-uri', {
+    describe: 'Whether to skip installing dependencies.',
   });
 
 /**

--- a/packages/web-cli/src/commands/index.js
+++ b/packages/web-cli/src/commands/index.js
@@ -1,5 +1,38 @@
 /* eslint-disable global-require */
 
+const lintOptions = yargs => yargs
+  .option('path', {
+    describe: 'A path (relative to the CWD) to execute the command in',
+  });
+
+const buildOptions = yargs => yargs
+  .option('path', {
+    describe: 'A path (relative to the CWD) to execute the command in',
+  });
+
+const devOptions = yargs => yargs
+  .option('file', {
+    describe: 'The website server file to execute.',
+  });
+
+const createOptions = yargs => yargs
+  .option('path', {
+    describe: 'A path (relative to the CWD) to create the project in',
+  })
+  .option('npm-org', {
+    describe: 'Your NPM org name. Will prefix the package name.',
+  })
+  .option('yarn', {
+    describe: 'Whether to use Yarn instead of NPM for installing dependencies.',
+    type: 'boolean',
+    default: true,
+  })
+  .option('skip-install', {
+    describe: 'Whether to skip installing dependencies.',
+    type: 'boolean',
+    default: false,
+  });
+
 /**
  * Note: commands are required only when requested.
  * This saves the overhead of requiring _all_ command dependencies when only a single
@@ -7,43 +40,8 @@
  */
 module.exports = (program) => {
   program
-    .command('lint', 'Lint JavaScript and SASS within the BaseCMS project', (yargs) => {
-      yargs.positional('path', {
-        describe: 'A path (relative to the CWD) to execute the command in',
-        type: 'string',
-      });
-    }, argv => require('./lint')(argv))
-
-    .command('build', 'Build BaseCMS assets and save them to the dist folder', (yargs) => {
-      yargs.positional('path', {
-        describe: 'A path (relative to the CWD) to execute the command in',
-        type: 'string',
-      });
-    }, argv => require('./build')(argv))
-
-    .command('dev', 'Start the BaseCMS website development server', (yargs) => {
-      yargs
-        .positional('file', {
-          describe: 'The website server file to execute.',
-          type: 'string',
-        });
-    }, argv => require('./dev')(argv))
-
-    .command('create', 'Create a new BaseCMS website project', (yargs) => {
-      yargs.positional('path', {
-        describe: 'A path (relative to the CWD) to create the project in',
-        type: 'string',
-      }).option('npm-org', {
-        describe: 'Your NPM org name. Will prefix the package name.',
-        type: 'string',
-      }).option('yarn', {
-        describe: 'Whether to use Yarn instead of NPM for installing dependencies.',
-        type: 'boolean',
-        default: true,
-      }).option('skip-install', {
-        describe: 'Whether to skip installing dependencies.',
-        type: 'boolean',
-        default: false,
-      });
-    }, argv => require('./create')(argv));
+    .command('lint <path>', 'Lint JavaScript and SASS within the BaseCMS project', lintOptions, argv => require('./lint')(argv))
+    .command('build <path>', 'Build BaseCMS assets and save them to the dist folder', buildOptions, argv => require('./build')(argv))
+    .command('dev <file>', 'Start the BaseCMS website development server', devOptions, argv => require('./dev')(argv))
+    .command('create <path>', 'Create a new BaseCMS website project', createOptions, argv => require('./create')(argv));
 };

--- a/packages/web-cli/src/commands/lint.js
+++ b/packages/web-cli/src/commands/lint.js
@@ -2,8 +2,7 @@ const logCmd = require('../utils/log-command');
 const cwd = require('../utils/get-cwd');
 const lint = require('../gulp/lint');
 
-module.exports = ({ _ }) => {
-  const [, path] = _;
+module.exports = ({ path }) => {
   const dir = cwd(path);
   logCmd('lint', dir);
   lint(dir)();

--- a/packages/web-cli/src/generator/build-files.js
+++ b/packages/web-cli/src/generator/build-files.js
@@ -1,29 +1,36 @@
 const handlebars = require('handlebars');
 const ignore = require('ignore');
 const readdir = require('recursive-readdir');
-const { join, parse } = require('path');
+const { parse } = require('path');
 const { readFileSync } = require('fs');
 const ifrm = require('./if-rm');
 
 handlebars.registerHelper('if-rm', ifrm);
 
 const cleanLines = contents => contents.replace(/\s^\s*__REMOVELINE__\s*$/gm, '').replace(/__REMOVELINE__/g, '');
+const getSourceFiles = async src => ({ src, items: await readdir(src) });
+const getDirectoryFiles = dirs => Promise.all(dirs.map(getSourceFiles));
 
-module.exports = async (templatesDir, answers) => {
-  const files = await readdir(templatesDir);
+module.exports = async (dirs = [], answers) => {
+  const dirFiles = await getDirectoryFiles(dirs);
+  const files = dirFiles.reduce((obj, { src, items }) => {
+    const set = items.reduce((s, f) => ({ ...s, [f.replace(`${src}/`, '')]: f }), {});
+    return { ...obj, ...set };
+  }, {});
 
-  // Create "relative" versions of each file.
-  const relative = files.map(f => f.replace(`${templatesDir}/`, ''));
+  const relative = Object.keys(files);
+  const absolute = relative.map(r => files[r]);
 
   // Load any .gitignore files and filter out files that should be ignored.
   const toIgnore = ignore();
-  files.filter(f => /gitignore$/.test(f)).map(f => readFileSync(f).toString()).forEach(patterns => toIgnore.add(patterns));
+  absolute.filter(f => /gitignore$/.test(f)).map(f => readFileSync(f).toString()).forEach(patterns => toIgnore.add(patterns));
+
   const filteredFiles = toIgnore.filter(relative);
 
   const targets = [];
 
-  const toWrite = filteredFiles.map((f) => {
-    const file = join(templatesDir, f);
+  const toWrite = filteredFiles.map((r) => {
+    const file = files[r];
     const {
       dir,
       ext,
@@ -31,9 +38,9 @@ module.exports = async (templatesDir, answers) => {
       name,
     } = parse(file);
 
-    const target = dir.replace(templatesDir, '');
+    const target = dirs.reduce((t, src) => t.replace(src, ''), dir);
     targets.push(target);
-    const info = { target };
+    const info = { src: file, target };
 
     if (ext === '.hbs') {
       // Render the template contents with command line answers.

--- a/packages/web-cli/src/generator/index.js
+++ b/packages/web-cli/src/generator/index.js
@@ -1,6 +1,6 @@
 const chalk = require('chalk');
 const log = require('fancy-log');
-const { join } = require('path');
+const { join, resolve } = require('path');
 const buildFiles = require('./build-files');
 const { mkdir, copy, write } = require('../utils/filesystem');
 const createPkg = require('./create-pkg');
@@ -25,23 +25,31 @@ const writeTemplates = async (dir, answers, templateDir) => {
 };
 
 module.exports = async (dir, answers) => {
-  const { projectName } = answers;
+  const { projectName, withBootstrap, templateDir } = answers;
   log(chalk`Creating {cyan ${projectName}} in {green ${dir}}...`);
 
   const pkg = createPkg(answers);
 
-  log(chalk`Creating {green core} templates`);
-  await writeTemplates(dir, answers, join(__dirname, 'templates/core'));
+  const dirs = [join(__dirname, 'templates/core')];
+  if (withBootstrap) dirs.push(join(__dirname, 'templates/bootstrap'));
+  if (templateDir) dirs.push(resolve(templateDir));
 
-  if (answers.withBootstrap) {
-    log(chalk`Creating {green bootstrap} templates`);
-    await writeTemplates(dir, answers, join(__dirname, 'templates/bootstrap'));
-  }
+  const { targets, files } = await buildFiles(dirs, answers);
 
-  if (answers.templateDir) {
-    log(chalk`Creating {green custom} templates`);
-    await writeTemplates(dir, answers, answers.templateDir);
-  }
+  targets.forEach(target => mkdir(dir, target));
+  files.forEach((file) => {
+    const { src } = file;
+    const dest = join(dir, file.target);
+    if (file.contents) {
+      write(dest, file.file, file.contents);
+    } else {
+      let destination = join(dest, file.file);
+      if (/gitignore$/.test(file.file)) {
+        destination = join(dest, file.file.replace('gitignore', '.gitignore'));
+      }
+      copy(src, destination);
+    }
+  });
 
   write(dir, 'package.json', `${JSON.stringify(pkg, null, 2)}\n`);
 };

--- a/packages/web-cli/src/generator/index.js
+++ b/packages/web-cli/src/generator/index.js
@@ -5,13 +5,7 @@ const buildFiles = require('./build-files');
 const { mkdir, copy, write } = require('../utils/filesystem');
 const createPkg = require('./create-pkg');
 
-module.exports = async (dir, answers) => {
-  const { projectName } = answers;
-  log(chalk`Creating {cyan ${projectName}} ...`);
-
-  const pkg = createPkg(answers);
-
-  const templateDir = join(__dirname, 'templates/core');
+const writeTemplates = async (dir, answers, templateDir) => {
   const toWrite = await buildFiles(templateDir, answers);
 
   toWrite.targets.forEach(target => mkdir(dir, target));
@@ -28,5 +22,21 @@ module.exports = async (dir, answers) => {
       copy(join(src, file), destination);
     }
   });
+};
+
+module.exports = async (dir, answers) => {
+  const { projectName } = answers;
+  log(chalk`Creating {cyan ${projectName}} in {green ${dir}}...`);
+
+  const pkg = createPkg(answers);
+
+  log(chalk`Creating {green core} templates`);
+  await writeTemplates(dir, answers, join(__dirname, 'templates/core'));
+
+  if (answers.withBootstrap) {
+    log(chalk`Creating {green bootstrap} templates`);
+    await writeTemplates(dir, answers, join(__dirname, 'templates/bootstrap'));
+  }
+
   write(dir, 'package.json', `${JSON.stringify(pkg, null, 2)}\n`);
 };

--- a/packages/web-cli/src/generator/index.js
+++ b/packages/web-cli/src/generator/index.js
@@ -38,5 +38,10 @@ module.exports = async (dir, answers) => {
     await writeTemplates(dir, answers, join(__dirname, 'templates/bootstrap'));
   }
 
+  if (answers.templateDir) {
+    log(chalk`Creating {green custom} templates`);
+    await writeTemplates(dir, answers, answers.templateDir);
+  }
+
   write(dir, 'package.json', `${JSON.stringify(pkg, null, 2)}\n`);
 };

--- a/packages/web-cli/src/index.js
+++ b/packages/web-cli/src/index.js
@@ -3,7 +3,10 @@ const log = require('fancy-log');
 const commands = require('./commands');
 
 log('CLI starting...');
-program.usage('Usage: $0 <command> [options]');
+program
+  .usage('Usage: $0 <command> [options]')
+  .help()
+  .demandCommand();
 
 commands(program);
 


### PR DESCRIPTION
- Ensures that the usage helper is called when executed with no arguments (`basecms-website`)
- Remove `yargs.positional` calls in favor of explicit positional arguments and option definitions
- Allow passing `siteName` and `graphqlUri` through from the command line
- Pull more website sections when prompting to create navigation
- Support bootstrap templates directory
- Support custom external templates directory