### PR TITLE
Only replace sourcemap values when creating manifest revisions

### DIFF
--- a/packages/web-cli/package.json
+++ b/packages/web-cli/package.json
@@ -42,7 +42,7 @@
     "gulp-eslint": "^5.0.0",
     "gulp-livereload": "^4.0.1",
     "gulp-postcss": "^8.0.0",
-    "gulp-rev-all": "^1.0.0",
+    "gulp-rev-all": "^2.0.2",
     "gulp-rev-delete-original": "^0.2.3",
     "gulp-sass": "^4.0.2",
     "gulp-sourcemaps": "^2.6.5",

--- a/packages/web-cli/src/gulp/js.js
+++ b/packages/web-cli/src/gulp/js.js
@@ -64,6 +64,7 @@ module.exports = cwd => (cb) => {
         libraryExport: 'default',
         libraryTarget: 'umd',
         filename: 'index.js',
+        publicPath: '/dist/js/',
       },
       module: {
         rules: [

--- a/packages/web-cli/src/gulp/manifest.js
+++ b/packages/web-cli/src/gulp/manifest.js
@@ -2,7 +2,7 @@ const pump = require('pump');
 const revall = require('gulp-rev-all');
 const del = require('gulp-rev-delete-original');
 const { dest, src } = require('gulp');
-const path = require('path');
+const { basename, extname } = require('path');
 const completeTask = require('../utils/task-callback');
 
 module.exports = cwd => (cb) => {
@@ -11,13 +11,21 @@ module.exports = cwd => (cb) => {
     revall.revision({
       includeFilesInManifest: ['.css', '.js'],
       transformFilename: (file, hash) => {
-        const basename = path.basename(file.path);
-        const mapname = path.basename(file.path, '.map');
-        const prefix = basename === mapname
-          ? path.basename(mapname, path.extname(file.path))
-          : path.basename(mapname, path.extname(mapname));
-        const suffix = basename.replace(prefix, '');
+        const base = basename(file.path);
+        const mapname = basename(file.path, '.map');
+        const prefix = base === mapname
+          ? basename(mapname, extname(file.path))
+          : basename(mapname, extname(mapname));
+        const suffix = base.replace(prefix, '');
         return `${prefix}.${hash.substr(0, 8)}${suffix}`;
+      },
+      annotator: (contents, path) => ([{ contents, path }]), // provide file path.
+      replacer: (fragment, replaceRegExp, newReference) => {
+        // Prevent replacing generic "index" values.
+        if (`${replaceRegExp}` !== '/(\'|")(index)()(\'|"|$)/g') {
+          // eslint-disable-next-line no-param-reassign
+          fragment.contents = fragment.contents.replace(replaceRegExp, `$1${newReference}$3$4`);
+        }
       },
     }),
     del(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3191,28 +3191,10 @@ btoa-lite@^1.0.0:
   resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
   integrity sha1-M3dm2hWAEhD92VbCLpxokaudAzc=
 
-buffer-alloc-unsafe@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
-  integrity sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==
-
-buffer-alloc@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
-  integrity sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==
-  dependencies:
-    buffer-alloc-unsafe "^1.1.0"
-    buffer-fill "^1.0.0"
-
 buffer-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-1.0.0.tgz#59616b498304d556abd466966b22eeda3eca5fbe"
   integrity sha1-WWFrSYME1Var1GaWayLu2j7KX74=
-
-buffer-fill@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
-  integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -6453,17 +6435,17 @@ gulp-postcss@^8.0.0:
     postcss-load-config "^2.0.0"
     vinyl-sourcemaps-apply "^0.2.1"
 
-gulp-rev-all@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gulp-rev-all/-/gulp-rev-all-1.0.0.tgz#365105b1ee7c3d1bf543bdafb4bf04e07d793045"
-  integrity sha512-/6SxY7jg87HRQKz9pJyA72BLxxpGSZh35T1Cxwdqys8s1hAh6V5vciAfAIDo/BkkIWnw6NvaCbxW2WsKeiQyDg==
+gulp-rev-all@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/gulp-rev-all/-/gulp-rev-all-2.0.2.tgz#af2c4f4027840481dfb671cf69eed4ffb241f7e5"
+  integrity sha512-dDnCgluu7n8nntNwym88qa+6XdY8GfhoxOkLfJMiAkFPBLPTfMJZdloCC2ChOCnAneHvGVvc52nk4qtGaQqBOQ==
   dependencies:
     chalk "^2.4.1"
     fancy-log "^1.3.2"
-    isbinaryfile "^3.0.2"
+    isbinaryfile "^4.0.0"
     merge "^1.2.0"
     plugin-error "^1.0.1"
-    through2 "^2.0.3"
+    through2 "^3.0.1"
     vinyl "^2.1.0"
 
 gulp-rev-delete-original@^0.2.3:
@@ -7565,12 +7547,10 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
-isbinaryfile@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-3.0.3.tgz#5d6def3edebf6e8ca8cae9c30183a804b5f8be80"
-  integrity sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==
-  dependencies:
-    buffer-alloc "^1.2.0"
+isbinaryfile@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.2.tgz#bfc45642da645681c610cca831022e30af426488"
+  integrity sha512-C3FSxJdNrEr2F4z6uFtNzECDM5hXk+46fxaa+cwBe5/XrWSmzdG8DDgyjfX6/NRdBB21q2JXuRAzPCUs+fclnQ==
 
 isexe@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Prevents `gulp-rev-all` from arbitrarily replacing instances of `'index'` or `"index"` within the bundled JS files. It will now only replace the `sourcemap` values.

Since the core, index.js bundle is never referenced/imported/required by any external JS files, this should be a safe change.

This specifically fixes issues when using Algolia search plugins, which use an `index` property throughout the code. These properties where being changed from `index` to `index.[hash]`, causing the code to fail.