### PR TITLE
Add related content indices; increase logging depth

### DIFF
--- a/packages/db/src/create-basedb.js
+++ b/packages/db/src/create-basedb.js
@@ -6,7 +6,7 @@ const { log } = console;
 
 const logger = (obj) => {
   log('');
-  Object.keys(obj).forEach(key => log(`${key}:`, inspect(obj[key], { colors: true, depth: 5 })));
+  Object.keys(obj).forEach(key => log(`${key}:`, inspect(obj[key], { colors: true, depth: 10 })));
   log('');
 };
 

--- a/services/graphql-server/src/graphql/utils/indexes.js
+++ b/services/graphql-server/src/graphql/utils/indexes.js
@@ -69,6 +69,9 @@ module.exports = {
         { 'sectionQuery.sectionId': 1, 'sectionQuery.optionId': 1 },
         { 'sectionQuery.sectionId': 1, 'sectionQuery.optionId': 1, primaryImage: 1 },
         { status: 1, type: 1, venue: 1 },
+        // Needed for related content queries
+        { 'relatedTo.$id': 1 },
+        { company: 1 },
       ],
       sort: [
         [{ name: 1, _id: 1 }, { collation: { locale: 'en_US' } }],


### PR DESCRIPTION
- add indices for related content queries, namely `relatedTo.$id` and `company`
- increase Base DB logging depth from 5 to 10 (when enabled)