### PR TITLE
Add onAsyncBlockError handler support

### DIFF
--- a/packages/async/src/each.js
+++ b/packages/async/src/each.js
@@ -1,0 +1,11 @@
+const each = require('async/each');
+
+module.exports = (coll, iteratee) => new Promise((resolve, reject) => {
+  each(coll, iteratee, (err, res) => {
+    if (err) {
+      reject(err);
+    } else {
+      resolve(res);
+    }
+  });
+});

--- a/packages/marko-web/src/components/queries/components/loader-multi.marko
+++ b/packages/marko-web/src/components/queries/components/loader-multi.marko
@@ -1,10 +1,12 @@
 $ const isDevelopment = process.env.NODE_ENV === 'development';
+$ const { onAsyncBlockError } = out.global;
 
 <await(input.loader(out.global.apollo, input))>
   <@then|{ nodes, pageInfo }|>
     <${input.renderBody} nodes=nodes page-info=pageInfo />
   </@then>
   <@catch|err|>
+    $ if (typeof onAsyncBlockError === 'function') onAsyncBlockError(err);
     <if(input.onError)>
       <${input.onError} err=err />
     </if>

--- a/packages/marko-web/src/components/queries/components/loader-single.marko
+++ b/packages/marko-web/src/components/queries/components/loader-single.marko
@@ -1,10 +1,12 @@
 $ const isDevelopment = process.env.NODE_ENV === 'development';
+$ const { onAsyncBlockError } = out.global;
 
 <await(input.loader(out.global.apollo, input))>
   <@then|{ node }|>
     <${input.renderBody} node=node />
   </@then>
   <@catch|err|>
+    $ if (typeof onAsyncBlockError === 'function') onAsyncBlockError(err);
     <if(input.onError)>
       <${input.onError} err=err />
     </if>

--- a/packages/marko-web/src/express/index.js
+++ b/packages/marko-web/src/express/index.js
@@ -16,6 +16,9 @@ module.exports = (config = {}) => {
   const serverDir = path.resolve(rootDir, 'server');
   const { siteName } = config.coreConfig;
 
+  // Add async block error handler.
+  app.locals.onAsyncBlockError = config.onAsyncBlockError;
+
   // Add cookie parsing
   app.use(cookieParser());
 

--- a/packages/marko-web/src/index.js
+++ b/packages/marko-web/src/index.js
@@ -26,6 +26,7 @@ const startServer = async ({
   cdnImageHostname = env.CDN_IMAGE_HOSTNAME || 'base.imgix.net',
   cdnAssetHostname = env.CDN_ASSET_HOSTNAME || 'media.baseplatform.io',
   errorTemplate,
+  onAsyncBlockError,
 
   // Terminus settings.
   timeout = 1000,
@@ -46,6 +47,7 @@ const startServer = async ({
     tenantKey,
     cdnImageHostname,
     cdnAssetHostname,
+    onAsyncBlockError,
   });
 
   // Await required services here...


### PR DESCRIPTION
Allows passing an `onAsyncBlockError` function when starting the web server. This will be invoked anytime the `loader-multi` or `loader-single` async components encounter an error, with the `Error` object as the first argument. Allows for users of the library to add additional error logging, etc.

For example, when loading the server, send a function:
```js
const { startServer } = require('@base-cms/marko-web');
const routes = require('./server/routes');
const siteConfig = require('./config/site');
const coreConfig = require('./config/core');

const { log } = console;

startServer({
  rootDir: __dirname,
  coreConfig,
  siteConfig,
  routes,
  onAsyncBlockError: e => log('ERROR IN ASYNC', e),
}).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

```

This will also be available globally in Marko templates via `out.global.onAsyncBlockError` and in Express routes via `app.locals.onAsyncBlockError`