### PR TITLE
Add all-published-content RSS query

### DIFF
--- a/packages/tenant-context/index.js
+++ b/packages/tenant-context/index.js
@@ -1,7 +1,7 @@
 const getFromRequest = (req) => {
-  const tenant = req.get('x-tenant-key');
-  const siteId = req.get('x-site-id');
-  if (!tenant) throw new Error('A required header `x-tenant-key` was not sent!');
+  const tenant = req.get('x-tenant-key') || req.query['tenant-key'];
+  const siteId = req.get('x-site-id') || req.query['site-id'];
+  if (!tenant) throw new Error('A required `tenant-key` was not sent. Provide as a header or a query param.');
   return {
     tenant,
     siteId: siteId || undefined,

--- a/services/rss/src/app.js
+++ b/services/rss/src/app.js
@@ -8,6 +8,10 @@ const app = express();
 app.use(helmet());
 app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal']);
 
+app.get('/favicon.ico', (req, res) => {
+  res.status(404).end();
+});
+
 app.use(apollo());
 app.use(websiteContext());
 app.use((req, res, next) => {

--- a/services/rss/src/routes/all-published-content.js
+++ b/services/rss/src/routes/all-published-content.js
@@ -1,0 +1,12 @@
+const { asyncRoute } = require('@base-cms/utils');
+const gql = require('graphql-tag');
+const createChannel = require('../utils/create-channel');
+const createItem = require('../utils/create-item');
+const contentFragment = require('../api/content-fragment');
+
+module.exports = asyncRoute(async (req, res) => {
+  const parts = [
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
+  ];
+  res.end(parts.join(''));
+});

--- a/services/rss/src/routes/all-published-content.js
+++ b/services/rss/src/routes/all-published-content.js
@@ -4,9 +4,42 @@ const createChannel = require('../utils/create-channel');
 const createItem = require('../utils/create-item');
 const contentFragment = require('../api/content-fragment');
 
+const query = gql`
+  query RSSAllPublishedContent($input: AllPublishedContentQueryInput = {}) {
+    allPublishedContent(input: $input) {
+      edges {
+        node {
+          ...RSSItemContentFragment
+        }
+      }
+    }
+  }
+  ${contentFragment}
+`;
+
 module.exports = asyncRoute(async (req, res) => {
+  const {
+    apollo,
+    input,
+    channel,
+    websiteContext: website,
+    mountHref,
+  } = res.locals;
+
+  const { data } = await apollo.query({ query, variables: { input } });
+  const { edges } = data.allPublishedContent;
+
   const parts = [
     '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
+    createChannel({
+      title: channel.title || `Published Content Feed | ${website.name}`,
+      link: channel.link || website.origin,
+      description: channel.description || `The latest published content from ${website.name}`,
+      language: website.language.code,
+      mountHref,
+      items: edges.map(edge => createItem(edge.node, website)),
+    }),
+    '</rss>',
   ];
   res.end(parts.join(''));
 });

--- a/services/rss/src/routes/index.js
+++ b/services/rss/src/routes/index.js
@@ -10,11 +10,11 @@ const parseJson = (value) => {
   }
 };
 
-const rss = () => (req, res, next) => {
+const rss = ({ requiresInput = true } = {}) => (req, res, next) => {
   const { websiteContext: website } = res.locals;
   const { query } = req;
-  if (!query.input) throw createError(400, 'No input was provided with the request.');
-  const input = parseJson(query.input);
+  if (requiresInput && !query.input) throw createError(400, 'No input was provided with the request.');
+  const input = parseJson(query.input || '{}');
   const channel = parseJson(query.channel);
   if (!input) throw createError(400, 'The provided input is invalid.');
   res.locals.input = { ...input, pagination: { limit: 25, ...input.pagination } };
@@ -28,6 +28,6 @@ const rss = () => (req, res, next) => {
 };
 
 module.exports = (app) => {
-  app.get('/all-published-content.xml', rss(), allPublishedContent);
+  app.get('/all-published-content.xml', rss({ requiresInput: false }), allPublishedContent);
   app.get('/website-scheduled-content.xml', rss(), websiteScheduledContent);
 };

--- a/services/rss/src/routes/index.js
+++ b/services/rss/src/routes/index.js
@@ -1,4 +1,5 @@
 const createError = require('http-errors');
+const allPublishedContent = require('./all-published-content');
 const websiteScheduledContent = require('./website-scheduled-content');
 
 const parseJson = (value) => {
@@ -27,5 +28,6 @@ const rss = () => (req, res, next) => {
 };
 
 module.exports = (app) => {
+  app.get('/all-published-content.xml', rss(), allPublishedContent);
   app.get('/website-scheduled-content.xml', rss(), websiteScheduledContent);
 };

--- a/services/rss/src/routes/index.js
+++ b/services/rss/src/routes/index.js
@@ -20,8 +20,9 @@ const rss = ({ requiresInput = true } = {}) => (req, res, next) => {
   res.locals.input = { ...input, pagination: { limit: 25, ...input.pagination } };
   res.locals.channel = channel || {};
 
-  const mountPoint = req.get('x-mount-point') || '/__rss';
-  res.locals.mountHref = `${website.origin}${mountPoint}${req.url}`;
+  const mountPoint = req.get('x-mount-point') || req.query['mount-point'] || '/__rss';
+  const useSelf = req.get('x-self-origin') || req.query['self-origin'];
+  res.locals.mountHref = useSelf ? `${req.protocol}://${req.get('host')}${req.url}` : `${website.origin}${mountPoint}${req.url}`;
 
   res.setHeader('Content-Type', 'application/rss+xml; charset=utf-8');
   next();

--- a/services/rss/src/routes/website-scheduled-content.js
+++ b/services/rss/src/routes/website-scheduled-content.js
@@ -5,7 +5,7 @@ const createItem = require('../utils/create-item');
 const contentFragment = require('../api/content-fragment');
 
 const query = gql`
-  query RSSWebsiteScheduledContent($input: WebsiteScheduledContentQueryInput) {
+  query RSSWebsiteScheduledContent($input: WebsiteScheduledContentQueryInput!) {
     websiteScheduledContent(input: $input) {
       section {
         id


### PR DESCRIPTION
Additionally, the tenant key and site ID values can now be passed via query string parameters, not just headers.
- Tenant: `x-tenant-key` header or `tenant-key` query param
- Site ID: `x-site-id` header or `site-id` query param

Header values take precedence over query params.