### PR TITLE
Support appending names to block queries

### DIFF
--- a/packages/web-common/src/block-loaders/all-published-content.js
+++ b/packages/web-common/src/block-loaders/all-published-content.js
@@ -42,6 +42,7 @@ module.exports = async (apolloClient, {
   sectionBubbling,
 
   queryFragment,
+  queryName,
 } = {}) => {
   const pagination = { limit, skip, after };
   const input = {
@@ -55,7 +56,7 @@ module.exports = async (apolloClient, {
     ending: { after: date(endingAfter), before: date(endingBefore) },
   };
   if (field || order) input.sort = { field, order };
-  const query = buildQuery({ queryFragment });
+  const query = buildQuery({ queryFragment, queryName });
   const variables = { input };
 
   const { data } = await apolloClient.query({ query, variables });

--- a/packages/web-common/src/block-loaders/magazine-active-issues.js
+++ b/packages/web-common/src/block-loaders/magazine-active-issues.js
@@ -10,12 +10,13 @@ module.exports = async (apolloClient, input = {}) => {
   const {
     publicationId,
     queryFragment,
+    queryName,
     limit,
     skip,
     after,
     sort,
   } = input;
-  const query = buildQuery({ queryFragment });
+  const query = buildQuery({ queryFragment, queryName });
   const pagination = { limit, skip, after };
   const variables = { input: { publicationId, sort, pagination } };
 

--- a/packages/web-common/src/block-loaders/magazine-latest-issue.js
+++ b/packages/web-common/src/block-loaders/magazine-latest-issue.js
@@ -6,8 +6,8 @@ const buildQuery = require('../gql/query-factories/block-magazine-latest-issue')
  * @param {string} [params.queryFragment] The `graphql-tag` fragment
  *                                        to apply to the `magazineLatestIssue` query.
  */
-module.exports = async (apolloClient, { publicationId, queryFragment } = {}) => {
-  const query = buildQuery({ queryFragment });
+module.exports = async (apolloClient, { publicationId, queryFragment, queryName } = {}) => {
+  const query = buildQuery({ queryFragment, queryName });
   const variables = { input: { publicationId } };
   const { data } = await apolloClient.query({ query, variables });
   if (!data || !data.magazineLatestIssue) return { node: null };

--- a/packages/web-common/src/block-loaders/magazine-publications.js
+++ b/packages/web-common/src/block-loaders/magazine-publications.js
@@ -6,8 +6,8 @@ const buildQuery = require('../gql/query-factories/block-magazine-publications')
  * @param {string} [params.queryFragment] The `graphql-tag` fragment
  *                                        to apply to the `magazinePublications` query.
  */
-module.exports = async (apolloClient, { queryFragment } = {}) => {
-  const query = buildQuery({ queryFragment });
+module.exports = async (apolloClient, { queryFragment, queryName } = {}) => {
+  const query = buildQuery({ queryFragment, queryName });
   const variables = { input: {} };
 
   const { data } = await apolloClient.query({ query, variables });

--- a/packages/web-common/src/block-loaders/magazine-scheduled-content.js
+++ b/packages/web-common/src/block-loaders/magazine-scheduled-content.js
@@ -18,6 +18,7 @@ module.exports = async (apolloClient, {
   issueId,
   sort,
   queryFragment,
+  queryName,
 } = {}) => {
   const pagination = { limit, skip, after };
   const input = {
@@ -25,7 +26,7 @@ module.exports = async (apolloClient, {
     pagination,
     issueId,
   };
-  const query = buildQuery({ queryFragment });
+  const query = buildQuery({ queryFragment, queryName });
   const variables = { input };
 
   const { data } = await apolloClient.query({ query, variables });

--- a/packages/web-common/src/block-loaders/related-published-content.js
+++ b/packages/web-common/src/block-loaders/related-published-content.js
@@ -26,6 +26,7 @@ module.exports = async (apolloClient, {
   requiresImage,
 
   queryFragment,
+  queryName,
 } = {}) => {
   const pagination = { limit, skip, after };
   const input = {
@@ -36,7 +37,7 @@ module.exports = async (apolloClient, {
     includeContentTypes,
     requiresImage,
   };
-  const query = buildQuery({ queryFragment });
+  const query = buildQuery({ queryFragment, queryName });
   const variables = { input };
 
   const { data } = await apolloClient.query({ query, variables });

--- a/packages/web-common/src/block-loaders/website-scheduled-content.js
+++ b/packages/web-common/src/block-loaders/website-scheduled-content.js
@@ -34,6 +34,7 @@ module.exports = async (apolloClient, {
   sectionBubbling,
 
   queryFragment,
+  queryName,
 } = {}) => {
   const pagination = { limit, skip, after };
   const input = {
@@ -47,7 +48,7 @@ module.exports = async (apolloClient, {
     sectionId,
     optionId,
   };
-  const query = buildQuery({ queryFragment });
+  const query = buildQuery({ queryFragment, queryName });
   const variables = { input };
 
   const { data } = await apolloClient.query({ query, variables });

--- a/packages/web-common/src/gql/query-factories/block-all-published-content.js
+++ b/packages/web-common/src/gql/query-factories/block-all-published-content.js
@@ -10,10 +10,10 @@ const { extractFragmentData } = require('../../utils');
  *                                        to apply to `edges.node` on
  *                                        the `allPublishedContent` query.
  */
-module.exports = ({ queryFragment }) => {
+module.exports = ({ queryFragment, queryName = '' } = {}) => {
   const { spreadFragmentName, processedFragment } = extractFragmentData(queryFragment);
   return gql`
-    query BlockAllPublishedContent($input: AllPublishedContentQueryInput!) {
+    query BlockAllPublishedContent${queryName}($input: AllPublishedContentQueryInput!) {
       allPublishedContent(input: $input) {
         edges {
           node {

--- a/packages/web-common/src/gql/query-factories/block-magazine-active-issues.js
+++ b/packages/web-common/src/gql/query-factories/block-magazine-active-issues.js
@@ -10,10 +10,10 @@ const { extractFragmentData } = require('../../utils');
  *                                        to apply to `edges.node` on
  *                                        the `magazineActiveIssues` query.
  */
-module.exports = ({ queryFragment }) => {
+module.exports = ({ queryFragment, queryName = '' } = {}) => {
   const { spreadFragmentName, processedFragment } = extractFragmentData(queryFragment);
   return gql`
-    query BlockMagazineActiveIssues($input: MagazineActiveIssuesQueryInput!) {
+    query BlockMagazineActiveIssues${queryName}($input: MagazineActiveIssuesQueryInput!) {
       magazineActiveIssues(input: $input) {
         edges {
           node {

--- a/packages/web-common/src/gql/query-factories/block-magazine-latest-issue.js
+++ b/packages/web-common/src/gql/query-factories/block-magazine-latest-issue.js
@@ -10,10 +10,10 @@ const { extractFragmentData } = require('../../utils');
  *                                        to apply to `edges.node` on
  *                                        the `magazineLatestIssue` query.
  */
-module.exports = ({ queryFragment }) => {
+module.exports = ({ queryFragment, queryName = '' } = {}) => {
   const { spreadFragmentName, processedFragment } = extractFragmentData(queryFragment);
   return gql`
-    query BlockMagazineLatestIssue($input: MagazineLatestIssueQueryInput!) {
+    query BlockMagazineLatestIssue${queryName}($input: MagazineLatestIssueQueryInput!) {
       magazineLatestIssue(input: $input) {
         ...BlockMagazineLatestIssueFragment
         ${spreadFragmentName}

--- a/packages/web-common/src/gql/query-factories/block-magazine-publications.js
+++ b/packages/web-common/src/gql/query-factories/block-magazine-publications.js
@@ -10,10 +10,10 @@ const { extractFragmentData } = require('../../utils');
  *                                        to apply to `edges.node` on
  *                                        the `magazinePublications` query.
  */
-module.exports = ({ queryFragment }) => {
+module.exports = ({ queryFragment, queryName = '' } = {}) => {
   const { spreadFragmentName, processedFragment } = extractFragmentData(queryFragment);
   return gql`
-    query BlockMagazinePublications($input: MagazinePublicationsQueryInput!) {
+    query BlockMagazinePublications${queryName}($input: MagazinePublicationsQueryInput!) {
       magazinePublications(input: $input) {
         edges {
           node {

--- a/packages/web-common/src/gql/query-factories/block-magazine-scheduled-content.js
+++ b/packages/web-common/src/gql/query-factories/block-magazine-scheduled-content.js
@@ -10,10 +10,10 @@ const { extractFragmentData } = require('../../utils');
  *                                        to apply to `edges.node` on
  *                                        the `magazineScheduledContent` query.
  */
-module.exports = ({ queryFragment }) => {
+module.exports = ({ queryFragment, queryName = '' } = {}) => {
   const { spreadFragmentName, processedFragment } = extractFragmentData(queryFragment);
   return gql`
-    query BlockMagazineScheduledContent($input: MagazineScheduledContentQueryInput!) {
+    query BlockMagazineScheduledContent${queryName}($input: MagazineScheduledContentQueryInput!) {
       magazineScheduledContent(input: $input) {
         edges {
           node {

--- a/packages/web-common/src/gql/query-factories/block-related-published-content.js
+++ b/packages/web-common/src/gql/query-factories/block-related-published-content.js
@@ -10,10 +10,10 @@ const { extractFragmentData } = require('../../utils');
  *                                        to apply to `edges.node` on
  *                                        the `relatedPublishedContent` query.
  */
-module.exports = ({ queryFragment }) => {
+module.exports = ({ queryFragment, queryName = '' } = {}) => {
   const { spreadFragmentName, processedFragment } = extractFragmentData(queryFragment);
   return gql`
-    query BlockPublishedRelatedContent($input: RelatedPublishedContentQueryInput!) {
+    query BlockPublishedRelatedContent${queryName}($input: RelatedPublishedContentQueryInput!) {
       relatedPublishedContent(input: $input) {
         edges {
           node {

--- a/packages/web-common/src/gql/query-factories/block-website-scheduled-content.js
+++ b/packages/web-common/src/gql/query-factories/block-website-scheduled-content.js
@@ -10,10 +10,10 @@ const { extractFragmentData } = require('../../utils');
  *                                        to apply to `edges.node` on
  *                                        the `websiteScheduledContent` query.
  */
-module.exports = ({ queryFragment }) => {
+module.exports = ({ queryFragment, queryName = '' } = {}) => {
   const { spreadFragmentName, processedFragment } = extractFragmentData(queryFragment);
   return gql`
-    query BlockWebsiteScheduledContent($input: WebsiteScheduledContentQueryInput!) {
+    query BlockWebsiteScheduledContent${queryName}($input: WebsiteScheduledContentQueryInput!) {
       websiteScheduledContent(input: $input) {
         edges {
           node {

--- a/packages/web-common/src/gql/query-factories/with-content.js
+++ b/packages/web-common/src/gql/query-factories/with-content.js
@@ -9,10 +9,10 @@ const { extractFragmentData } = require('../../utils');
  * @param {string} [params.queryFragment] The `graphql-tag` fragment
  *                                        to apply to the `content` query.
  */
-module.exports = ({ queryFragment }) => {
+module.exports = ({ queryFragment, queryName = '' } = {}) => {
   const { spreadFragmentName, processedFragment } = extractFragmentData(queryFragment);
   return gql`
-    query WithContent($input: ContentQueryInput!) {
+    query WithContent${queryName}($input: ContentQueryInput!) {
       content(input: $input) {
         ...WithContentFragment
         ${spreadFragmentName}

--- a/packages/web-common/src/gql/query-factories/with-dynamic-page.js
+++ b/packages/web-common/src/gql/query-factories/with-dynamic-page.js
@@ -9,10 +9,10 @@ const { extractFragmentData } = require('../../utils');
  * @param {string} [params.queryFragment] The `graphql-tag` fragment
  *                                        to apply to the `contentPage` query.
  */
-module.exports = ({ queryFragment } = {}) => {
+module.exports = ({ queryFragment, queryName = '' } = {}) => {
   const { spreadFragmentName, processedFragment } = extractFragmentData(queryFragment);
   return gql`
-    query WithDynamicPage($input: ContentPageQueryInput!) {
+    query WithDynamicPage${queryName}($input: ContentPageQueryInput!) {
       contentPage(input: $input) {
         ...WithDynamicPageFragment
         ${spreadFragmentName}

--- a/packages/web-common/src/gql/query-factories/with-magazine-issue.js
+++ b/packages/web-common/src/gql/query-factories/with-magazine-issue.js
@@ -9,10 +9,10 @@ const { extractFragmentData } = require('../../utils');
  * @param {string} [params.queryFragment] The `graphql-tag` fragment
  *                                        to apply to the `magazineIssue` query.
  */
-module.exports = ({ queryFragment } = {}) => {
+module.exports = ({ queryFragment, queryName = '' } = {}) => {
   const { spreadFragmentName, processedFragment } = extractFragmentData(queryFragment);
   return gql`
-    query WithMagazineIssue($input: MagazineIssueQueryInput!) {
+    query WithMagazineIssue${queryName}($input: MagazineIssueQueryInput!) {
       magazineIssue(input: $input) {
         ...WithMagazineIssueFragment
         ${spreadFragmentName}

--- a/packages/web-common/src/gql/query-factories/with-magazine-publication.js
+++ b/packages/web-common/src/gql/query-factories/with-magazine-publication.js
@@ -9,10 +9,10 @@ const { extractFragmentData } = require('../../utils');
  * @param {string} [params.queryFragment] The `graphql-tag` fragment
  *                                        to apply to the `magazinePublication` query.
  */
-module.exports = ({ queryFragment } = {}) => {
+module.exports = ({ queryFragment, queryName = '' } = {}) => {
   const { spreadFragmentName, processedFragment } = extractFragmentData(queryFragment);
   return gql`
-    query WithMagazinePublication($input: MagazinePublicationQueryInput!) {
+    query WithMagazinePublication${queryName}($input: MagazinePublicationQueryInput!) {
       magazinePublication(input: $input) {
         ...WithMagazinePublicationFragment
         ${spreadFragmentName}

--- a/packages/web-common/src/gql/query-factories/with-magazine-subscribe-url.js
+++ b/packages/web-common/src/gql/query-factories/with-magazine-subscribe-url.js
@@ -9,10 +9,10 @@ const { extractFragmentData } = require('../../utils');
  * @param {string} [params.queryFragment] The `graphql-tag` fragment
  *                                        to apply to the `magazineSubscribeUrl` query.
  */
-module.exports = ({ queryFragment } = {}) => {
+module.exports = ({ queryFragment, queryName = '' } = {}) => {
   const { spreadFragmentName, processedFragment } = extractFragmentData(queryFragment);
   return gql`
-    query WithMagazineSubscribeUrl($input: MagazineSubscribeUrlQueryInput!) {
+    query WithMagazineSubscribeUrl${queryName}($input: MagazineSubscribeUrlQueryInput!) {
       magazineSubscribeUrl(input: $input) {
         ...WithMagazineSubscribeUrlFragment
         ${spreadFragmentName}

--- a/packages/web-common/src/gql/query-factories/with-website-section.js
+++ b/packages/web-common/src/gql/query-factories/with-website-section.js
@@ -9,10 +9,10 @@ const { extractFragmentData } = require('../../utils');
  * @param {string} [params.queryFragment] The `graphql-tag` fragment
  *                                        to apply to the `websiteSectionAlias` query.
  */
-module.exports = ({ queryFragment } = {}) => {
+module.exports = ({ queryFragment, queryName = '' } = {}) => {
   const { spreadFragmentName, processedFragment } = extractFragmentData(queryFragment);
   return gql`
-    query WithWebsiteSection($input: WebsiteSectionAliasQueryInput!, $redirect: WebsiteSectionRedirectQueryInput!) {
+    query WithWebsiteSection${queryName}($input: WebsiteSectionAliasQueryInput!, $redirect: WebsiteSectionRedirectQueryInput!) {
       websiteSectionAlias(input: $input) {
         ...WithWebsiteSectionFragment
         ${spreadFragmentName}


### PR DESCRIPTION
Appends provided `queryName` input parameter to the GraphQL operation name, allowing queries to be broken out more betterer.