### PR TITLE
Include URI with GAM targeting by default

### DIFF
--- a/packages/marko-web/src/components/ads/gam/head.marko
+++ b/packages/marko-web/src/components/ads/gam/head.marko
@@ -1,10 +1,15 @@
 import buildSlots from './utils/build-slots';
 import buildTargeting from './utils/build-targeting';
+import { get, getAsObject } from '@base-cms/object-path';
 
 $ const calls = [];
 $ buildSlots(input.slots).forEach(slot => calls.push(slot));
 $ if (input.enableSingleRequest) calls.push('googletag.pubads().enableSingleRequest();');
 $ if (input.collapseEmptyDivs) calls.push('googletag.pubads().collapseEmptyDivs();');
+$ if (input.targetingIncludeUri) {
+  input.targeting = getAsObject(input, 'targeting');
+  input.targeting.uri = get(out, 'global.req.url');
+}
 $ const targeting = buildTargeting(input.targeting);
 $ if (targeting) calls.push(`googletag.pubads().${targeting};`);
 $ calls.push('googletag.enableServices();');

--- a/packages/marko-web/src/components/ads/gam/marko.json
+++ b/packages/marko-web/src/components/ads/gam/marko.json
@@ -20,6 +20,10 @@
       "type": "boolean",
       "default-value": true
     },
+    "@targeting-include-uri": {
+      "type": "boolean",
+      "default-value": true
+    },
     "@slots": "object",
     "@targeting": "object"
   }


### PR DESCRIPTION
Since GAM/DFP does not include the URI/path, add support for it to the gam initializer.

Unless disabled, URI will be appended to the targeting on all pages.