### PR TITLE
Add sectionAlias support to websiteScheduledContent

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -139,7 +139,8 @@ input AllContentQueryInput {
 }
 
 input WebsiteScheduledContentQueryInput {
-  sectionId: Int!
+  sectionId: Int
+  sectionAlias: String
   optionId: Int
   excludeContentIds: [Int!] = []
   excludeSectionIds: [Int!] = []


### PR DESCRIPTION
The `websiteScheduledContent` query now supports either a `sectionId` or `sectionAlias` in its input. The user MUST provide one or the other and cannot provide both.

```graphql
input WebsiteScheduledContentQueryInput {
  sectionId: Int
  sectionAlias: String
  optionId: Int
  excludeContentIds: [Int!] = []
  excludeSectionIds: [Int!] = []
  excludeContentTypes: [ContentType!] = []
  includeContentTypes: [ContentType!] = []
  requiresImage: Boolean = false
  useOptionFallback: Boolean = false
  sectionBubbling: Boolean = true
  pagination: PaginationInput = {}
}
```

```js
if (!sectionId && !sectionAlias) throw new UserInputError('Either a sectionId or sectionAlias input must be provided.');
if (sectionId && sectionAlias) throw new UserInputError('You cannot provided both a sectionId and sectionAlias as input.');
```