### PR TITLE
Deprecate leadsDelivery, update inquiry contacts

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/inquirable.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/inquirable.js
@@ -6,9 +6,11 @@ module.exports = gql`
 interface Inquirable {
   # fields from platform.model::Content mutations
   enableRmi: Boolean @projection(localField: "mutations.Website.enableRmi") @value(localField: "mutations.Website.enableRmi")
-  leadsDelivery: Boolean @projection(localField: "mutations.Website.leadsDelivery") @value(localField: "mutations.Website.leadsDelivery")
   # GraphQL-only fields
   inquiryContacts: [ContentContact!]! @projection(localField: "salesContacts", needs: ["company", "parentCompany", "venue", "parentVenue", "supplier", "parentSupplier"])
+
+  # @deprecated: This field was deprecated in Base3 and should no longer be used.
+  leadsDelivery: Boolean @projection(localField: "mutations.Website.leadsDelivery") @value(localField: "mutations.Website.leadsDelivery")
 }
 
 `;

--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/inquirable.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/inquirable.js
@@ -2,12 +2,11 @@ const gql = require('graphql-tag');
 
 module.exports = gql`
 
-# Renamed from 'Contacts' interface in Base Platform
 interface Inquirable {
-  # fields from platform.model::Content mutations
+  # fields from platform.interface::Contacts
   enableRmi: Boolean @projection(localField: "mutations.Website.enableRmi") @value(localField: "mutations.Website.enableRmi")
   # GraphQL-only fields
-  inquiryContacts: [ContentContact!]! @projection(localField: "salesContacts", needs: ["company", "parentCompany", "venue", "parentVenue", "supplier", "parentSupplier"])
+  inquiryContacts: [ContentContact!]! @projection(localField: "salesContacts", needs: ["mutations.Website.enableRmi", "company", "parentCompany", "venue", "parentVenue", "supplier", "parentSupplier"])
 
   # @deprecated: This field was deprecated in Base3 and should no longer be used.
   leadsDelivery: Boolean @projection(localField: "mutations.Website.leadsDelivery") @value(localField: "mutations.Website.leadsDelivery")

--- a/services/graphql-server/src/graphql/utils/inquiry-contacts.js
+++ b/services/graphql-server/src/graphql/utils/inquiry-contacts.js
@@ -1,15 +1,5 @@
 const { getAsObject } = require('@base-cms/object-path');
 
-const options = {
-  projection: {
-    company: 1,
-    salesContacts: 1,
-    parentCompany: 1,
-    parentSupplier: 1,
-    parentVenue: 1,
-  },
-};
-
 /**
  * Returns the first set of sales contacts in the heirarchy tree.
  * If no results are found, returns an empty array.
@@ -27,7 +17,14 @@ const contactsFor = async (content, basedb) => {
   }, null);
 
   if (relatedId) {
-    const item = await basedb.findOne('platform.Content', { _id: relatedId, 'mutations.Website.enableRmi': true }, options);
+    const projection = {
+      company: 1,
+      salesContacts: 1,
+      parentCompany: 1,
+      parentSupplier: 1,
+      parentVenue: 1,
+    };
+    const item = await basedb.findOne('platform.Content', { _id: relatedId, 'mutations.Website.enableRmi': true }, { projection });
     return contactsFor(item, basedb);
   }
 

--- a/services/graphql-server/src/graphql/utils/inquiry-contacts.js
+++ b/services/graphql-server/src/graphql/utils/inquiry-contacts.js
@@ -1,4 +1,4 @@
-const { getAsObject } = require('@base-cms/object-path');
+const { get } = require('@base-cms/object-path');
 
 /**
  * Returns the first set of sales contacts in the heirarchy tree.
@@ -7,7 +7,7 @@ const { getAsObject } = require('@base-cms/object-path');
 const contactsFor = async (content, basedb) => {
   if (!content) return [];
   const { salesContacts } = content;
-  const { enableRmi } = getAsObject(content, 'mutations.Website');
+  const enableRmi = get(content, 'mutations.Website.enableRmi');
   if (enableRmi && salesContacts && salesContacts.length) return salesContacts;
 
   const relatedId = ['company', 'parentCompany', 'parentSupplier', 'parentVenue'].reduce((id, key) => {

--- a/services/graphql-server/src/graphql/utils/inquiry-contacts.js
+++ b/services/graphql-server/src/graphql/utils/inquiry-contacts.js
@@ -1,5 +1,7 @@
+const { getAsObject } = require('@base-cms/object-path');
+
 const options = {
-  fields: {
+  projection: {
     company: 1,
     salesContacts: 1,
     parentCompany: 1,
@@ -14,8 +16,9 @@ const options = {
  */
 const contactsFor = async (content, basedb) => {
   if (!content) return [];
-  const { leadsDelivery, salesContacts } = content;
-  if (leadsDelivery && salesContacts && salesContacts.length) return salesContacts;
+  const { salesContacts } = content;
+  const { enableRmi } = getAsObject(content, 'mutations.Website');
+  if (enableRmi && salesContacts && salesContacts.length) return salesContacts;
 
   const relatedId = ['company', 'parentCompany', 'parentSupplier', 'parentVenue'].reduce((id, key) => {
     if (id) return id;
@@ -24,7 +27,7 @@ const contactsFor = async (content, basedb) => {
   }, null);
 
   if (relatedId) {
-    const item = await basedb.findOne('platform.Content', { _id: relatedId, leadsDelivery: true }, options);
+    const item = await basedb.findOne('platform.Content', { _id: relatedId, 'mutations.Website.enableRmi': true }, options);
     return contactsFor(item, basedb);
   }
 

--- a/services/graphql-server/src/graphql/utils/inquiry-contacts.js
+++ b/services/graphql-server/src/graphql/utils/inquiry-contacts.js
@@ -1,4 +1,4 @@
-const { get } = require('@base-cms/object-path');
+const { get, getAsArray } = require('@base-cms/object-path');
 
 /**
  * Returns the first set of sales contacts in the heirarchy tree.
@@ -6,9 +6,9 @@ const { get } = require('@base-cms/object-path');
  */
 const contactsFor = async (content, basedb) => {
   if (!content) return [];
-  const { salesContacts } = content;
   const enableRmi = get(content, 'mutations.Website.enableRmi');
-  if (enableRmi && salesContacts && salesContacts.length) return salesContacts;
+  const salesContacts = getAsArray(content, 'salesContacts');
+  if (enableRmi && salesContacts.length) return salesContacts;
 
   const relatedId = ['company', 'parentCompany', 'parentSupplier', 'parentVenue'].reduce((id, key) => {
     if (id) return id;


### PR DESCRIPTION
Utility now uses the enableRmi field, reads and queries mutations correctly.