### PR TITLE
Add option name input to website scheduled content

### DIFF
--- a/packages/web-common/src/block-loaders/website-optioned-content.js
+++ b/packages/web-common/src/block-loaders/website-optioned-content.js
@@ -13,10 +13,16 @@ const { isArray } = Array;
  * @param {object} params The params object that will be sent to `websiteScheduledContent`.
  */
 module.exports = async (apolloClient, params) => {
-  // Must set a default limit.
-  const { optionId, limit = 20, optionDepleted } = params;
-  // If no option was provided (or the option query is depleted), perform a "regular" query.
-  if (!optionId || optionDepleted) return websiteScheduledContent(apolloClient, params);
+  const {
+    optionId,
+    optionName,
+    limit = 20, // Must set a default limit.
+    optionDepleted,
+  } = params;
+  // If no option id/name was provided (or the option query is depleted), perform a "regular" query.
+  if ((!optionId && !optionName) || optionDepleted) {
+    return websiteScheduledContent(apolloClient, params);
+  }
 
   // Retrieve content with option (do not allow section bubbling).
   const optioned = await websiteScheduledContent(apolloClient, {
@@ -35,6 +41,7 @@ module.exports = async (apolloClient, params) => {
   const scheduled = await websiteScheduledContent(apolloClient, {
     ...params,
     optionId: undefined,
+    optionName: undefined,
     excludeContentIds,
   });
 

--- a/packages/web-common/src/block-loaders/website-scheduled-content.js
+++ b/packages/web-common/src/block-loaders/website-scheduled-content.js
@@ -9,6 +9,7 @@ const buildQuery = require('../gql/query-factories/block-website-scheduled-conte
  * @param {number} [params.limit] The number of results to return.
  * @param {string} [params.after] The cursor to start returning results from.
  * @param {number} [params.optionId] The option ID.
+ * @param {string} [params.optionName] The option name.
  * @param {number[]} [params.excludeContentIds] An array of content IDs to exclude.
  * @param {string[]} [params.excludeContentTypes] An array of content types to exclude.
  * @param {string[]} [params.includeContentTypes] An array of content types to include.
@@ -25,6 +26,7 @@ module.exports = async (apolloClient, {
   sectionId,
   sectionAlias,
   optionId,
+  optionName,
 
   excludeContentIds,
   excludeContentTypes,
@@ -47,6 +49,7 @@ module.exports = async (apolloClient, {
     sectionBubbling,
     sectionId,
     optionId,
+    optionName,
   };
   const query = buildQuery({ queryFragment, queryName });
   const variables = { input };

--- a/services/example-laserfocusworld/server/templates/website-section/index.marko
+++ b/services/example-laserfocusworld/server/templates/website-section/index.marko
@@ -31,7 +31,7 @@ $ const { id, alias, name, pageNode } = data;
 
     <marko-web-query|{ nodes }|
       name="website-optioned-content"
-      params={ sectionId: id, optionId: 9, limit: 5, queryFragment }
+      params={ sectionId: id, optionName: "Pinned", limit: 5, queryFragment }
     >
       <website-content-hero-flow nodes=nodes>
         <@native-x index=3 name="list1" aliases=[alias] />

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -304,6 +304,7 @@ input WebsiteScheduledContentQueryInput {
   sectionId: Int
   sectionAlias: String
   optionId: Int
+  optionName: String
   excludeContentIds: [Int!] = []
   excludeSectionIds: [Int!] = []
   excludeContentTypes: [ContentType!] = []

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -711,6 +711,7 @@ module.exports = {
         sectionId,
         sectionAlias,
         optionId,
+        optionName,
         excludeContentIds,
         excludeSectionIds,
         includeContentTypes,
@@ -721,7 +722,8 @@ module.exports = {
       } = input;
 
       if (!sectionId && !sectionAlias) throw new UserInputError('Either a sectionId or sectionAlias input must be provided.');
-      if (sectionId && sectionAlias) throw new UserInputError('You cannot provided both a sectionId and sectionAlias as input.');
+      if (sectionId && sectionAlias) throw new UserInputError('You cannot provide both sectionId and sectionAlias as input.');
+      if (optionId && optionName) throw new UserInputError('You cannot provide both optionId and optionName as input.');
 
       const siteId = site._id;
       const [section, option] = await Promise.all([
@@ -735,7 +737,7 @@ module.exports = {
           basedb,
           siteId,
           id: optionId,
-          name: 'Standard',
+          name: optionName || 'Standard',
         }),
       ]);
 


### PR DESCRIPTION
Can now pass either `optionId` _or_ `optionName` (but not both) to website scheduled content queries.