### PR TITLE
Redirect handler support

### DIFF
--- a/packages/marko-web/src/express/error-handlers.js
+++ b/packages/marko-web/src/express/error-handlers.js
@@ -30,7 +30,7 @@ const render = (res, { statusCode, err, template }) => {
   return renderError(res, { statusCode, err, template });
 };
 
-module.exports = (app, { template }) => {
+module.exports = (app, { template, redirectHandler }) => {
   // Force Express to throw an error on 404s.
   app.use((req, res, next) => { // eslint-disable-line no-unused-vars
     throw createError(404, `No page found for '${req.path}'`);
@@ -41,7 +41,7 @@ module.exports = (app, { template }) => {
   app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
     const statusCode = err.status || err.statusCode || 500;
 
-    getRedirect(req).then((redirect) => {
+    getRedirect(req, redirectHandler).then((redirect) => {
       if (redirect) {
         const { code, to } = redirect;
         res.redirect(code, to);

--- a/packages/marko-web/src/express/get-redirect.js
+++ b/packages/marko-web/src/express/get-redirect.js
@@ -25,6 +25,6 @@ module.exports = async (req, handler) => {
   // Attempt to find a redirect using the handler.
   if (typeof handler !== 'function') return null;
   const result = await handler({ from, params });
-  if (!typeof result === 'object' || !result.to) return null;
+  if (!result || !result.to) return null;
   return { ...result, code: result.code || 301 };
 };

--- a/packages/marko-web/src/express/get-redirect.js
+++ b/packages/marko-web/src/express/get-redirect.js
@@ -9,10 +9,22 @@ const query = gql`
   }
 `;
 
-module.exports = async (req) => {
-  const { apollo, path: from, query: params } = req;
+/**
+ * @param {object} req The Express request object.
+ * @param {function} [handler] An optional redirect handler to execute if no redirect was found.
+ *                             Must return an object of `{ to, code }` or `null`
+ */
+module.exports = async (req, handler) => {
+  const { apollo, path, query: params } = req;
+  const from = path.replace(/\/$/, '');
   const variables = { input: { from, params } };
   const { data } = await apollo.query({ query, variables });
   const { websiteRedirect } = data;
-  return websiteRedirect;
+  const { to } = websiteRedirect || {};
+  if (to) return websiteRedirect;
+  // Attempt to find a redirect using the handler.
+  if (typeof handler !== 'function') return null;
+  const result = await handler({ from, params });
+  if (!typeof result === 'object' || !result.to) return null;
+  return { ...result, code: result.code || 301 };
 };

--- a/packages/marko-web/src/index.js
+++ b/packages/marko-web/src/index.js
@@ -27,6 +27,7 @@ const startServer = async ({
   cdnAssetHostname = env.CDN_ASSET_HOSTNAME || 'media.baseplatform.io',
   errorTemplate,
   onAsyncBlockError,
+  redirectHandler,
 
   // Terminus settings.
   timeout = 1000,
@@ -58,7 +59,7 @@ const startServer = async ({
   routes(app);
 
   // Apply error handlers.
-  errorHandlers(app, { template: errorTemplate });
+  errorHandlers(app, { template: errorTemplate, redirectHandler });
 
   const server = http.createServer(app);
 


### PR DESCRIPTION
- Allows a website to register a `redirectHandler` function that will be executed if no redirect for a URL is found.

- Cleans up redirect build script to include values found on `platform.Products` and ensures all paths are filtered/cleaned consistently.