### PR TITLE
Use `<span>` tag for embedded elements

### DIFF
--- a/packages/embedded-media/src/constants.js
+++ b/packages/embedded-media/src/constants.js
@@ -12,7 +12,7 @@ module.exports = {
   /**
    * The default HTML element to use for HTML tags.
    */
-  DEFAULT_HTML_ELEMENT: 'aside',
+  DEFAULT_HTML_ELEMENT: 'span',
 
   /**
    * The attribute name that siginfies the html element the tag should use.


### PR DESCRIPTION
Because embedded media objects can (and do) appear within `<p>` elements, generating them with `<div>` or `<aside>` elements cause browser rendering issues. As such, natively return the elements with inline `<span>` tags. Frontened applications can then set these to `inline: block` via CSS if so desired.