### PR TITLE
Fix duplicated first word of teasers

### DIFF
--- a/services/graphql-server/src/graphql/utils/content-teaser.js
+++ b/services/graphql-server/src/graphql/utils/content-teaser.js
@@ -17,7 +17,10 @@ const truncateTeaser = (value, { maxLength, truncatedSuffix }) => {
   let truncated = '';
   const words = stripped.split(' ').filter(v => v);
   words.forEach((word) => {
-    if (!truncated) truncated = word;
+    if (!truncated) {
+      truncated = word;
+      return;
+    }
     if (truncated.length < maxLength) {
       truncated = `${truncated} ${word}`;
     }


### PR DESCRIPTION
Fixes...
```
Today’s Today’s consumers are...
```
to
```
Today’s consumers are...
```