### PR TITLE
Add content teaser truncation support

### DIFF
--- a/services/graphql-server/package.json
+++ b/services/graphql-server/package.json
@@ -17,6 +17,7 @@
     "@base-cms/utils": "^0.6.0",
     "@godaddy/terminus": "^4.1.0",
     "apollo-server-express": "^2.3.1",
+    "cheerio": "^1.0.0-rc.2",
     "cors": "^2.8.5",
     "dataloader": "^1.4.0",
     "deep-assign": "^3.0.0",

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -175,6 +175,9 @@ input ContentMutationInput {
 input ContentTeaserInput {
   mutation: ContentMutation = Website
   useFallback: Boolean = true
+  minLength: Int = 75
+  maxLength: Int = 125
+  truncatedSuffix: String = "..."
 }
 
 input ContentBodyInput {

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -15,6 +15,7 @@ const {
   getPublishedCriteria,
   getDefaultContentTypes,
 } = require('../../utils/content');
+const contentTeaser = require('../../utils/content-teaser');
 
 const { isArray } = Array;
 
@@ -59,14 +60,10 @@ module.exports = {
     __resolveType: resolveType,
 
     teaser: (content, { input }) => {
-      const { mutation, useFallback } = input;
-      const { teaser, teaserFallback } = content;
-
-      const value = !teaser && useFallback ? teaserFallback : teaser;
-      if (!mutation) return value;
-
-      const mutated = get(content, `mutations.${mutation}.teaser`);
-      return mutated || value;
+      const { mutation } = input;
+      const teaser = contentTeaser.getTeaser(mutation, content);
+      const { teaserFallback } = content;
+      return contentTeaser.generateTeaser(teaser, teaserFallback, input) || null;
     },
 
     body: (content, { input }, { imageHost, basedb }) => {

--- a/services/graphql-server/src/graphql/utils/content-teaser.js
+++ b/services/graphql-server/src/graphql/utils/content-teaser.js
@@ -14,7 +14,7 @@ const truncateTeaser = (value, { maxLength, truncatedSuffix }) => {
   // @todo This strips HTML from truncated teasers. We could attempt to preserve it?
   const stripped = stripHtml(value);
 
-  let truncated;
+  let truncated = '';
   const words = stripped.split(' ').filter(v => v);
   words.forEach((word) => {
     if (!truncated) truncated = word;

--- a/services/graphql-server/src/graphql/utils/content-teaser.js
+++ b/services/graphql-server/src/graphql/utils/content-teaser.js
@@ -1,0 +1,49 @@
+const { get } = require('@base-cms/object-path');
+const { stripHtml } = require('@base-cms/html');
+
+const cleanTeaser = value => String(value || '').trim();
+
+const getTeaser = (mutation, content) => {
+  const teaser = cleanTeaser(get(content, 'teaser', ''));
+  if (!mutation) return teaser;
+  return cleanTeaser(get(content, `mutations.${mutation}.teaser`, teaser));
+};
+
+const truncateTeaser = (value, { maxLength, truncatedSuffix }) => {
+  if (!maxLength) return value;
+  // @todo This strips HTML from truncated teasers. We could attempt to preserve it?
+  const stripped = stripHtml(value);
+
+  let truncated;
+  const words = stripped.split(' ').filter(v => v);
+  words.forEach((word) => {
+    if (!truncated) truncated = word;
+    if (truncated.length < maxLength) {
+      truncated = `${truncated} ${word}`;
+    }
+  });
+  // Ensure truncated string has punctuation removed.
+  return truncatedSuffix ? `${truncated.replace(/\p{P}+?$/u, '')}${truncatedSuffix}` : truncated;
+};
+
+const generateTeaser = (teaser, fallback, {
+  minLength,
+  maxLength,
+  useFallback,
+  truncatedSuffix,
+}) => {
+  const opts = { maxLength, truncatedSuffix };
+  if (!useFallback) return truncateTeaser(teaser, opts);
+  if (minLength) {
+    if (teaser.length < minLength) return truncateTeaser(fallback, opts);
+    return truncateTeaser(teaser, opts);
+  }
+  return truncateTeaser(teaser || fallback, opts);
+};
+
+module.exports = {
+  cleanTeaser,
+  getTeaser,
+  truncateTeaser,
+  generateTeaser,
+};


### PR DESCRIPTION
The `Content.teaser` field now supports the following:

```graphql
input ContentTeaserInput {
  mutation: ContentMutation = Website
  useFallback: Boolean = true
  minLength: Int = 75
  maxLength: Int = 125
  truncatedSuffix: String = "..."
}

```