### PR TITLE
Set AssetImage src defaults

### DIFF
--- a/services/graphql-server/src/graphql/resolvers/platform/asset.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/asset.js
@@ -6,7 +6,7 @@ module.exports = {
    *
    */
   AssetImage: {
-    src: image => createSrcFor(CDN_IMAGE_HOSTNAME, image),
+    src: image => createSrcFor(CDN_IMAGE_HOSTNAME, image, undefined, { w: 320, auto: 'format' }),
     alt: image => createAltFor(image),
   },
 };


### PR DESCRIPTION
Force a width of 320 and an auto format for all GraphQL image sources.