### PR TITLE
Image `isLogo` bug fixes

### DIFF
--- a/packages/image/src/build-imgix-url.js
+++ b/packages/image/src/build-imgix-url.js
@@ -29,8 +29,12 @@ const coreDefaults = {
   w: 320,
 };
 
-module.exports = (src, selected, defaults) => {
-  const options = selected || defaults || coreDefaults;
+module.exports = (src, selected, defaults, isLogo) => {
+  const options = { ...(selected || defaults || coreDefaults) };
+  if (isLogo) {
+    options.fit = 'fillmax';
+    options.fillColor = options.fillColor || 'fff';
+  }
   try {
     const url = new URL(src);
     const searchParams = params.sort().reduce((sp, key) => {

--- a/packages/marko-web/src/components/elements/core/components/imgix.marko
+++ b/packages/marko-web/src/components/elements/core/components/imgix.marko
@@ -1,7 +1,7 @@
 import { buildImgixUrl } from '@base-cms/image';
 
 $ const { config } = out.global;
-$ const src = buildImgixUrl(input.src, input.options);
+$ const src = buildImgixUrl(input.src, input.options, undefined, input.isLogo);
 
 <if(src)>
   <if(config.lazyloadImages() && input.lazyload !== false)>

--- a/packages/marko-web/src/components/elements/core/image.marko
+++ b/packages/marko-web/src/components/elements/core/image.marko
@@ -16,7 +16,7 @@ $ const imgInput = {
   height: input.height,
   isLogo: get(input.obj, 'isLogo', input.logo),
   lazyload: input.lazyload,
-  options: options, // imgix options
+  options: input.options, // imgix options
   src,
   title: input.title,
   width: input.width,

--- a/packages/marko-web/src/components/elements/core/image.marko
+++ b/packages/marko-web/src/components/elements/core/image.marko
@@ -8,7 +8,9 @@ $ let src = result == null ? '' : `${result}`.trim();
 $ src = /^http/i.test(src) ? src : null;
 $ const collapse = shouldCollapse(input.collapse);
 
-$ const options = getAsObject(input, 'options');
+$ const options = {
+  ...getAsObject(input, 'options')
+};
 
 $ if (get(input.obj, 'isLogo', input.logo)) {
   options.fit = 'fillmax';

--- a/packages/marko-web/src/components/elements/core/image.marko
+++ b/packages/marko-web/src/components/elements/core/image.marko
@@ -8,21 +8,13 @@ $ let src = result == null ? '' : `${result}`.trim();
 $ src = /^http/i.test(src) ? src : null;
 $ const collapse = shouldCollapse(input.collapse);
 
-$ const options = {
-  ...getAsObject(input, 'options')
-};
-
-$ if (get(input.obj, 'isLogo', input.logo)) {
-  options.fit = 'fillmax';
-  options.fillColor = options.fillColor || 'fff';
-}
-
 $ const href = getHref(input.linkTo, input.linkPath);
 $ const imgInput = {
   alt: get(input.obj, 'alt', input.alt),
   class: [...elementClassNames(input.block, input.obj, null, input.modifiers), input.class],
   collapse,
   height: input.height,
+  isLogo: get(input.obj, 'isLogo', input.logo),
   lazyload: input.lazyload,
   options: options, // imgix options
   src,


### PR DESCRIPTION
Ensure image options are copied
- Otherwise reassigned logo options will stick to the next image, even if it isn’t a logo

Move isLogo handling to core imgix url builder
- Ensures logo handling can be used globally across packages/services, not just Marko web components
