### PR TITLE
Image caption handling

### DIFF
--- a/packages/embedded-media/package.json
+++ b/packages/embedded-media/package.json
@@ -10,7 +10,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@base-cms/html": "^0.9.44",
     "@base-cms/image": "^0.9.22",
     "@base-cms/inflector": "^0.9.0",
     "cheerio": "^1.0.0-rc.2",

--- a/packages/embedded-media/src/tags/image-asset.js
+++ b/packages/embedded-media/src/tags/image-asset.js
@@ -1,8 +1,5 @@
 const { createAltFor, createSrcFor } = require('@base-cms/image');
-const { htmlEntities, stripHtml } = require('@base-cms/html');
 const AbstractTag = require('./abstract-tag');
-
-const clean = v => htmlEntities.encode(stripHtml(v));
 
 class ImageAssetTag extends AbstractTag {
   async buildHtmlTagContents({ imageHost, basedb, lazyload }) {
@@ -31,7 +28,7 @@ class ImageAssetTag extends AbstractTag {
       class: lazyload ? 'lazyload' : null,
       src: lazyload ? 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==' : src,
       'data-src': lazyload ? src : null,
-      alt: clean(alt),
+      alt,
     };
     const stringifiedAttrs = Object.keys(attrs).reduce((arr, key) => {
       const value = attrs[key];

--- a/packages/embedded-media/src/tags/image-asset.js
+++ b/packages/embedded-media/src/tags/image-asset.js
@@ -1,4 +1,4 @@
-const { createAltFor, createSrcFor } = require('@base-cms/image');
+const { createAltFor, createSrcFor, createCaptionFor } = require('@base-cms/image');
 const AbstractTag = require('./abstract-tag');
 
 class ImageAssetTag extends AbstractTag {
@@ -36,9 +36,11 @@ class ImageAssetTag extends AbstractTag {
       return arr;
     }, []).join(' ');
 
-    const caption = image.caption ? `<span class="caption">${image.caption}</span>` : '';
-    const credit = image.credit ? `<span class="credit">${image.credit}</span>` : '';
-    return `<img ${stringifiedAttrs}>${caption}${credit}`;
+    const caption = createCaptionFor(image.caption);
+
+    const captionElement = caption ? `<span class="caption">${caption}</span>` : '';
+    const creditElement = image.credit ? `<span class="credit">${image.credit}</span>` : '';
+    return `<img ${stringifiedAttrs}>${captionElement}${creditElement}`;
   }
 }
 

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -7,6 +7,7 @@
   "repository": "https://github.com/base-cms/base-cms/tree/master/packages/image",
   "license": "MIT",
   "dependencies": {
+    "@base-cms/html": "^0.9.44",
     "@base-cms/inflector": "^0.9.0"
   },
   "publishConfig": {

--- a/packages/image/src/create-alt-for.js
+++ b/packages/image/src/create-alt-for.js
@@ -1,4 +1,5 @@
 const { titleize } = require('@base-cms/inflector');
+const { htmlEntities, stripHtml } = require('@base-cms/html');
 
 const altFrom = (value = '') => {
   if (!value) return '';
@@ -14,8 +15,10 @@ const altFrom = (value = '') => {
   return v;
 };
 
+const clean = v => htmlEntities.encode(stripHtml(v));
+
 module.exports = ({ caption, name, fileName } = {}) => {
-  if (caption) return caption;
-  if (name) return altFrom(name);
-  return altFrom(fileName);
+  if (caption) return clean(caption);
+  if (name) return clean(altFrom(name));
+  return clean(altFrom(fileName));
 };

--- a/packages/image/src/create-caption-for.js
+++ b/packages/image/src/create-caption-for.js
@@ -1,6 +1,5 @@
-module.exports = (image = {}) => {
-  const { caption } = image;
+module.exports = (caption) => {
   if (!caption) return '';
   // Replace new lines with <br> elements.
-  return caption.replace('\n', '<br>');
+  return `${caption}`.replace('\n', '<br>');
 };

--- a/packages/image/src/create-caption-for.js
+++ b/packages/image/src/create-caption-for.js
@@ -1,0 +1,6 @@
+module.exports = (image = {}) => {
+  const { caption } = image;
+  if (!caption) return '';
+  // Replace new lines with <br> elements.
+  return caption.replace('\n', '<br>');
+};

--- a/packages/image/src/index.js
+++ b/packages/image/src/index.js
@@ -1,9 +1,11 @@
 const buildImgixUrl = require('./build-imgix-url');
 const createAltFor = require('./create-alt-for');
+const createCaptionFor = require('./create-caption-for');
 const createSrcFor = require('./create-src-for');
 
 module.exports = {
   buildImgixUrl,
   createAltFor,
+  createCaptionFor,
   createSrcFor,
 };

--- a/services/graphql-server/src/graphql/resolvers/platform/asset.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/asset.js
@@ -1,4 +1,4 @@
-const { createAltFor, createSrcFor } = require('@base-cms/image');
+const { createAltFor, createSrcFor, createCaptionFor } = require('@base-cms/image');
 
 module.exports = {
   /**
@@ -7,5 +7,6 @@ module.exports = {
   AssetImage: {
     src: (image, _, { imageHost }) => createSrcFor(imageHost, image, undefined, { w: 320, auto: 'format' }),
     alt: image => createAltFor(image),
+    caption: image => createCaptionFor(image.caption),
   },
 };


### PR DESCRIPTION
Creates a consistent image caption util (used by both`graphql-server` and `embedded-media`) that replaces new lines with `<br>` elements.

In addition, the image `alt` attribution handling was moved from `embedded-media` to the `image` so that the GraphQL resolver would also receive the HTML cleaning.