### PR TITLE
Add CDN environment vars and use in file source resolvers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,8 @@ services:
     environment:
       <<: *env
       <<: *env-mongo
+      CDN_IMAGE_HOSTNAME: ${CDN_IMAGE_HOSTNAME-base.imgix.net}
+      CDN_ASSET_HOSTNAME: ${CDN_ASSET_HOSTNAME-cdn.baseplatform.io}
     depends_on:
       - mongodb
     ports:

--- a/services/graphql-server/src/env.js
+++ b/services/graphql-server/src/env.js
@@ -12,4 +12,6 @@ module.exports = cleanEnv(process.env, {
   TENANT_KEY: nonemptystr({ desc: 'The Base tenant key to connect to, e.g. cygnus_ofcr' }),
   ENABLE_BASEDB_LOGGING: bool({ desc: 'Whether the BaseDB instance should log to the console.', default: false }),
   GRAPHQL_ENDPOINT: nonemptystr({ desc: 'The GraphQL endpoint', default: '/' }),
+  CDN_IMAGE_HOSTNAME: nonemptystr({ desc: 'The CDN hostname that serves images.', default: 'base.imgix.net' }),
+  CDN_ASSET_HOSTNAME: nonemptystr({ desc: 'The CDN hostname that serves assets/documents.', default: 'cdn.baseplatform.io' }),
 });

--- a/services/graphql-server/src/graphql/definitions/platform/asset.js
+++ b/services/graphql-server/src/graphql/definitions/platform/asset.js
@@ -24,8 +24,8 @@ type AssetImage {
   approvedWebsite: Boolean @projection(localField: "mutations.Website.approved") @value(localField: "mutations.Website.approved")
   approvedMagazine: Boolean @projection(localField: "mutations.Magazine.approved") @value(localField: "mutations.Magazine.approved")
 
-  #GraphQL specific fields
-  src(input: AssetImageSrcInput = {}): String! @projection(localField: "fileName", needs: ["filePath"])
+  # GraphQL specific fields
+  src: String! @projection(localField: "fileName", needs: ["filePath"])
   alt: String! @projection(localField: "name", needs: ["caption", "fileName"])
 }
 
@@ -66,10 +66,6 @@ enum AssetImageSortField {
 
 input AssetImageQueryInput {
   id: ObjectID!
-}
-
-input AssetImageSrcInput {
-  host: String = "base.imgix.net"
 }
 
 input AssetImageSortInput {

--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/media.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/media.js
@@ -9,6 +9,9 @@ interface Media {
   sourceFilename: String @projection
   sourceFile: String @projection
   contacts(input: MediaContactsInput = {}): ContentContactConnection! @projection @refMany(model: "platform.Content", criteria: "contentContact")
+
+  # GraphQL specific fields
+  fileSrc: String! @projection(localField: "fileName", needs: ["filePath"])
 }
 
 input MediaContactsInput {

--- a/services/graphql-server/src/graphql/resolvers/platform/asset.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/asset.js
@@ -1,11 +1,12 @@
 const { createAltFor, createSrcFor } = require('@base-cms/image');
+const { CDN_IMAGE_HOSTNAME } = require('../../../env');
 
 module.exports = {
   /**
    *
    */
   AssetImage: {
-    src: (image, _, { imageHost }) => createSrcFor(imageHost, image),
+    src: image => createSrcFor(CDN_IMAGE_HOSTNAME, image),
     alt: image => createAltFor(image),
   },
 };

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -1,10 +1,12 @@
 const { BaseDB } = require('@base-cms/db');
 const { UserInputError } = require('apollo-server-express');
+const { cleanPath } = require('@base-cms/utils');
+const { content: canonicalPathFor } = require('@base-cms/canonical-path');
 const { get } = require('@base-cms/object-path');
 const { parser: embedParser } = require('@base-cms/embedded-media');
 const { underscore, dasherize, titleize } = require('@base-cms/inflector');
-const { content: canonicalPathFor } = require('@base-cms/canonical-path');
 
+const { CDN_ASSET_HOSTNAME } = require('../../../env');
 const relatedContent = require('../../utils/related-content');
 const connectionProjection = require('../../utils/connection-projection');
 const getDefaultOption = require('../../utils/get-default-option');
@@ -25,8 +27,18 @@ module.exports = {
   Addressable: { __resolveType: resolveType },
   Authorable: { __resolveType: resolveType },
   Contactable: { __resolveType: resolveType },
-  Media: { __resolveType: resolveType },
 
+  /**
+   *
+   */
+  Media: {
+    __resolveType: resolveType,
+    fileSrc: ({ fileName, filePath }) => `https://${CDN_ASSET_HOSTNAME}/${cleanPath(filePath)}/${fileName}`,
+  },
+
+  /**
+   *
+   */
   ContentMetadata: {
     title: content => createTitle(content),
     description: content => createDescription(content),


### PR DESCRIPTION
- Adds the `CDN_IMAGE_HOSTNAME` and `CDN_ASSET_HOSTNAME` environment variables
- The `AssetImage.src` field now resolves using the `CDN_IMAGE_HOSTNAME` value
- The `fileSrc` field was created on the content `Media` interface, and resolves using the `CDN_ASSET_HOSTNAME` value