### PR TITLE
Allow health checks to be accessed on any path

### DIFF
--- a/services/graphql-server/src/index.js
+++ b/services/graphql-server/src/index.js
@@ -13,7 +13,6 @@ const run = async () => {
   createTerminus(server, {
     timeout: 1000,
     signals: ['SIGTERM', 'SIGINT', 'SIGHUP', 'SIGQUIT'],
-    healthChecks: { '/_health': () => services.ping() },
     onSignal: () => {
       log('> Cleaning up...');
       return services.stop().catch(e => log('> CLEANUP ERRORS:', e));

--- a/services/graphql-server/src/routes/_health.js
+++ b/services/graphql-server/src/routes/_health.js
@@ -1,0 +1,23 @@
+const { asyncRoute } = require('@base-cms/utils');
+const { ping } = require('../services');
+
+module.exports = (app) => {
+  const path = '([a-z0-9-/]*)?/_health';
+  const handle = asyncRoute(async (req, res) => {
+    try {
+      const info = await ping();
+      res.status(200).json({
+        status: 'ok',
+        info,
+      });
+    } catch (e) {
+      res.status(500).json({
+        status: 'error',
+        info: e.message,
+      });
+    }
+  });
+
+  app.get(path, handle);
+  app.head(path, handle);
+};

--- a/services/graphql-server/src/routes/index.js
+++ b/services/graphql-server/src/routes/index.js
@@ -1,5 +1,7 @@
 const graphql = require('./graphql');
+const health = require('./_health');
 
 module.exports = (app) => {
+  health(app);
   app.use('/', graphql);
 };


### PR DESCRIPTION
Via either `get` or `head` methods, the `/_health` endpoint can be accessed on any path... e.g. `/foo/bar/_health`