### PR TITLE
Rework CMS GTM components

### DIFF
--- a/packages/marko-web/src/components/gtm/container-init.marko
+++ b/packages/marko-web/src/components/gtm/container-init.marko
@@ -10,15 +10,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 })(window,document,'script','${name}','${containerId}');
 `;
 
-$ const start = (name = 'dataLayer', context) => {
-  const contextCall = isObject(context) ? `${name}.push(${JSON.stringify(context)});` : '';
-  return `${contextCall}${name}.push({'gtm.start':new Date().getTime(),event:'gtm.js'});`;
-};
-
 $ const containerIds = (isArray(input.containerId) ? input.containerId : [input.containerId]).filter(v => v);
 $ const scripts = containerIds.map(containerId => createContainerScript(containerId, input.name));
 
 <if(scripts.length)>
   <script>${scripts.join().replace(/\n/g, '')}</script>
-  <script>${start(input.name, input.push)}</script>
 </if>

--- a/packages/marko-web/src/components/gtm/container-push.marko
+++ b/packages/marko-web/src/components/gtm/container-push.marko
@@ -1,0 +1,10 @@
+import { isObject } from '@base-cms/utils';
+
+$ const { isArray } = Array;
+
+$ const names = (isArray(input.name) ? input.name : [input.name]).filter(v => v);
+$ const scripts = names.map(name => isObject(input.data) ? `${name}.push(${JSON.stringify(input.data)});` : '');
+
+<if(scripts.length)>
+  <script>${scripts.join().replace(/\n/g, '')}</script>
+</if>

--- a/packages/marko-web/src/components/gtm/container-start.marko
+++ b/packages/marko-web/src/components/gtm/container-start.marko
@@ -1,0 +1,13 @@
+import { isObject } from '@base-cms/utils';
+
+$ const { isArray } = Array;
+
+$ const names = (isArray(input.name) ? input.name : [input.name]).filter(v => v);
+$ const payload = {
+  'gtm.start': new Date().getTime(),
+  event: 'gtm.js',
+};
+
+<for|name| of=names>
+  <cms-gtm-container-push name=name data=payload />
+</for>

--- a/packages/marko-web/src/components/gtm/container.marko
+++ b/packages/marko-web/src/components/gtm/container.marko
@@ -16,3 +16,7 @@ $ const scripts = containerIds.map(containerId => createContainerScript(containe
 <if(scripts.length)>
   <script>${scripts.join().replace(/\n/g, '')}</script>
 </if>
+
+<if(input.push)>
+  <cms-gtm-container-push name=input.name data=input.push />
+</if>

--- a/packages/marko-web/src/components/gtm/container.marko
+++ b/packages/marko-web/src/components/gtm/container.marko
@@ -20,3 +20,7 @@ $ const scripts = containerIds.map(containerId => createContainerScript(containe
 <if(input.push)>
   <cms-gtm-container-push name=input.name data=input.push />
 </if>
+
+<if(input.start)>
+  <cms-gtm-container-start name=input.name />
+</if>

--- a/packages/marko-web/src/components/gtm/marko.json
+++ b/packages/marko-web/src/components/gtm/marko.json
@@ -1,7 +1,7 @@
 {
   "tags": {
-    "cms-gtm-container-init": {
-      "template": "./container-init.marko",
+    "cms-gtm-container": {
+      "template": "./container.marko",
       "@container-id": {
         "type": "expression",
         "required": true
@@ -10,7 +10,8 @@
         "type": "string",
         "required": true,
         "default-value": "dataLayer"
-      }
+      },
+      "@push": "object"
     },
     "cms-gtm-container-push": {
       "template": "./container-push.marko",

--- a/packages/marko-web/src/components/gtm/marko.json
+++ b/packages/marko-web/src/components/gtm/marko.json
@@ -1,14 +1,33 @@
 {
   "tags": {
-    "cms-gtm-container": {
-      "template": "./container.marko",
+    "cms-gtm-container-init": {
+      "template": "./container-init.marko",
       "@container-id": {
         "type": "expression",
         "required": true
       },
-      "@push": "object",
       "@name": {
         "type": "string",
+        "required": true,
+        "default-value": "dataLayer"
+      }
+    },
+    "cms-gtm-container-push": {
+      "template": "./container-push.marko",
+      "@name": {
+        "type": "expression",
+        "required": true,
+        "default-value": "dataLayer"
+      },
+      "@data": {
+        "type": "object",
+        "required": true
+      }
+    },
+    "cms-gtm-container-start": {
+      "template": "./container-start.marko",
+      "@name": {
+        "type": "expression",
         "required": true,
         "default-value": "dataLayer"
       }

--- a/packages/marko-web/src/components/gtm/marko.json
+++ b/packages/marko-web/src/components/gtm/marko.json
@@ -6,12 +6,12 @@
         "type": "expression",
         "required": true
       },
+      "@push": "object",
       "@name": {
         "type": "string",
         "required": true,
         "default-value": "dataLayer"
-      },
-      "@push": "object"
+      }
     },
     "cms-gtm-container-push": {
       "template": "./container-push.marko",

--- a/packages/marko-web/src/components/gtm/marko.json
+++ b/packages/marko-web/src/components/gtm/marko.json
@@ -11,6 +11,11 @@
         "type": "string",
         "required": true,
         "default-value": "dataLayer"
+      },
+      "@start": {
+        "type": "boolean",
+        "default-value": true,
+        "deprecated": true
       }
     },
     "cms-gtm-container-push": {

--- a/services/marko-example-website/server/templates/content/components/layout.marko
+++ b/services/marko-example-website/server/templates/content/components/layout.marko
@@ -26,7 +26,9 @@ $ const context = {
 
 <document>
   <@head>
-    <cms-gtm-container container-id=site.get('gtm.containerId') push=context />
+    <cms-gtm-container-init container-id=site.get('gtm.containerId') />
+    <cms-gtm-container-push data=context />
+    <cms-gtm-container-start />
     <cms-page-metadata for="content" ...content />
     <${input.head} />
   </@head>

--- a/services/marko-example-website/server/templates/content/components/layout.marko
+++ b/services/marko-example-website/server/templates/content/components/layout.marko
@@ -26,12 +26,11 @@ $ const context = {
 
 <document>
   <@head>
-    <cms-gtm-container-init container-id=site.get('gtm.containerId') />
-    <cms-gtm-container-push data=context />
-    <cms-gtm-container-start />
+    <cms-gtm-container container-id=site.get('gtm.containerId') push=context />
     <cms-page-metadata for="content" ...content />
     <${input.head} />
   </@head>
+  <cms-gtm-container-start />
 
   <div class="container-fluid-max">
     <${input.renderBody} />

--- a/services/marko-example-website/server/templates/dynamic-page/components/layout.marko
+++ b/services/marko-example-website/server/templates/dynamic-page/components/layout.marko
@@ -9,12 +9,11 @@ $ const context = {
 
 <document>
   <@head>
-    <cms-gtm-container-init container-id=site.get('gtm.containerId') />
-    <cms-gtm-container-push data=context />
-    <cms-gtm-container-start />
+    <cms-gtm-container container-id=site.get('gtm.containerId') push=context />
     <cms-page-metadata for="dynamic-page" ...page />
     <${input.head} />
   </@head>
+  <cms-gtm-container-start />
   <cms-page-container for="dynamic-page" class="container-fluid-max" data=page>
     <${input.renderBody} />
   </cms-page-container>

--- a/services/marko-example-website/server/templates/dynamic-page/components/layout.marko
+++ b/services/marko-example-website/server/templates/dynamic-page/components/layout.marko
@@ -9,7 +9,9 @@ $ const context = {
 
 <document>
   <@head>
-    <cms-gtm-container container-id=site.get('gtm.containerId') push=context />
+    <cms-gtm-container-init container-id=site.get('gtm.containerId') />
+    <cms-gtm-container-push data=context />
+    <cms-gtm-container-start />
     <cms-page-metadata for="dynamic-page" ...page />
     <${input.head} />
   </@head>

--- a/services/marko-example-website/server/templates/error.marko
+++ b/services/marko-example-website/server/templates/error.marko
@@ -4,7 +4,8 @@ $ const { site } = out.global;
 
 <document>
   <@head>
-    <cms-gtm-container container-id=site.get('gtm.containerId') />
+    <cms-gtm-container-init container-id=site.get('gtm.containerId') />
+    <cms-gtm-container-start />
   </@head>
   <cms-page-container class="container-fluid-max">
     <div class="row">

--- a/services/marko-example-website/server/templates/error.marko
+++ b/services/marko-example-website/server/templates/error.marko
@@ -4,9 +4,9 @@ $ const { site } = out.global;
 
 <document>
   <@head>
-    <cms-gtm-container-init container-id=site.get('gtm.containerId') />
-    <cms-gtm-container-start />
+    <cms-gtm-container container-id=site.get('gtm.containerId') />
   </@head>
+  <cms-gtm-container-start />
   <cms-page-container class="container-fluid-max">
     <div class="row">
       <div class="col">

--- a/services/marko-example-website/server/templates/index.marko
+++ b/services/marko-example-website/server/templates/index.marko
@@ -15,14 +15,9 @@ $ const context = {
 
 <document>
   <@head>
-    <cms-gtm-container-init container-id=site.get('gtm.containerId') />
-    <cms-gtm-container-push data=context />
-    <cms-gtm-container-push data={
-      event: 'test',
-      includedBefore: 'gtm.start',
-    } />
-    <cms-gtm-container-start />
+    <cms-gtm-container container-id=site.get('gtm.containerId') push=context />
   </@head>
+  <cms-gtm-container-start />
   <cms-page-container for="home" class="container-fluid">
     <h1>Homepage</h1>
     $ const block = 'content-list';

--- a/services/marko-example-website/server/templates/index.marko
+++ b/services/marko-example-website/server/templates/index.marko
@@ -15,7 +15,13 @@ $ const context = {
 
 <document>
   <@head>
-    <cms-gtm-container container-id=site.get('gtm.containerId') push=context />
+    <cms-gtm-container-init container-id=site.get('gtm.containerId') />
+    <cms-gtm-container-push data=context />
+    <cms-gtm-container-push data={
+      event: 'test',
+      includedBefore: 'gtm.start',
+    } />
+    <cms-gtm-container-start />
   </@head>
   <cms-page-container for="home" class="container-fluid">
     <h1>Homepage</h1>

--- a/services/marko-example-website/server/templates/website-section/components/layout.marko
+++ b/services/marko-example-website/server/templates/website-section/components/layout.marko
@@ -15,12 +15,11 @@ $ const context = {
 
 <document>
   <@head>
-    <cms-gtm-container-init container-id=site.get('gtm.containerId') />
-    <cms-gtm-container-push data=context />
-    <cms-gtm-container-start />
+    <cms-gtm-container container-id=site.get('gtm.containerId') push=context />
     <cms-page-metadata for="website-section" ...section />
     <${input.head} />
   </@head>
+  <cms-gtm-container-start />
   <cms-page-container for="website-section" class="container-fluid-max" data=section>
     <${input.renderBody} />
   </cms-page-container>

--- a/services/marko-example-website/server/templates/website-section/components/layout.marko
+++ b/services/marko-example-website/server/templates/website-section/components/layout.marko
@@ -15,7 +15,9 @@ $ const context = {
 
 <document>
   <@head>
-    <cms-gtm-container container-id=site.get('gtm.containerId') push=context />
+    <cms-gtm-container-init container-id=site.get('gtm.containerId') />
+    <cms-gtm-container-push data=context />
+    <cms-gtm-container-start />
     <cms-page-metadata for="website-section" ...section />
     <${input.head} />
   </@head>


### PR DESCRIPTION
Restructures the `cms-gtm-container` component into three distinct components:
- `cms-gtm-container`: Performs the dataLayer (or whatever) initialization
  - `container-id` (String|[String]), `push` (Object), and `name` (String = 'dataLayer')
- `cms-gtm-container-push`: Pushes a data object into the dataLayer
  - Accepts `name` (String|[String] = 'dataLayer')
  - Accepts `data` (Object!)
- `cms-gtm-container-start`: Utilizes the `container-push` component to start GTM.
  - Accepts `name` (String|[String] = 'dataLayer')

With these changes, implementing sites will need to update templates to call the GTM start tag, and can optionally push additional data into the dataLayer with the `push` component.
```diff
    <cms-gtm-container container-id=site.get('gtm.containerId') push=context />
+    <cms-gtm-container-push data={ some: 'extra-data' } />
+    <cms-gtm-container-start />
```

<img width="1150" alt="Screen Shot 2019-08-01 at 10 23 20 AM" src="https://user-images.githubusercontent.com/1778222/62306614-c9090500-b447-11e9-8f47-94969b822f26.png">


This is an intentional breaking change and should require a minor version bump.