### PR TITLE
Fix rel canonical component + document defaults

### DIFF
--- a/packages/marko-web/src/components/document/index.marko
+++ b/packages/marko-web/src/components/document/index.marko
@@ -1,11 +1,11 @@
 $ const { config } = out.global;
 
 <!doctype html>
-<html lang=config.locale() dir=input.dir>
+<html lang=config.locale() dir=(input.dir || 'ltr')>
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content=input.viewport>
+    <meta name="viewport" content=(input.viewport || 'width=device-width, initial-scale=1, shrink-to-fit=no')>
     <link rel="stylesheet" href="/dist/index.css">
     <!-- @todo determine if this should go at the bottom of the page -->
     <assets />

--- a/packages/marko-web/src/components/page/marko.json
+++ b/packages/marko-web/src/components/page/marko.json
@@ -7,7 +7,7 @@
       "template": "./title.marko"
     },
     "cms-page-rel-canonical": {
-      "template": "./title.marko"
+      "template": "./rel-canonical.marko"
     },
     "cms-page-description": {
       "template": "./description.marko"

--- a/services/marko-example-website/config/core.js
+++ b/services/marko-example-website/config/core.js
@@ -1,4 +1,4 @@
 module.exports = {
-  siteName: 'Evaluation Engineering',
+  siteName: 'Officer',
   locale: 'en_US',
 };

--- a/services/marko-example-website/config/site.js
+++ b/services/marko-example-website/config/site.js
@@ -13,7 +13,7 @@ module.exports = {
     { to: '/features/honoring-the-fallen', label: 'Honoring the Fallen' },
     { to: '/magazine', label: 'Publications' },
     { to: '/subscribe', label: 'Subscribe' },
-    { to: '/advertise', label: 'Advertise' },
+    { to: '/page/advertise', label: 'Advertise' },
     { to: '/contact-us', label: 'Contact Us' },
   ],
   // logo: 'https://cdn.evaluationengineering.com/files/base/ebm/ee/image/static/logo/site_logo_bare.png',

--- a/services/marko-example-website/server/components/content/card-body/style-a.marko
+++ b/services/marko-example-website/server/components/content/card-body/style-a.marko
@@ -37,11 +37,14 @@ $ const content = asObject(input.content);
 <content-card-image block=block obj=content.primaryImage link-to=content class="border-bottom" />
 <div class="card-body d-flex flex-column">
   <cms-content-short-name tag="h4" block=block obj=content link=true />
-  <cms-content-name tag="small" block=block obj=content.company link=true />
-  <cms-content-teaser tag="p" block=block obj=content />
-
-  <small class="element-row mt-auto">
-    <cms-website-section-name block=block obj=content.primarySection link=true />
-    <cms-content-published block=block obj=content />
-  </small>
+  <cms-content-name tag="small" class="mb-2" block=block obj=content.company link=true>
+    <@before>
+      From:&nbsp;
+    </@before>
+  </cms-content-name>
+  <cms-content-teaser tag="p" class="mb-0" block=block obj=content />
+</div>
+<div class="card-footer d-flex justify-content-between small">
+  <cms-website-section-name block=block obj=content.primarySection link=true />
+  <cms-content-published block=block obj=content />
 </div>


### PR DESCRIPTION
- Use the correct template for the `<cms-rel-canonical>` component
- Set defaults for `input.dir` and `input.viewport` in the `<cms-document>` component
- Add the `From:` prefix (within the before hook) to company names
- Update example site name and advertise routes to match Officer