### PR TITLE
Support setting SafeFrame config

### DIFF
--- a/packages/marko-web-gam/components/enable.marko
+++ b/packages/marko-web-gam/components/enable.marko
@@ -6,6 +6,7 @@ $ const { req } = out.global;
 $ const options = {
   enableSingleRequest: true,
   collapseEmptyDivs: true,
+  setSafeFrameConfig: false,
   ...input.options,
 };
 
@@ -13,6 +14,10 @@ $ const options = {
 $ const calls = [];
 $ if (options.enableSingleRequest) calls.push("googletag.pubads().enableSingleRequest();");
 $ if (options.collapseEmptyDivs) calls.push("googletag.pubads().collapseEmptyDivs();");
+$ if (options.setSafeFrameConfig) {
+  const cfg = JSON.stringify(options.setSafeFrameConfig);
+  calls.push(`googletag.pubads().setSafeFrameConfig(${cfg});`);
+}
 
 <!-- Build global targeting calls -->
 $ const keyValues = {


### PR DESCRIPTION
Allows sites using the `@base-cms/marko-web-gam` package to specify SafeFrame configuration.

If not specified, the default GPT SafeFrame config is used (the sf config call is not sent).

Ex.
```marko
$ const setSafeFrameConfig = {
  allowOverlayExpansion: true,
  allowPushExpansion: true,
  sandbox: true,
};

<marko-web-document ...input>
  <@head>
    <marko-web-gam-init />
    <marko-web-gam-enable options={ setSafeFrameConfig } />
  </@head>
</marko-web-document>
```

Results in the following call being appended:
`googletag.pubads().setSafeFrameConfig({"allowOverlayExpansion":true,"allowPushExpansion":true,"sandbox":true});`