### PR TITLE
Support for customizing babel build from rcfile

### DIFF
--- a/packages/marko-web/src/components/document/index.marko
+++ b/packages/marko-web/src/components/document/index.marko
@@ -9,6 +9,7 @@ $ const { config } = out.global;
     <link rel="stylesheet" href="/dist/index.css">
     <!-- @todo determine if this should go at the bottom of the page -->
     <!-- @todo determine how to split assets out by vendor, core, site, etc. -->
+    <script src ="https://polyfill.io/v3/polyfill.min.js?flags=gated&features=es7%2Cfetch%2Ces6%2CPromise.prototype.finally"></script>
     <assets />
     <${input.head} />
   </head>

--- a/packages/web-cli/src/gulp/js.js
+++ b/packages/web-cli/src/gulp/js.js
@@ -7,14 +7,52 @@ const webpack = require('webpack-stream');
 const wp = require('webpack');
 const { dest, src } = require('gulp');
 const { getIfUtils } = require('webpack-config-utils');
+const { existsSync } = require('fs');
+const { join } = require('path');
 const completeTask = require('../utils/task-callback');
 
 const absoluteRuntime = path.dirname(require.resolve('@babel/runtime/package.json'));
+
+/**
+ * Loads an RC file from the CWD, if present, to provide gulp configuration
+ * @param {String} cwd The current directory
+ */
+const readRcFile = (cwd) => {
+  const excludeFn = file => (
+    /node_modules/.test(file)
+    && !/\.vue\.js/.test(file)
+  );
+
+  const defaultTargets = {
+    browsers: [
+      'Chrome >= 49',
+      'Firefox >= 45',
+      'Safari >= 10',
+      'Edge >= 12',
+      'Explorer >= 11',
+      'iOS >= 10',
+    ],
+  };
+
+  // eslint-disable-next-line import/no-dynamic-require
+  const rc = existsSync(join(cwd, '.basecmsrc.js')) ? require(join(cwd, '.basecmsrc.js')) : {};
+  const exclude = rc && rc.babelLoader && typeof rc.babelLoader.exclude === 'function'
+    ? rc.babelLoader.exclude : excludeFn;
+
+  const targets = rc && rc.babelLoader && rc.babelLoader.targets
+    ? rc.babelLoader.targets : defaultTargets;
+
+  const debug = rc && rc.babelLoader && typeof rc.babelLoader.debug === 'boolean'
+    ? rc.babelLoader.debug : false;
+
+  return { exclude, targets, debug };
+};
 
 // @todo Determine how to combine CSS with the main CSS build
 // @todo Add sass to Vue components
 // @todo Add default polyfills to entry point
 module.exports = cwd => (cb) => {
+  const { exclude, targets, debug } = readRcFile(cwd);
   const { ifProduction, ifNotProduction } = getIfUtils(process.env.NODE_ENV);
   pump([
     src('browser/index.js', { cwd }),
@@ -37,10 +75,7 @@ module.exports = cwd => (cb) => {
           {
             test: /\.js$/,
             loader: require.resolve('babel-loader'),
-            exclude: file => (
-              /node_modules/.test(file)
-              && !/\.vue\.js/.test(file)
-            ),
+            exclude,
             options: {
               presets: [
                 [
@@ -49,17 +84,9 @@ module.exports = cwd => (cb) => {
                     modules: false,
                     useBuiltIns: 'usage',
                     corejs: 2,
-                    targets: {
-                      browsers: [
-                        'Chrome >= 49',
-                        'Firefox >= 45',
-                        'Safari >= 10',
-                        'Edge >= 12',
-                        'Explorer >= 11',
-                        'iOS >= 10',
-                      ],
-                    },
+                    targets,
                     loose: false,
+                    debug,
                   },
                 ],
               ],

--- a/packages/web-cli/src/gulp/js.js
+++ b/packages/web-cli/src/gulp/js.js
@@ -20,6 +20,7 @@ const absoluteRuntime = path.dirname(require.resolve('@babel/runtime/package.jso
 const readRcFile = (cwd) => {
   const excludeFn = file => (
     /node_modules/.test(file)
+    && !/packages\/marko-web\/browser/.test(file)
     && !/\.vue\.js/.test(file)
   );
 

--- a/packages/web-cli/src/gulp/js.js
+++ b/packages/web-cli/src/gulp/js.js
@@ -84,7 +84,6 @@ module.exports = cwd => (cb) => {
                   {
                     modules: false,
                     useBuiltIns: false,
-                    corejs: 2,
                     targets,
                     loose: false,
                     debug,
@@ -95,8 +94,8 @@ module.exports = cwd => (cb) => {
                 [
                   require.resolve('@babel/plugin-transform-runtime'),
                   {
-                    regenerator: false,
-                    corejs: 2,
+                    regenerator: true,
+                    corejs: false,
                     helpers: true,
                     useESModules: false,
                     absoluteRuntime,

--- a/packages/web-cli/src/gulp/js.js
+++ b/packages/web-cli/src/gulp/js.js
@@ -82,7 +82,7 @@ module.exports = cwd => (cb) => {
                   require.resolve('@babel/preset-env'),
                   {
                     modules: false,
-                    useBuiltIns: 'usage',
+                    useBuiltIns: false,
                     corejs: 2,
                     targets,
                     loose: false,


### PR DESCRIPTION
You can now create a `.basecmsrc.js` file in your CWD that allows customization of certain babel build configuration, specifically:
- `babelLoader.exclude` A function to include/exclude files from the babel loader rule
- `babelLoader.targets` Specification of browser targets
- `babelLoader.debug` boolean flag for debug output