### PR TITLE
Actually support natural sort

### DIFF
--- a/packages/db/src/basedb.js
+++ b/packages/db/src/basedb.js
@@ -234,7 +234,6 @@ class BaseDB {
     projection,
     excludeProjection,
     ignoreCompoundAfterSort,
-    ids,
   }) {
     return paginateFind(this, modelName, {
       query,
@@ -246,7 +245,6 @@ class BaseDB {
       projection,
       excludeProjection,
       ignoreCompoundAfterSort,
-      ids,
     });
   }
 

--- a/packages/db/src/basedb.js
+++ b/packages/db/src/basedb.js
@@ -234,6 +234,7 @@ class BaseDB {
     projection,
     excludeProjection,
     ignoreCompoundAfterSort,
+    ids,
   }) {
     return paginateFind(this, modelName, {
       query,
@@ -245,6 +246,7 @@ class BaseDB {
       projection,
       excludeProjection,
       ignoreCompoundAfterSort,
+      ids,
     });
   }
 

--- a/packages/db/src/paginate/find.js
+++ b/packages/db/src/paginate/find.js
@@ -27,6 +27,7 @@ module.exports = async (basedb, modelName, {
   excludeProjection,
   ignoreCompoundAfterSort,
   collate = false,
+  ids = [],
 }) => {
   const $limit = new Limit({ value: limit });
   const $sort = new Sort(sort);
@@ -59,6 +60,13 @@ module.exports = async (basedb, modelName, {
   if (collate) options.collation = $sort.collation;
 
   const results = await basedb.find(modelName, $query, options);
-
+  if (isArray(ids) && ids.length) {
+    const sorted = ids
+      // Resort the items to match the ID order
+      .map(id => results.find(({ _id }) => `${_id}` === `${id}`))
+      // If we have less results than expected, filter out bad ones
+      .filter(id => id);
+    return createResponse(basedb, modelName, sorted, params);
+  }
   return createResponse(basedb, modelName, results, params);
 };

--- a/packages/db/src/paginate/find.js
+++ b/packages/db/src/paginate/find.js
@@ -22,12 +22,11 @@ module.exports = async (basedb, modelName, {
   limit = 10,
   skip,
   after,
-  sort = { field: '_id', order: 1 },
+  sort = { field: '_id', order: 1, values: [] },
   projection,
   excludeProjection,
   ignoreCompoundAfterSort,
   collate = false,
-  ids = [],
 }) => {
   const $limit = new Limit({ value: limit });
   const $sort = new Sort(sort);
@@ -60,13 +59,6 @@ module.exports = async (basedb, modelName, {
   if (collate) options.collation = $sort.collation;
 
   const results = await basedb.find(modelName, $query, options);
-  if (isArray(ids) && ids.length) {
-    const sorted = ids
-      // Resort the items to match the ID order
-      .map(id => results.find(({ _id }) => `${_id}` === `${id}`))
-      // If we have less results than expected, filter out bad ones
-      .filter(id => id);
-    return createResponse(basedb, modelName, sorted, params);
-  }
-  return createResponse(basedb, modelName, results, params);
+  const sorted = $sort.sortResults(results);
+  return createResponse(basedb, modelName, sorted, params);
 };

--- a/packages/db/src/paginate/sort.js
+++ b/packages/db/src/paginate/sort.js
@@ -10,12 +10,32 @@ class Sort {
    * @param {string} params.field
    * @param {number} params.order
    * @param {object} params.options
+   * @param {array}  params.values
    */
-  constructor({ field, order, options } = {}) {
+  constructor({
+    field,
+    order,
+    options,
+    values,
+  } = {}) {
     this.options = options;
     this.values = {};
     this.field = field;
     this.order = order;
+    this.orderValues = values;
+    this.sortByValues = order === 'values';
+  }
+
+  /**
+   * Sorts a result set using the configured field, order, and values.
+   */
+  sortResults(results = []) {
+    const { field, sortByValues, orderValues } = this;
+    if (sortByValues && orderValues.length) {
+      const map = results.reduce((m, r) => m.set(`${r[field]}`, r), new Map());
+      return orderValues.map(value => map.get(`${value}`)).filter(value => value);
+    }
+    return results;
   }
 
   /**
@@ -99,6 +119,9 @@ class Sort {
       this.values.order = 1;
     } else if (order === 'desc') {
       this.values.order = -1;
+    } else if (order === 'values') {
+      this.values.order = 1;
+      this.sortByValues = true;
     } else if (!order) {
       this.values.order = 1;
     } else {

--- a/services/graphql-server/src/graphql/definitions/index.js
+++ b/services/graphql-server/src/graphql/definitions/index.js
@@ -36,7 +36,7 @@ type PageInfo {
 enum SortOrder {
   asc
   desc
-  natural
+  values
 }
 
 enum ModelStatus {

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -289,7 +289,7 @@ input ContentCompanyInput {
 }
 
 input ContentImagesInput {
-  sort: AssetImageSortInput = { order: natural }
+  sort: AssetImageSortInput = { order: values }
   pagination: PaginationInput = {}
 }
 

--- a/services/graphql-server/src/graphql/definitions/platform/content/types/venue.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/types/venue.js
@@ -26,7 +26,7 @@ input ContentVenueParentVenueInput {
 
 input ContentSpacesQueryInput {
   status: ModelStatus = active
-  sort: ContentSpaceSortInput = { order: natural }
+  sort: ContentSpaceSortInput = { order: values }
 }
 
 `;

--- a/services/graphql-server/src/graphql/directives/ref-many.js
+++ b/services/graphql-server/src/graphql/directives/ref-many.js
@@ -50,11 +50,10 @@ class RefManyDirective extends SchemaDirectiveVisitor {
       const projection = connectionProjection(info);
       const result = await basedb.paginate(model, {
         query,
-        sort,
+        sort: { values: ids, ...sort },
         ...pagination,
         collate: shouldCollate(sort.field),
         projection,
-        ids: sort.order === 'natural' ? ids : undefined,
       });
       basedb.log('@refMany', start, { model });
       return result;

--- a/services/graphql-server/src/graphql/directives/ref-many.js
+++ b/services/graphql-server/src/graphql/directives/ref-many.js
@@ -54,6 +54,7 @@ class RefManyDirective extends SchemaDirectiveVisitor {
         ...pagination,
         collate: shouldCollate(sort.field),
         projection,
+        ids: sort.order === 'natural' ? ids : undefined,
       });
       basedb.log('@refMany', start, { model });
       return result;

--- a/services/graphql-server/src/graphql/directives/ref-many.js
+++ b/services/graphql-server/src/graphql/directives/ref-many.js
@@ -50,7 +50,7 @@ class RefManyDirective extends SchemaDirectiveVisitor {
       const projection = connectionProjection(info);
       const result = await basedb.paginate(model, {
         query,
-        sort: { values: ids, ...sort },
+        sort: { ...sort, values: ids },
         ...pagination,
         collate: shouldCollate(sort.field),
         projection,


### PR DESCRIPTION
Evidently the few cases I checked weren't a good enough base. This modification to `basedb.paginate` and GraphQL `refMany` directive will perform 'natural' (array order) sorting of results, when natural sort is specified.