### PR TITLE
Content `hasWebsiteSchedule` support

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -442,6 +442,15 @@ input ContentSortInput {
   order: SortOrder = desc
 }
 
+input ContentHasWebsiteScheduleInput {
+  siteId: ObjectID
+  sectionId: Int
+  sectionAlias: String
+  optionId: Int
+  optionName: String
+  sectionBubbling: Boolean = true
+}
+
 ${interfaces}
 ${types}
 

--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
@@ -77,6 +77,8 @@ interface Content @requiresProject(fields: ["type"]) {
   userRegistration: ContentUserRegistration! @projection(localField: "mutations.Website.requiresAccessLevels", needs: ["mutations.Website.requiresRegistration"])
   # Returns the website section query schedules
   websiteSchedules: [ContentWebsiteSchedule]! @projection(localField: "sectionQuery") @arrayValue(localField: "sectionQuery")
+
+  hasWebsiteSchedule(input: ContentHasWebsiteScheduleInput!): Boolean! @projection(localField: "sectionQuery")
 }
 
 `;


### PR DESCRIPTION
Adds the `hasWebsiteSchedule` field to Content items in the GraphQL API.

This field will accept input arguments to determine if the content in question is scheduled to the specified section.

```graphql
query DevLeaderCompany($input:ContentQueryInput!,$leadership:ContentHasWebsiteScheduleInput!){
  content(input:$input) {
    id
    name
    siteContext{
      path
    }
    hasWebsiteSchedule(input:$leadership)
  }
}
```

```json
{
  "data": {
    "content": {
      "id": 13305784,
      "name": "AutomationDirect",
      "siteContext": {
        "path": "/leaders/actuators-valves/company/13305784"
      },
      "hasWebsiteSchedule": true
    }
  }
}
```