### PR TITLE
Add NR instrumentation, rework prod configs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,7 @@ services:
     environment:
       <<: *env
       <<: *env-mongo
+      ENGINE_API_KEY: ${ENGINE_API_KEY}
     depends_on:
       - mongodb
     ports:

--- a/services/graphql-server/package.json
+++ b/services/graphql-server/package.json
@@ -19,6 +19,7 @@
     "@base-cms/utils": "^0.9.0",
     "@godaddy/terminus": "^4.1.0",
     "@newrelic/native-metrics": "^4.1.0",
+    "apollo-newrelic-extension": "^0.1.0",
     "apollo-server-express": "^2.4.8",
     "cheerio": "^1.0.0-rc.2",
     "cors": "^2.8.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2796,6 +2796,15 @@ apollo-link@^1.2.8:
   dependencies:
     zen-observable-ts "^0.8.15"
 
+apollo-newrelic-extension@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/apollo-newrelic-extension/-/apollo-newrelic-extension-0.1.0.tgz#968c8d750e5cebbedb514fe011b41724cc54b049"
+  integrity sha512-ymixd6qwfybEeGbM431lSY6lIrNx5vSfbcdYnm/pnTVyVaK8hHTMLTceKiZf/fNKMnc+VC3AaGzVjg9QGWU1tQ==
+  dependencies:
+    graphql "^0.13.2"
+    graphql-extensions "^0.1.2"
+    ramda "^0.25.0"
+
 apollo-server-caching@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/apollo-server-caching/-/apollo-server-caching-0.3.1.tgz#63fcb2aaa176e1e101b36a8450e6b4c593d2767a"
@@ -2828,6 +2837,14 @@ apollo-server-core@2.4.8:
     sha.js "^2.4.11"
     subscriptions-transport-ws "^0.9.11"
     ws "^6.0.0"
+
+apollo-server-env@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/apollo-server-env/-/apollo-server-env-2.0.3.tgz#3c13552cd33f400160076cf8e1c9b24be4d27e13"
+  integrity sha512-uIfKFH8n8xKO0eLb9Fa79+s2DdMuVethgznvW6SrOYq5VzgkIIobqKEuZPKa5wObw9CkCyju/+Sr7b7WWMFxUQ==
+  dependencies:
+    node-fetch "^2.1.2"
+    util.promisify "^1.0.0"
 
 apollo-server-env@2.2.0:
   version "2.2.0"
@@ -9673,6 +9690,13 @@ graphql-extensions@0.5.7:
   dependencies:
     "@apollographql/apollo-tools" "^0.3.3"
 
+graphql-extensions@^0.1.2:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.1.3.tgz#f8cabaf543619e7dec1db5e274981d2a44c13ab6"
+  integrity sha512-q+d1bTR7GW4qRiZP17SXN0TZo+k/I1FEKYd6H4JMbxzpY8mqTLbg8MzrLu7LxafF+mPEJwRfipcEcA375k3eXA==
+  dependencies:
+    apollo-server-env "2.0.3"
+
 graphql-subscriptions@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/graphql-subscriptions/-/graphql-subscriptions-1.0.0.tgz#475267694b3bd465af6477dbab4263a3f62702b8"
@@ -15109,6 +15133,11 @@ raf@^3.1.0:
   integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
   dependencies:
     performance-now "^2.1.0"
+
+ramda@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
+  integrity sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==
 
 randomatic@^3.0.0:
   version "3.1.1"


### PR DESCRIPTION
This PR notably:
- Adds New Relic instrumentation to GraphQL queries, allowing them to be broken out by the `queryName`:
<img width="506" alt="Screen Shot 2019-05-01 at 11 03 25 AM" src="https://user-images.githubusercontent.com/1778222/57026993-c73d6480-6c00-11e9-87c3-46f546a2a934.png">

- Enables query tracing for Apollo Engine
- Enables debug mode in dev
- Disables introspection in production