### PR TITLE
Adjust paginated sort parameters for scheduled content query

### DIFF
--- a/packages/db/src/paginate/utils.js
+++ b/packages/db/src/paginate/utils.js
@@ -74,6 +74,7 @@ module.exports = {
     const matches = pattern.exec(field);
     const projection = {};
     if (matches && matches[1] && matches[3]) {
+      projection._id = 1;
       projection[matches[1]] = { $slice: [Number(matches[3]), 1] };
     } else {
       projection[field] = 1;

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -285,10 +285,9 @@ module.exports = {
       const projection = connectionProjection(info);
       return basedb.paginate('platform.Content', {
         query,
-        sort: { field: 'sectionQuery.start', order: 'desc' },
+        sort: { field: 'sectionQuery.0.start', order: 'desc' },
         projection: { 'sectionQuery.$.start': 1, ...projection },
         excludeProjection: ['sectionQuery.start'],
-        ignoreCompoundAfterSort: true,
         ...pagination,
       });
     },


### PR DESCRIPTION
This is not 100% perfect, but prevents exact duplication of paginated queries. Ultimately, website scheduled content (due to it's query complexity) will need to use skip/offset pagination instead of cursor-based pagination.