### PR TITLE
Add method to return years for content scheduling

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -13,6 +13,7 @@ extend type Query {
   allCompanyContent(input: AllCompanyContentQueryInput = {}): ContentConnection!
   magazineScheduledContent(input: MagazineScheduledContentQueryInput = {}): ContentConnection!
   websiteScheduledContent(input: WebsiteScheduledContentQueryInput = {}): ContentConnection!
+  websiteScheduledContentByYear(input: WebsiteScheduledContentQueryInput = {}): [String!]!
   relatedPublishedContent(input: RelatedPublishedContentQueryInput = {}): ContentConnection!
 }
 


### PR DESCRIPTION
When given website schedule query criteria, return an array of the years content was scheduled for, ex `[2009, 2007, 1995]`.