### PR TITLE
Remove oembed-parser dependency

### DIFF
--- a/packages/embedded-media/package.json
+++ b/packages/embedded-media/package.json
@@ -14,7 +14,6 @@
     "@base-cms/image": "^0.10.0",
     "@base-cms/inflector": "^0.10.0",
     "cheerio": "^1.0.0-rc.2",
-    "escape-string-regexp": "^1.0.5",
-    "oembed-parser": "^1.2.2"
+    "escape-string-regexp": "^1.0.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13691,14 +13691,6 @@ object.values@^1.1.0:
     function-bind "^1.1.1"
     has "^1.0.3"
 
-oembed-parser@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/oembed-parser/-/oembed-parser-1.2.2.tgz#0ababb60eb6bef0538878b690eb71ecb7fdfb4d1"
-  integrity sha512-dFsRPQZTUvIG5EA0Gq9kWCfxxdt+hBk0D9xvYkrGq1lh0NyzJTMWkrJWFXGu7P/9MiP7t2VHvlRFsC4I3SuGPw==
-  dependencies:
-    node-fetch "^2.3.0"
-    promise-wtf "^1.2.4"
-
 on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
@@ -15136,11 +15128,6 @@ promise-retry@^1.1.1:
   dependencies:
     err-code "^1.0.0"
     retry "^0.10.0"
-
-promise-wtf@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/promise-wtf/-/promise-wtf-1.2.4.tgz#8cbdd31ea10dee074fbb6387cbc96e413993376c"
-  integrity sha512-wOZ+ZUG0/Lsk+muOElLtteIteyvF5B1bNcVLhmlv6PDKcAAQGa5Bf0maN3rj73FWyjJE840MzeQyNE6KOKpgrg==
 
 promise.prototype.finally@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
It’s no longer used by the embedded media package.