### PR TITLE
Include published date with content metadata

### DIFF
--- a/packages/marko-web/src/components/page/description.marko
+++ b/packages/marko-web/src/components/page/description.marko
@@ -1,3 +1,3 @@
 <if(input.content)>
-   <meta name="description" content=`${input.content}` />
+   <meta name="description" property="og:description" item-prop="description" content=`${input.content}` />
 </if>

--- a/packages/marko-web/src/components/page/metadata/components/content.marko
+++ b/packages/marko-web/src/components/page/metadata/components/content.marko
@@ -17,9 +17,6 @@ $ const src = get(image, 'src');
 
 <!-- Schema.org -->
 <meta item-prop="name" content=title />
-<if (description)>
-  <meta item-prop="description" content=description />
-</if>
 <if (src)>
   <meta item-prop="image" content=src />
 </if>
@@ -36,9 +33,6 @@ $ const src = get(image, 'src');
 
 <!-- OpenGraph (Facebook, etc.) -->
 <meta name="og:title" content=title />
-<if (description)>
-  <meta name="og:description" content=description />
-</if>
 <if(src)>
   <!-- @todo Create a new focal point preview for FB's 1200x630 ratio -->
   <meta name="og:image" content=src />

--- a/packages/marko-web/src/components/page/metadata/components/content.marko
+++ b/packages/marko-web/src/components/page/metadata/components/content.marko
@@ -3,6 +3,7 @@ import { get } from '@base-cms/object-path';
 $ const { config } = out.global;
 $ const metadata = input.metadata;
 $ const { title, description, image } = metadata;
+$ const { publishedDate } = metadata;
 $ const src = get(image, 'src');
 
 <!-- Standard Fields -->
@@ -43,3 +44,6 @@ $ const src = get(image, 'src');
 <meta name="og:site_name" content=config.siteName() />
 <meta name="og:locale" content=config.locale() />
 <meta name="og:type" content="article" />
+<if (publishedDate)>
+  <meta property="article:published_time" content=publishedDate />
+</if>

--- a/packages/web-common/src/gql/fragments/with-content.js
+++ b/packages/web-common/src/gql/fragments/with-content.js
@@ -10,6 +10,7 @@ fragment WithContentFragment on Content {
   metadata {
     title
     description
+    publishedDate
     image {
       id
       src

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -133,6 +133,7 @@ type ContentEdge {
 type ContentMetadata {
   title: String
   description: String
+  publishedDate(input: FormatDate = {}): String @projection(localField: "published") @momentFormat(localField: "published")
   image: AssetImage @refOne(localField: "primaryImage", loader: "platformAsset", criteria: "assetImage")
 }
 


### PR DESCRIPTION
**JIRA: [CS-2325](https://southcomm.atlassian.net/browse/CS-2325)**

Ensures that the published date is included on content pages, and unifies duplicative meta description tags.