### PR TITLE
Set fileSrc to null when path or name are empty

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/media.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/media.js
@@ -11,7 +11,7 @@ interface Media {
   contacts(input: MediaContactsInput = {}): ContentContactConnection! @projection @refMany(model: "platform.Content", criteria: "contentContact")
 
   # GraphQL specific fields
-  fileSrc: String! @projection(localField: "fileName", needs: ["filePath"])
+  fileSrc: String @projection(localField: "fileName", needs: ["filePath"])
 }
 
 input MediaContactsInput {

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -53,7 +53,10 @@ module.exports = {
    */
   Media: {
     __resolveType: resolveType,
-    fileSrc: ({ fileName, filePath }, _, { assetHost }) => `https://${assetHost}/${cleanPath(filePath)}/${fileName}`,
+    fileSrc: ({ fileName, filePath }, _, { assetHost }) => {
+      if (!fileName || !filePath) return null;
+      return `https://${assetHost}/${cleanPath(filePath)}/${fileName}`;
+    },
   },
 
   /**


### PR DESCRIPTION
Previously this would return values like `https://cdn.laserfocusworld.com//undefined` or `https://media.baseplatform.io//undefined` (based on the `x-cdn-asset-hostname` header value) when the `fileName` and `filePath` were empty.

Now if either of those fields are missing, the `fileSrc` will be treated as non-existant and return `null`.