### PR TITLE
Use image crop aspect ratio in file path

### DIFF
--- a/packages/image/src/create-src-for.js
+++ b/packages/image/src/create-src-for.js
@@ -1,7 +1,8 @@
 const buildImgixUrl = require('./build-imgix-url');
 
 module.exports = (host, image, options, defaultOptions) => {
-  const { filePath, fileName } = image;
-  const src = `https://${host}/${filePath}/${fileName}`;
+  const { filePath, fileName, cropDimensions } = image;
+  const path = cropDimensions && cropDimensions.aspectRatio ? `${filePath}/${cropDimensions.aspectRatio}` : filePath;
+  const src = `https://${host}/${path}/${fileName}`;
   return buildImgixUrl(src, options, defaultOptions);
 };

--- a/services/graphql-server/src/graphql/definitions/platform/asset.js
+++ b/services/graphql-server/src/graphql/definitions/platform/asset.js
@@ -26,7 +26,7 @@ type AssetImage {
   approvedMagazine: Boolean @projection(localField: "mutations.Magazine.approved") @value(localField: "mutations.Magazine.approved")
 
   # GraphQL specific fields
-  src: String! @projection(localField: "fileName", needs: ["filePath"])
+  src: String! @projection(localField: "fileName", needs: ["filePath", "cropDimensions"])
   alt: String! @projection(localField: "name", needs: ["caption", "fileName"])
 }
 


### PR DESCRIPTION
If a crop is set on a `PlatformAssetImage` append its `aspectRatio` to the `src` when requesting the image from imgix.

Ensures an image such as this:
![image](https://user-images.githubusercontent.com/3289485/57940570-56e64280-7892-11e9-9f54-5f32a62c447b.png)
https://base.imgix.net/files/base/ebm/rdh/image/2019/05/dreamstime_xxl_37821776.5cdd88dda5b23.png?auto=format&w=320

Becomes this:
![image](https://user-images.githubusercontent.com/3289485/57940574-5b126000-7892-11e9-9260-e700ba902c99.png)
https://base.imgix.net/files/base/ebm/rdh/image/2019/05/16x9/dreamstime_xxl_37821776.5cdd88dda5b23.png?auto=format&w=320