### PR TITLE
Add rel noopener to target _blank links

### DIFF
--- a/packages/marko-web/src/components/elements/core/link.marko
+++ b/packages/marko-web/src/components/elements/core/link.marko
@@ -1,3 +1,4 @@
+import { get } from '@base-cms/object-path';
 import { linkClassNames } from '@base-cms/web-common/utils';
 import getHref from './get-href';
 import shouldCollapse from '../../../utils/should-collapse';
@@ -5,6 +6,9 @@ import shouldCollapse from '../../../utils/should-collapse';
 $ const href = getHref(input.to, input.path);
 $ const classes = [...linkClassNames(input.block, input.to, input.modifiers), input.class];
 $ const collapse = shouldCollapse(input.collapse);
+$ const target = get(input, 'attrs.target');
+$ const rel = get(input, 'attrs.rel');
+$ if (target === '_blank' && !rel) input.attrs.rel = 'noopener';
 
 <if(!collapse || href)>
   <a href=href class=classes ...input.attrs>


### PR DESCRIPTION
Adds `rel="noopener"` to `target="_blank"` links when no `rel` attribute is provided.