### PR TITLE
Add websiteExpiringContent query and content.websiteSchedules

### DIFF
--- a/services/graphql-server/build-section-query.js
+++ b/services/graphql-server/build-section-query.js
@@ -100,6 +100,7 @@ const run = async () => {
     contentColl.createIndex({ 'sectionQuery.sectionId': 1, 'sectionQuery.optionId': 1 }),
     contentColl.createIndex({ 'sectionQuery.sectionId': 1, 'sectionQuery.optionId': 1, primaryImage: 1 }),
     contentColl.createIndex({ 'sectionQuery.start': -1, _id: -1 }),
+    contentColl.createIndex({ 'sectionQuery.end': -1, _id: -1 }),
   ]);
   log('Indexing complete.');
 

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -14,6 +14,7 @@ extend type Query {
   magazineScheduledContent(input: MagazineScheduledContentQueryInput = {}): ContentConnection!
   websiteScheduledContent(input: WebsiteScheduledContentQueryInput = {}): ContentConnection!
   relatedPublishedContent(input: RelatedPublishedContentQueryInput = {}): ContentConnection!
+  websiteExpiringContent(input: WebsiteExpiringContentQueryInput = {}): ContentConnection!
 }
 
 enum GateableUserRole {
@@ -211,6 +212,18 @@ input MagazineScheduledContentQueryInput {
   excludeContentTypes: [ContentType!] = []
   includeContentTypes: [ContentType!] = []
   requiresImage: Boolean = false
+  pagination: PaginationInput = {}
+}
+
+input WebsiteExpiringContentQueryInput {
+  before: Date
+  after: Date
+  sectionId: Int
+  optionId: Int
+  excludeContentIds: [Int!] = []
+  excludeSectionIds: [Int!] = []
+  excludeContentTypes: [ContentType!] = []
+  includeContentTypes: [ContentType!] = []
   pagination: PaginationInput = {}
 }
 

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -147,6 +147,15 @@ type ContentStubLocation {
   longitude: Float
 }
 
+type ContentWebsiteSchedule {
+  section: WebsiteSection @refOne(loader: "websiteSection", localField: "sectionId")
+  option: WebsiteOption @refOne(loader: "websiteOption", localField: "optionId")
+  start: Date
+  startDate(input: FormatDate = {}): String @momentFormat(localField: "start")
+  end: Date
+  endDate(input: FormatDate = {}): String @momentFormat(localField: "end")
+}
+
 input ContentQueryInput {
   status: ModelStatus = active
   id: Int!

--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
@@ -66,6 +66,8 @@ interface Content @requiresProject(fields: ["type"]) {
   # Returns related, published content based on input flags
   relatedContent(input: ContentRelatedContentInput = {}): ContentConnection! @projection(localField: "_id", needs: ["relatedTo", "mutations.Website.primarySection"])
   userRegistration: ContentUserRegistration! @projection(localField: "mutations.Website.requiresAccessLevels", needs: ["mutations.Website.requiresRegistration"])
+  # Returns the website section query schedules
+  websiteSchedules: [ContentWebsiteSchedule]! @projection(localField: "sectionQuery") @arrayValue(localField: "sectionQuery")
 }
 
 `;

--- a/services/graphql-server/src/graphql/types/date.js
+++ b/services/graphql-server/src/graphql/types/date.js
@@ -14,7 +14,7 @@ module.exports = new GraphQLScalarType({
   },
   parseLiteral(ast) {
     if (ast.kind === Kind.INT) {
-      return parseInt(ast.value, 10);
+      return new Date(parseInt(ast.value, 10));
     }
     return null;
   },

--- a/services/graphql-server/src/graphql/utils/indexes.js
+++ b/services/graphql-server/src/graphql/utils/indexes.js
@@ -82,6 +82,7 @@ module.exports = {
         [{ endDate: 1, _id: 1 }, { sparse: true }],
         // Section query sort
         { 'sectionQuery.start': -1, _id: -1 },
+        { 'sectionQuery.end': -1, _id: -1 },
       ],
     },
     Product: {


### PR DESCRIPTION
Adds ability to return website scheduled content that has expired (or will expire) between a date range (or before/after a certain date). In addition, website schedules (via the `sectionQuery` db field) are also available on all `Content` types.

Either the `sectionId` input or the `optionId` input is required - but both can be used together.
Also, a `before` or `after` input is required - and both can be used together.
See the `WebsiteExpiringContentQueryInput` definition for a complete list of available inputs.

Example query (using Bizbash):
Return all content that expired between April 1st and April 30th of 2019 that was scheduled with the "Premium" option (id `40114`)

```graphql
query {
  websiteExpiringContent(input: {
    optionId: 40114,
    after: 1554094800000,
    before: 1556686799999
  }) {
    totalCount
    pageInfo {
      hasNextPage
      endCursor
    }
    edges {
      node {
        id
        name
        type
        websiteSchedules {
          startDate
          endDate
          section {
            id
            name
          }
          option {
            id
            name
          }
        }
      }
    }
  }
}
```

Results:
```json
{
  "data": {
    "websiteExpiringContent": {
      "totalCount": 26,
      "pageInfo": {
        "hasNextPage": true,
        "endCursor": "MTMzOTcyMDA"
      },
      "edges": [
        {
          "node": {
            "id": 13461285,
            "name": "Crow's Theatre",
            "type": "venue",
            "websiteSchedules": [
              {
                "startDate": "2016-11-03T00:00:00-05:00",
                "endDate": "2019-04-30T00:00:00-05:00",
                "section": {
                  "id": 59828,
                  "name": "Venue Directory"
                },
                "option": {
                  "id": 40114,
                  "name": "Premium"
                }
              }
            ]
          }
        },
        {
          "node": {
            "id": 13438745,
            "name": "Candela La Brea",
            "type": "venue",
            "websiteSchedules": [
              {
                "startDate": "2018-05-01T00:00:00-05:00",
                "endDate": "2019-04-30T00:00:00-05:00",
                "section": {
                  "id": 59828,
                  "name": "Venue Directory"
                },
                "option": {
                  "id": 40114,
                  "name": "Premium"
                }
              }
            ]
          }
        },
        {
          "node": {
            "id": 13424665,
            "name": "Suite Treatments Inc.",
            "type": "supplier",
            "websiteSchedules": [
              {
                "startDate": "2018-05-01T00:00:00-05:00",
                "endDate": "2019-04-30T00:00:00-05:00",
                "section": {
                  "id": 59829,
                  "name": "Supplier Directory"
                },
                "option": {
                  "id": 40114,
                  "name": "Premium"
                }
              }
            ]
          }
        },
        {
          "node": {
            "id": 13421381,
            "name": "Keep Memory Alive Event Center",
            "type": "venue",
            "websiteSchedules": [
              {
                "startDate": "2014-02-06T00:00:00-06:00",
                "endDate": "2019-04-30T00:00:00-05:00",
                "section": {
                  "id": 59828,
                  "name": "Venue Directory"
                },
                "option": {
                  "id": 40114,
                  "name": "Premium"
                }
              }
            ]
          }
        },
        {
          "node": {
            "id": 13387545,
            "name": "Rainbow Room",
            "type": "venue",
            "websiteSchedules": [
              {
                "startDate": "2006-10-11T00:00:00-05:00",
                "endDate": "2019-04-30T00:00:00-05:00",
                "section": {
                  "id": 59828,
                  "name": "Venue Directory"
                },
                "option": {
                  "id": 40114,
                  "name": "Premium"
                }
              }
            ]
          }
        },
        {
          "node": {
            "id": 13386232,
            "name": "Dazian",
            "type": "supplier",
            "websiteSchedules": [
              {
                "startDate": "2011-03-17T00:00:00-05:00",
                "endDate": "2019-04-30T00:00:00-05:00",
                "section": {
                  "id": 59829,
                  "name": "Supplier Directory"
                },
                "option": {
                  "id": 40114,
                  "name": "Premium"
                }
              }
            ]
          }
        },
        {
          "node": {
            "id": 13419291,
            "name": "Scenic Elementz",
            "type": "supplier",
            "websiteSchedules": [
              {
                "startDate": "2011-01-04T18:57:14-06:00",
                "endDate": "2019-04-29T00:00:00-05:00",
                "section": {
                  "id": 59829,
                  "name": "Supplier Directory"
                },
                "option": {
                  "id": 40114,
                  "name": "Premium"
                }
              }
            ]
          }
        },
        {
          "node": {
            "id": 13394552,
            "name": "Design Exchange",
            "type": "venue",
            "websiteSchedules": [
              {
                "startDate": "2013-04-03T00:00:00-05:00",
                "endDate": "2019-04-25T00:00:00-05:00",
                "section": {
                  "id": 59828,
                  "name": "Venue Directory"
                },
                "option": {
                  "id": 40114,
                  "name": "Premium"
                }
              }
            ]
          }
        },
        {
          "node": {
            "id": 13401233,
            "name": "The Vintage DJ",
            "type": "supplier",
            "websiteSchedules": [
              {
                "startDate": "2018-04-25T00:00:00-05:00",
                "endDate": "2019-04-24T00:00:00-05:00",
                "section": {
                  "id": 59829,
                  "name": "Supplier Directory"
                },
                "option": {
                  "id": 40114,
                  "name": "Premium"
                }
              }
            ]
          }
        },
        {
          "node": {
            "id": 13397200,
            "name": "The Westin Harbour Castle",
            "type": "venue",
            "websiteSchedules": [
              {
                "startDate": "2018-04-25T00:00:00-05:00",
                "endDate": "2019-04-24T00:00:00-05:00",
                "section": {
                  "id": 59828,
                  "name": "Venue Directory"
                },
                "option": {
                  "id": 40114,
                  "name": "Premium"
                }
              }
            ]
          }
        }
      ]
    }
  }
}
```