### PR TITLE
Inverse reference sorting

### DIFF
--- a/packages/db/src/create-basedb.js
+++ b/packages/db/src/create-basedb.js
@@ -11,7 +11,7 @@ const logger = (obj) => {
 };
 
 const shouldLog = () => {
-  if (!NODE_ENV !== 'development') return false;
+  if (NODE_ENV !== 'development') return false;
   return ENABLE_BASEDB_LOGGING;
 };
 

--- a/services/graphql-server/src/graphql/definitions/platform/content/types/venue.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/types/venue.js
@@ -26,7 +26,7 @@ input ContentVenueParentVenueInput {
 
 input ContentSpacesQueryInput {
   status: ModelStatus = active
-  sort: ContentSpaceSortInput = { order: values }
+  sort: ContentSpaceSortInput = { order: asc }
 }
 
 `;

--- a/services/graphql-server/src/graphql/directives/ref-many.js
+++ b/services/graphql-server/src/graphql/directives/ref-many.js
@@ -38,9 +38,8 @@ class RefManyDirective extends SchemaDirectiveVisitor {
         sort,
         pagination,
       } = input;
-      if (sort.order === 'values' && foreignField !== '_id') {
-        throw new UserInputError('Cannot use `values` sort on an inverse reference.');
-      }
+      const isInverse = foreignField !== '_id';
+      if (sort.order === 'values' && isInverse) throw new UserInputError('Cannot use `values` sort on an inverse reference.');
       const query = applyInput({
         query: {
           ...criteriaFor(criteria),

--- a/services/graphql-server/src/graphql/directives/ref-many.js
+++ b/services/graphql-server/src/graphql/directives/ref-many.js
@@ -38,7 +38,9 @@ class RefManyDirective extends SchemaDirectiveVisitor {
         sort,
         pagination,
       } = input;
-      if (sort.order === 'values' && localField) throw new UserInputError('Cannot use `values` sort on an inverse reference.');
+      if (sort.order === 'values' && foreignField !== '_id') {
+        throw new UserInputError('Cannot use `values` sort on an inverse reference.');
+      }
       const query = applyInput({
         query: {
           ...criteriaFor(criteria),

--- a/services/graphql-server/src/graphql/directives/ref-many.js
+++ b/services/graphql-server/src/graphql/directives/ref-many.js
@@ -1,5 +1,6 @@
 const { SchemaDirectiveVisitor } = require('graphql-tools');
 const { BaseDB } = require('@base-cms/db');
+const { UserInputError } = require('apollo-server-express');
 const formatStatus = require('../utils/format-status');
 const criteriaFor = require('../utils/criteria-for');
 const applyInput = require('../utils/apply-input');
@@ -37,6 +38,7 @@ class RefManyDirective extends SchemaDirectiveVisitor {
         sort,
         pagination,
       } = input;
+      if (sort.order === 'values' && localField) throw new UserInputError('Cannot use `values` sort on an inverse reference.');
       const query = applyInput({
         query: {
           ...criteriaFor(criteria),


### PR DESCRIPTION
If querying an inverse reference, `values` sort doesn’t make sense, and will return no results. Throws a user input error to inform the user they need to use a different sort on this field, and changes the default sort of `Venue.spaces` to be by ID, ascending.