### PR TITLE
Create website section hierarchy GraphQL field

### DIFF
--- a/services/graphql-server/src/graphql/definitions/website/section.js
+++ b/services/graphql-server/src/graphql/definitions/website/section.js
@@ -41,6 +41,8 @@ type WebsiteSection {
   canonicalPath: String! @projection(localField: "alias")
   # Determines if this content item should redirect to another location.
   redirectTo: String
+  # Retrieves the flattened hierarchy for this section.
+  hierarchy: [WebsiteSection!]! @projection(localField: "parent")
 }
 
 type WebsiteSectionConnection @projectUsing(type: "WebsiteSection") {

--- a/services/graphql-server/src/graphql/resolvers/website/section.js
+++ b/services/graphql-server/src/graphql/resolvers/website/section.js
@@ -13,6 +13,7 @@ const loadHierarchy = async (section, load, projection, sections = []) => {
   const parentId = BaseDB.extractRefId(ref);
   if (!parentId) return sections;
   const parent = await load('websiteSection', parentId, projection, { status: 1 });
+  if (!parent) return sections;
   sections.push(parent);
   return loadHierarchy(parent, load, projection, sections);
 };

--- a/services/graphql-server/src/graphql/utils/get-graph-type.js
+++ b/services/graphql-server/src/graphql/utils/get-graph-type.js
@@ -1,0 +1,6 @@
+const getType = (type) => {
+  if (!type.ofType) return type;
+  return getType(type.ofType);
+};
+
+module.exports = getType;


### PR DESCRIPTION
Returns a flattened array of a website section's parent sections.

Example:
![image](https://user-images.githubusercontent.com/3289485/55413006-17f06d80-552e-11e9-9b67-4cf21337a0af.png)
