### PR TITLE
Add preview mode support to content middleware

### DIFF
--- a/packages/marko-web/package.json
+++ b/packages/marko-web/package.json
@@ -14,6 +14,7 @@
     "@base-cms/utils": "^0.9.0",
     "@base-cms/web-common": "^0.9.0",
     "@godaddy/terminus": "^4.1.0",
+    "cookie-parser": "^1.4.4",
     "express": "^4.16.4",
     "express-http-proxy": "^1.5.1",
     "http-errors": "^1.7.2",

--- a/packages/marko-web/src/express/index.js
+++ b/packages/marko-web/src/express/index.js
@@ -1,4 +1,5 @@
 const { buildRequestHeaders } = require('@base-cms/tenant-context');
+const cookieParser = require('cookie-parser');
 const express = require('express');
 const path = require('path');
 const apollo = require('./apollo');
@@ -13,6 +14,9 @@ module.exports = (config = {}) => {
   const distDir = path.resolve(rootDir, 'dist');
   const app = express();
   const serverDir = path.resolve(rootDir, 'server');
+
+  // Add cookie parsing
+  app.use(cookieParser());
 
   // Set the core config.
   app.locals.config = new CoreConfig({ ...config.coreConfig, distDir });

--- a/packages/marko-web/src/middleware/with-content.js
+++ b/packages/marko-web/src/middleware/with-content.js
@@ -10,7 +10,10 @@ module.exports = ({
   const id = isFn(idResolver) ? await idResolver(req, res) : req.params.id;
   const { apollo } = req;
 
-  const content = await loader(apollo, { id, queryFragment });
+  const additionalInput = {};
+  if (req.cookies['preview-mode']) additionalInput.status = 'any';
+
+  const content = await loader(apollo, { id, queryFragment, additionalInput });
   const { redirectTo, canonicalPath } = content;
   if (redirectTo) {
     return res.redirect(301, redirectTo);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5931,6 +5931,14 @@ convert-source-map@1.X, convert-source-map@^1.1.0, convert-source-map@^1.5.0, co
   dependencies:
     safe-buffer "~5.1.1"
 
+cookie-parser@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.4.tgz#e6363de4ea98c3def9697b93421c09f30cf5d188"
+  integrity sha512-lo13tqF3JEtFO7FyA49CqbhaFkskRJ0u/UAiINgrIXeRCY41c88/zxtrECl8AKH3B0hj9q10+h3Kt8I7KlW4tw==
+  dependencies:
+    cookie "0.3.1"
+    cookie-signature "1.0.6"
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"


### PR DESCRIPTION
The content middleware will allow deleted and draft items to be displayed when a non-falsey `preview-mode` cookie is set.