### PR TITLE
Do not return wrapping <html> tag with image

### DIFF
--- a/packages/embedded-media/src/tags/image-asset.js
+++ b/packages/embedded-media/src/tags/image-asset.js
@@ -36,7 +36,7 @@ class ImageAssetTag extends AbstractTag {
     if (image.caption) $.root().append(`<span class="caption">${image.caption}</span>`);
     if (image.credit) $.root().append(`<span class="credit">${image.credit}</span>`);
 
-    return $.html();
+    return $('body').html();
   }
 }
 


### PR DESCRIPTION
Fixes an issue where embedded image markup was being wrapped with `<html>` and `<body>`  elements. 