### PR TITLE
Fallback to development if NODE_ENV is empty

### DIFF
--- a/packages/web-cli/src/gulp/js.js
+++ b/packages/web-cli/src/gulp/js.js
@@ -53,7 +53,7 @@ const readRcFile = (cwd) => {
 // @todo Add default polyfills to entry point
 module.exports = cwd => (cb) => {
   const { exclude, targets, debug } = readRcFile(cwd);
-  const { ifProduction, ifNotProduction } = getIfUtils(process.env.NODE_ENV);
+  const { ifProduction, ifNotProduction } = getIfUtils(process.env.NODE_ENV || 'development');
   pump([
     src('browser/index.js', { cwd }),
     webpack({


### PR DESCRIPTION
Without this, if the `NODE_ENV` is empty, the JS build will fail, as the `getIfUtils` function requires its argument to be string or object.