### PR TITLE
Add "optioned content" query, aka "pinned content" with fallback

### DIFF
--- a/packages/marko-web/src/components/queries/components/loader-multi.marko
+++ b/packages/marko-web/src/components/queries/components/loader-multi.marko
@@ -2,8 +2,8 @@ $ const isDevelopment = process.env.NODE_ENV === 'development';
 $ const { onAsyncBlockError } = out.global;
 
 <await(input.loader(out.global.apollo, input))>
-  <@then|{ nodes, pageInfo }|>
-    <${input.renderBody} nodes=nodes page-info=pageInfo />
+  <@then|results|>
+    <${input.renderBody} ...results />
   </@then>
   <@catch|err|>
     $ if (typeof onAsyncBlockError === 'function') onAsyncBlockError(err);

--- a/packages/marko-web/src/components/queries/components/loader-single.marko
+++ b/packages/marko-web/src/components/queries/components/loader-single.marko
@@ -2,8 +2,8 @@ $ const isDevelopment = process.env.NODE_ENV === 'development';
 $ const { onAsyncBlockError } = out.global;
 
 <await(input.loader(out.global.apollo, input))>
-  <@then|{ node }|>
-    <${input.renderBody} node=node />
+  <@then|results|>
+    <${input.renderBody} ...results />
   </@then>
   <@catch|err|>
     $ if (typeof onAsyncBlockError === 'function') onAsyncBlockError(err);

--- a/packages/marko-web/src/components/queries/marko.json
+++ b/packages/marko-web/src/components/queries/marko.json
@@ -26,6 +26,9 @@
     },
     "cms-query-magazine-scheduled-content": {
       "template": "./magazine-scheduled-content.marko"
+    },
+    "cms-query-website-optioned-content": {
+      "template": "./website-optioned-content.marko"
     }
   }
 }

--- a/packages/marko-web/src/components/queries/website-optioned-content.marko
+++ b/packages/marko-web/src/components/queries/website-optioned-content.marko
@@ -1,0 +1,3 @@
+import { websiteOptionedContent as loader } from '@base-cms/web-common/block-loaders';
+
+<loader-multi loader=loader ...input />

--- a/packages/web-common/src/block-loaders/index.js
+++ b/packages/web-common/src/block-loaders/index.js
@@ -7,6 +7,7 @@ const magazineScheduledContent = require('./magazine-scheduled-content');
 const allPublishedContent = require('./all-published-content');
 const allAuthorContent = require('./all-author-content');
 const allCompanyContent = require('./all-company-content');
+const websiteOptionedContent = require('./website-optioned-content');
 
 module.exports = {
   relatedPublishedContent,
@@ -18,4 +19,5 @@ module.exports = {
   allPublishedContent,
   allAuthorContent,
   allCompanyContent,
+  websiteOptionedContent,
 };

--- a/packages/web-common/src/block-loaders/website-optioned-content.js
+++ b/packages/web-common/src/block-loaders/website-optioned-content.js
@@ -1,0 +1,48 @@
+const websiteScheduledContent = require('./website-scheduled-content');
+
+const { isArray } = Array;
+
+/**
+ * Performs a `websiteScheduledContent` with an `optionId`.
+ * If the optioned content is less than the requested limit, another query
+ * will be perfomed without the option to fill the remaining limit requirement.
+ *
+ * This is primarily used for creating "Pinned Content" blocks.
+ *
+ * @param {ApolloClient} apolloClient The Apollo GraphQL client that will perform the query.
+ * @param {object} params The params object that will be sent to `websiteScheduledContent`.
+ */
+module.exports = async (apolloClient, params) => {
+  // Must set a default limit.
+  const { optionId, limit = 20, optionDepleted } = params;
+  // If no option was provided (or the option query is depleted), perform a "regular" query.
+  if (!optionId || optionDepleted) return websiteScheduledContent(apolloClient, params);
+
+  // Retrieve content with option (do not allow section bubbling).
+  const optioned = await websiteScheduledContent(apolloClient, {
+    ...params,
+    sectionBubbling: false,
+  });
+  const { length } = optioned.nodes;
+
+  // If enough optioned content was found to fulfill then return it.
+  if (length >= limit) return { ...optioned, optionDepleted: false };
+
+  // Retrieve scheduled content, excluding the option and any found content.
+  const ids = optioned.nodes.map(node => node.id);
+  const excludeContentIds = isArray(params.excludeContentIds)
+    ? [...ids, ...params.excludeContentIds] : ids;
+  const scheduled = await websiteScheduledContent(apolloClient, {
+    ...params,
+    optionId: undefined,
+    excludeContentIds,
+  });
+
+  // If no optioned content was found then return the scheduled content.
+  if (!length) return { ...scheduled, optionDepleted: true };
+
+  // Merge the content up to the limit and return the scheduled page info.
+  const diff = limit - length;
+  const nodes = [...optioned.nodes, ...scheduled.nodes.slice(0, diff)];
+  return { nodes, pageInfo: scheduled.pageInfo, optionDepleted: true };
+};


### PR DESCRIPTION
Adds the `<cms-query-website-optioned-content>` component that queries for fallback content when the returned, optioned content does not fulfill the limit requirement.

Affords the ability to handle "pinned" or "featured" content blocks on websites.