### PR TITLE
oEmbed Error Handling

### DIFF
--- a/packages/embedded-media/src/tags/oembed.js
+++ b/packages/embedded-media/src/tags/oembed.js
@@ -1,16 +1,22 @@
 const oembed = require('oembed-parser');
 const AbstractTag = require('./abstract-tag');
 
+const { log } = console;
+
 class OEmbedTag extends AbstractTag {
   async buildHtmlTagContents() {
-    const maxwidth = this.getAttribute('maxwidth');
-    const maxheight = this.getAttribute('maxheight');
-    const data = await oembed.extract(this.identifier, { maxwidth, maxheight });
+    try {
+      const maxwidth = this.getAttribute('maxwidth');
+      const maxheight = this.getAttribute('maxheight');
+      const data = await oembed.extract(this.identifier, { maxwidth, maxheight });
 
-    if (data) {
-      this.setAttribute('data-oembed-type', data.type);
-      this.setAttribute('data-oembed-provider', data.provider_name);
-      return data.html;
+      if (data) {
+        this.setAttribute('data-oembed-type', data.type);
+        this.setAttribute('data-oembed-provider', data.provider_name);
+        return data.html;
+      }
+    } catch (e) {
+      log(e);
     }
     return '<!-- invalid oembed -->';
   }


### PR DESCRIPTION
If encountering an error, return the default invalid embed code response. @zarathustra323 is there a better place to put this? I wanted to do it within the body resolver rather than in the package itself, but it seems more efficient to do this here. Since we already had a fallback concept (the `<!-- invalid oembed -->` it would make sense to me to use this when encountering an error, but that may not always be the intent for consumers of the package. Thoughts?

When encountering a content item with a body similar to the following: 
```
<p><p>%{[ data-embed-type="oembed" data-embed-id="https://youtu.be/I8u2NdWuaYs" data-embed-element="aside" ]}%<br></p></p>
```
The GraphQL resolver throws a hard error due to the oembed library throwing inside a promise. This *is* a valid URL, but that's a separate issue from the entire query breaking.