### PR TITLE
Return contacts regardless of status/publicEmail

### DIFF
--- a/services/graphql-server/src/graphql/utils/inquiry-contacts.js
+++ b/services/graphql-server/src/graphql/utils/inquiry-contacts.js
@@ -33,5 +33,11 @@ const contactsFor = async (content, basedb) => {
 
 module.exports = async (content, _, { basedb }) => {
   const contactIds = await contactsFor(content, basedb);
-  return basedb.find('platform.Content', { _id: { $in: contactIds }, status: 1, email: { $exists: true } }, { fields: { name: 1, email: 1 } });
+  const emails = {
+    $or: [
+      { email: { $exists: true } },
+      { publicEmail: { $exists: true } },
+    ],
+  };
+  return basedb.find('platform.Content', { _id: { $in: contactIds }, ...emails }, { fields: { name: 1, email: 1, publicEmail: 1 } });
 };

--- a/services/graphql-server/src/graphql/utils/inquiry-contacts.js
+++ b/services/graphql-server/src/graphql/utils/inquiry-contacts.js
@@ -39,5 +39,5 @@ module.exports = async (content, _, { basedb }) => {
       { publicEmail: { $exists: true } },
     ],
   };
-  return basedb.find('platform.Content', { _id: { $in: contactIds }, ...emails }, { fields: { name: 1, email: 1, publicEmail: 1 } });
+  return basedb.find('platform.Content', { _id: { $in: contactIds }, ...emails }, { projection: { name: 1, email: 1, publicEmail: 1 } });
 };


### PR DESCRIPTION
Ensures that contacts returned for the `inquiryContacts` field disregard status, and include publicEmail.