### PR TITLE
Base4 REST API Client + Schedule Mutations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,8 @@ services:
       <<: *env-mongo
       <<: *env-newrelic
       ENGINE_API_KEY: ${ENGINE_API_KEY-(unset)}
+      BASE4_REST_USERNAME: ${BASE4_REST_USERNAME-}
+      BASE4_REST_PASSWORD: ${BASE4_REST_PASSWORD-}
       PORT: 80
       EXPOSED_PORT: 10002
     depends_on:
@@ -103,6 +105,8 @@ services:
       MONGO_DSN: ${MONGO_DSN_AERILON-mongodb://mongodb:27017}
       ENABLE_BASEDB_LOGGING: ${ENABLE_BASEDB_LOGGING-}
       ENGINE_API_KEY: ${ENGINE_API_KEY-(unset)}
+      BASE4_REST_USERNAME: ${BASE4_REST_USERNAME-}
+      BASE4_REST_PASSWORD: ${BASE4_REST_PASSWORD-}
       PORT: 80
       EXPOSED_PORT: 11000
     depends_on:
@@ -120,6 +124,8 @@ services:
       MONGO_DSN: ${MONGO_DSN_CAPRICA-mongodb://mongodb:27017}
       ENABLE_BASEDB_LOGGING: ${ENABLE_BASEDB_LOGGING-}
       ENGINE_API_KEY: ${ENGINE_API_KEY-(unset)}
+      BASE4_REST_USERNAME: ${BASE4_REST_USERNAME-}
+      BASE4_REST_PASSWORD: ${BASE4_REST_PASSWORD-}
       PORT: 80
       EXPOSED_PORT: 11001
     depends_on:
@@ -137,6 +143,8 @@ services:
       MONGO_DSN: ${MONGO_DSN_PICON-mongodb://mongodb:27017}
       ENABLE_BASEDB_LOGGING: ${ENABLE_BASEDB_LOGGING-}
       ENGINE_API_KEY: ${ENGINE_API_KEY-(unset)}
+      BASE4_REST_USERNAME: ${BASE4_REST_USERNAME-}
+      BASE4_REST_PASSWORD: ${BASE4_REST_PASSWORD-}
       PORT: 80
       EXPOSED_PORT: 11002
     depends_on:

--- a/multi-site.md
+++ b/multi-site.md
@@ -2,6 +2,7 @@
 
 ## Punch List
 - [ ] All sites/services should boot and return a 200 when testing
+- [ ] Use relative imgix component for site logos
 - [ ] Update whitepaper/webinar start/end dates on content lists and pages
 - [ ] Add support for secondary site+section contexts
 - [ ] Ensure ContentPage respects primary site

--- a/packages/base4-rest-api/README.md
+++ b/packages/base4-rest-api/README.md
@@ -1,0 +1,1 @@
+# Base4 REST API Client

--- a/packages/base4-rest-api/package.json
+++ b/packages/base4-rest-api/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@base-cms/base4-rest-api",
+  "version": "1.0.0-beta.1",
+  "description": "A Base4 REST API client.",
+  "main": "src/index.js",
+  "author": "Jacob Bare <jacob@limit0.io>",
+  "repository": "https://github.com/base-cms/base-cms/tree/master/packages/base4-rest-api",
+  "license": "MIT",
+  "scripts": {
+    "lint": "eslint --ext .js --max-warnings 5 ./",
+    "test": "yarn lint"
+  },
+  "dependencies": {
+    "@base-cms/inflector": "^1.0.0-beta.1",
+    "@base-cms/object-path": "^1.0.0-beta.1",
+    "@base-cms/utils": "^1.0.0-beta.1",
+    "http-errors": "^1.7.3",
+    "node-fetch": "^2.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/base4-rest-api/src/client.js
+++ b/packages/base4-rest-api/src/client.js
@@ -20,10 +20,10 @@ class Base4RestApiClient {
     this.baseEndpoint = baseEndpoint;
     this.options = {
       ...options,
-      includeMeta: 1,
+      includeMeta: 0,
       queryInversed: 1,
       referenceFormat: 'object',
-      sideloadData: 1,
+      sideloadData: 0,
     };
   }
 

--- a/packages/base4-rest-api/src/client.js
+++ b/packages/base4-rest-api/src/client.js
@@ -32,7 +32,7 @@ class Base4RestApiClient {
   async findOne({ model, id, options } = {}) {
     if (!id) throw new Error('A Base4 model `id` value is required to findOne.');
     if (!model) throw new Error('A Base4 API model type is required to findOne.');
-    return this.retrieve({
+    return this.get({
       endpoint: `/${cleanPath(model)}/${id}`,
       options,
     });
@@ -40,7 +40,7 @@ class Base4RestApiClient {
 
   async insertOne({ model, body, options } = {}) {
     if (!model) throw new Error('A Base4 API model type is required to insertOne.');
-    return this.create({
+    return this.post({
       endpoint: `/${cleanPath(model)}`,
       body,
       options,
@@ -52,6 +52,21 @@ class Base4RestApiClient {
     return Promise.all(bodies.map(body => this.insertOne({ model, body, options })));
   }
 
+  async updateOne({
+    model,
+    id,
+    body,
+    options,
+  } = {}) {
+    if (!id) throw new Error('A Base4 model `id` value is required to updateOne.');
+    if (!model) throw new Error('A Base4 API model type is required to updateOne.');
+    return this.patch({
+      endpoint: `/${cleanPath(model)}/${id}`,
+      body,
+      options,
+    });
+  }
+
   async removeOne({ model, id, options } = {}) {
     if (!id) throw new Error('A Base4 model `id` value is required to removeOne.');
     if (!model) throw new Error('A Base4 API model type is required to removeOne.');
@@ -61,9 +76,9 @@ class Base4RestApiClient {
     });
   }
 
-  async create({ endpoint, body, options } = {}) {
-    if (!endpoint) throw new Error('A Base4 API endpoint is required to create.');
-    if (!body) throw new Error('A Base4 API request body is required to create.');
+  async post({ endpoint, body, options } = {}) {
+    if (!endpoint) throw new Error('A Base4 API endpoint is required to execute a post request.');
+    if (!body) throw new Error('A Base4 API request body is required to execute a post request.');
     return this.fetch({
       method: 'post',
       body,
@@ -73,8 +88,20 @@ class Base4RestApiClient {
     });
   }
 
-  async retrieve({ endpoint, options } = {}) {
-    if (!endpoint) throw new Error('A Base4 API endpoint is required to retrieve.');
+  async patch({ endpoint, body, options } = {}) {
+    if (!endpoint) throw new Error('A Base4 API endpoint is required to execute a patch request.');
+    if (!body) throw new Error('A Base4 API request body is required to execute a patch request.');
+    return this.fetch({
+      method: 'patch',
+      body,
+      type: 'persistence',
+      endpoint,
+      options,
+    });
+  }
+
+  async get({ endpoint, options } = {}) {
+    if (!endpoint) throw new Error('A Base4 API endpoint is required to execute a get request.');
     return this.fetch({
       method: 'get',
       type: 'persistence',
@@ -84,7 +111,7 @@ class Base4RestApiClient {
   }
 
   async delete({ endpoint, options } = {}) {
-    if (!endpoint) throw new Error('A Base4 API endpoint is required to delete.');
+    if (!endpoint) throw new Error('A Base4 API endpoint is required to execute a delete request.');
     return this.fetch({
       method: 'delete',
       type: 'persistence',

--- a/packages/base4-rest-api/src/index.js
+++ b/packages/base4-rest-api/src/index.js
@@ -1,3 +1,4 @@
 const Base4RestApiClient = require('./client');
+const Base4RestPayload = require('./payload');
 
-module.exports = { Base4RestApiClient };
+module.exports = { Base4RestApiClient, Base4RestPayload };

--- a/packages/base4-rest-api/src/index.js
+++ b/packages/base4-rest-api/src/index.js
@@ -1,0 +1,3 @@
+const Base4RestApiClient = require('./client');
+
+module.exports = { Base4RestApiClient };

--- a/packages/base4-rest-api/src/payload.js
+++ b/packages/base4-rest-api/src/payload.js
@@ -1,0 +1,43 @@
+const { set } = require('@base-cms/object-path');
+
+const { isArray } = Array;
+
+class Base4RestPayload {
+  constructor({ type }) {
+    if (!type) throw new Error('A model type is required to create a REST payload.');
+    this.data = { type };
+  }
+
+  obj() {
+    return { data: this.data };
+  }
+
+  set(path, value) {
+    let v = value;
+    if (v instanceof Date) v = v.toISOString();
+    if (path === 'id') v = `${v}`;
+    if (path) set(this.data, path, v);
+    return this;
+  }
+
+  setLink(field, { id, type } = {}) {
+    Base4RestPayload.validateLink(id, type);
+    if (field) this.set(`links.${field}.linkage`, { id: `${id}`, type });
+    return this;
+  }
+
+  setLinks(field, links) {
+    if (isArray(links)) {
+      links.forEach(({ id, type } = {}) => Base4RestPayload.validateLink(id, type));
+      if (field) this.set(`links.${field}.linkage`, links.map(({ id, type }) => ({ id: `${id}`, type })));
+    }
+    return this;
+  }
+
+  static validateLink(id, type) {
+    if (!type || !id) throw new Error('An id and type are required to create a REST payload link.');
+    return true;
+  }
+}
+
+module.exports = Base4RestPayload;

--- a/packages/db/src/basedb.js
+++ b/packages/db/src/basedb.js
@@ -231,6 +231,26 @@ class BaseDB {
   }
 
   /**
+   * Inserts a multiple documents to a collection.
+   *
+   * @param {string} modelName The model name, e.g. `platform.Content`.
+   * @param {object[]} docs The documents to insert
+   * @param {object} [options] Options to pass to `Collection.insertMany`.
+   */
+  async insertMany(modelName, doc, options) {
+    const start = hrtime();
+    const { namespace, resource } = BaseDB.parseModelName(modelName);
+    const coll = await this.collection(namespace, resource);
+    const result = await coll.insertMany(doc, options);
+    this.log('insertMany', start, {
+      modelName,
+      doc,
+      options,
+    });
+    return result;
+  }
+
+  /**
    * Update multiple documents in a collection.
    *
    * @param {string} modelName The model name, e.g. `platform.Content`.

--- a/packages/db/src/basedb.js
+++ b/packages/db/src/basedb.js
@@ -273,6 +273,26 @@ class BaseDB {
   }
 
   /**
+   * Delete a document from a collection.
+   *
+   * @param {string} modelName The model name, e.g. `platform.Content`.
+   * @param {object} filter The Filter used to select the document to remove.
+   * @param {object} [options] Options to pass to `Collection.deleteOne`.
+   */
+  async deleteOne(modelName, filter, options) {
+    const start = hrtime();
+    const { namespace, resource } = BaseDB.parseModelName(modelName);
+    const coll = await this.collection(namespace, resource);
+    const result = await coll.deleteOne(filter, options);
+    this.log('deleteOne', start, {
+      modelName,
+      filter,
+      options,
+    });
+    return result;
+  }
+
+  /**
    *
    * @param {string} modelName The model name, e.g. `platform.Content`.
    * @param {object} params

--- a/packages/db/src/paginate/find.js
+++ b/packages/db/src/paginate/find.js
@@ -53,7 +53,7 @@ module.exports = async (basedb, modelName, {
 
   const options = {
     sort: $sort.value,
-    limit: $limit.value + 1, // peek to see if there is another page.
+    limit: $limit.value === 0 ? 0 : $limit.value + 1, // peek to see if there is another page.
     skip,
     projection: $projection,
   };

--- a/packages/db/src/paginate/limit.js
+++ b/packages/db/src/paginate/limit.js
@@ -44,7 +44,9 @@ class Limit {
   set value(value) {
     const { def, max } = this.opts;
     const v = parseInt(value, 10);
-    if (!v || value < 0) {
+    if (v === 0) {
+      this.v = 0;
+    } else if (!v || value < 0) {
       this.v = def;
     } else if (v > max) {
       this.v = max;

--- a/packages/db/src/paginate/utils.js
+++ b/packages/db/src/paginate/utils.js
@@ -16,7 +16,7 @@ module.exports = {
   } = {}, additionalData = {}) {
     const hasNextPage = results.length > limit.value;
     // Remove the extra model that was queried to peek for the page.
-    if (hasNextPage) results.pop();
+    if (hasNextPage && limit.value !== 0) results.pop();
 
     // Cursor generation is actually pretty slow... 5 - 20ms on large datasets.
     // As such, only return the values if requested (by making the property a function).

--- a/services/graphql-server/package.json
+++ b/services/graphql-server/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@base-cms/async": "^1.0.0-beta.1",
+    "@base-cms/base4-rest-api": "^1.0.0-beta.1",
     "@base-cms/canonical-path": "^1.0.0-beta.4",
     "@base-cms/db": "^1.0.0-beta.4",
     "@base-cms/embedded-media": "^1.0.0-beta.1",

--- a/services/graphql-server/src/create-rest-client.js
+++ b/services/graphql-server/src/create-rest-client.js
@@ -1,0 +1,16 @@
+const { Base4RestApiClient } = require('@base-cms/base4-rest-api');
+const { BASE4_REST_USERNAME: username, BASE4_REST_PASSWORD: password } = require('./env');
+
+module.exports = ({ hostname, options } = {}) => {
+  if (!hostname) return undefined;
+
+  if (!username || !password) {
+    throw new Error('The Base4 REST API username and password env variables are required!');
+  }
+  return new Base4RestApiClient({
+    hostname,
+    username,
+    password,
+    options,
+  });
+};

--- a/services/graphql-server/src/dataloaders/index.js
+++ b/services/graphql-server/src/dataloaders/index.js
@@ -26,4 +26,5 @@ module.exports = basedb => ({
   websiteSection: createProjectLoader({ basedb, modelName: 'website.Section' }),
   magazineIssue: createProjectLoader({ basedb, modelName: 'magazine.Issue' }),
   magazineSection: createProjectLoader({ basedb, modelName: 'magazine.Section' }),
+  emailSection: createProjectLoader({ basedb, modelName: 'email.Section' }),
 });

--- a/services/graphql-server/src/dataloaders/index.js
+++ b/services/graphql-server/src/dataloaders/index.js
@@ -24,4 +24,6 @@ module.exports = basedb => ({
   platformUser: createProjectLoader({ basedb, modelName: 'platform.User' }),
   websiteOption: createProjectLoader({ basedb, modelName: 'website.Option' }),
   websiteSection: createProjectLoader({ basedb, modelName: 'website.Section' }),
+  magazineIssue: createProjectLoader({ basedb, modelName: 'magazine.Issue' }),
+  magazineSection: createProjectLoader({ basedb, modelName: 'magazine.Section' }),
 });

--- a/services/graphql-server/src/env.js
+++ b/services/graphql-server/src/env.js
@@ -5,6 +5,7 @@ const {
   cleanEnv,
   bool,
   port,
+  str,
 } = envalid;
 const { nonemptystr } = custom;
 
@@ -16,4 +17,6 @@ module.exports = cleanEnv(process.env, {
   NEW_RELIC_ENABLED: bool({ desc: 'Whether New Relic is enabled.', default: true, devDefault: false }),
   NEW_RELIC_LICENSE_KEY: nonemptystr({ desc: 'The license key for New Relic.', devDefault: '(unset)' }),
   ENGINE_API_KEY: nonemptystr({ desc: 'The Apollo Engine API key', devDefault: '(unset)' }),
+  BASE4_REST_USERNAME: str({ desc: 'The Base4 REST API username.', default: '' }),
+  BASE4_REST_PASSWORD: str({ desc: 'The Base4 REST API password.', default: '' }),
 });

--- a/services/graphql-server/src/graphql/definitions/email/index.js
+++ b/services/graphql-server/src/graphql/definitions/email/index.js
@@ -1,12 +1,14 @@
 const gql = require('graphql-tag');
 const campaign = require('./campaign');
 const newsletter = require('./newsletter');
+const schedule = require('./schedule');
 const section = require('./section');
 
 module.exports = gql`
 
 ${campaign}
 ${newsletter}
+${schedule}
 ${section}
 
 `;

--- a/services/graphql-server/src/graphql/definitions/email/schedule.js
+++ b/services/graphql-server/src/graphql/definitions/email/schedule.js
@@ -1,0 +1,81 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+extend type Query {
+  emailSchedule(input: EmailScheduleQueryInput!): EmailSchedule @findOne(
+    model: "email.Schedule",
+    using: { id: "_id" },
+  )
+  contentEmailSchedules(input: ContentEmailSchedulesQueryInput!): EmailScheduleConnection! @findMany(
+    model: "email.Schedule",
+    using: { contentId: "content.$id" },
+  )
+}
+
+type EmailSchedule {
+  # fields from email.model::Schedule
+  id: ObjectID! @projection(localField: "_id") @value(localField: "_id")
+  newsletter(input: EmailScheduleNewsletterInput = {}): EmailNewsletter! @projection(localField: "product") @refOne(
+    loader: "platformProduct",
+    localField: "product"
+    criteria: "emailNewsletter",
+  )
+  content(input: EmailScheduleContentInput = {}): Content! @projection @refOne(
+    loader: "platformContent",
+    criteria: "content"
+  )
+  section(input: EmailScheduleSectionInput = {}): EmailSection! @projection @refOne(loader: "emailSection")
+  deploymentDate: Date! @projection
+  sequence: Int @projection
+
+  # fields from trait.platform::StatusEnabled
+  status: Int @projection
+}
+
+enum EmailScheduleSortField {
+  id
+  deploymentDate
+}
+
+type EmailScheduleConnection @projectUsing(type: "EmailSchedule") {
+  totalCount: Int!
+  edges: [EmailScheduleEdge]!
+  pageInfo: PageInfo!
+}
+
+type EmailScheduleEdge {
+  node: EmailSchedule!
+  cursor: String!
+}
+
+input EmailScheduleNewsletterInput {
+  status: ModelStatus = active
+}
+
+input EmailScheduleContentInput {
+  status: ModelStatus = active
+}
+
+input EmailScheduleSectionInput {
+  status: ModelStatus = active
+}
+
+input EmailScheduleQueryInput {
+  status: ModelStatus = active
+  id: ObjectID!
+}
+
+input ContentEmailSchedulesQueryInput {
+  contentId: Int!
+  status: ModelStatus = active
+  sort: EmailScheduleSortInput = {}
+  pagination: PaginationInput = {}
+}
+
+input EmailScheduleSortInput {
+  field: EmailScheduleSortField = id
+  order: SortOrder = desc
+}
+
+`;

--- a/services/graphql-server/src/graphql/definitions/email/schedule.js
+++ b/services/graphql-server/src/graphql/definitions/email/schedule.js
@@ -14,6 +14,7 @@ extend type Query {
 }
 
 extend type Mutation {
+  quickCreateEmailSchedules(input: QuickCreateEmailSchedulesMutationInput!): [EmailSchedule!]!
   deleteEmailSchedule(input: DeleteEmailScheduleMutationInput!): String!
 }
 
@@ -84,6 +85,12 @@ input ContentEmailSchedulesQueryInput {
 input EmailScheduleSortInput {
   field: EmailScheduleSortField = id
   order: SortOrder = desc
+}
+
+input QuickCreateEmailSchedulesMutationInput {
+  contentId: Int!
+  sectionIds: [Int!]!
+  deploymentDates: [Date!]!
 }
 
 `;

--- a/services/graphql-server/src/graphql/definitions/email/schedule.js
+++ b/services/graphql-server/src/graphql/definitions/email/schedule.js
@@ -15,6 +15,7 @@ extend type Query {
 
 extend type Mutation {
   quickCreateEmailSchedules(input: QuickCreateEmailSchedulesMutationInput!): [EmailSchedule!]!
+  updateEmailSchedule(input: UpdateEmailScheduleMutationInput!): EmailSchedule!
   deleteEmailSchedule(input: DeleteEmailScheduleMutationInput!): String!
 }
 
@@ -91,6 +92,18 @@ input QuickCreateEmailSchedulesMutationInput {
   contentId: Int!
   sectionIds: [Int!]!
   deploymentDates: [Date!]!
+}
+
+input UpdateEmailScheduleMutationInput {
+  id: ObjectID!
+  payload: UpdateEmailSchedulePayloadInput!
+}
+
+input UpdateEmailSchedulePayloadInput {
+  status: Int = 1
+  sectionId: Int!
+  deploymentDate: Date!
+  sequence: Int
 }
 
 `;

--- a/services/graphql-server/src/graphql/definitions/email/schedule.js
+++ b/services/graphql-server/src/graphql/definitions/email/schedule.js
@@ -13,6 +13,10 @@ extend type Query {
   )
 }
 
+extend type Mutation {
+  deleteEmailSchedule(input: DeleteEmailScheduleMutationInput!): String!
+}
+
 type EmailSchedule {
   # fields from email.model::Schedule
   id: ObjectID! @projection(localField: "_id") @value(localField: "_id")
@@ -47,6 +51,10 @@ type EmailScheduleConnection @projectUsing(type: "EmailSchedule") {
 type EmailScheduleEdge {
   node: EmailSchedule!
   cursor: String!
+}
+
+input DeleteEmailScheduleMutationInput {
+  id: ObjectID!
 }
 
 input EmailScheduleNewsletterInput {

--- a/services/graphql-server/src/graphql/definitions/magazine/index.js
+++ b/services/graphql-server/src/graphql/definitions/magazine/index.js
@@ -1,12 +1,14 @@
 const gql = require('graphql-tag');
 const issue = require('./issue');
 const publication = require('./publication');
+const schedule = require('./schedule');
 const section = require('./section');
 
 module.exports = gql`
 
 ${issue}
 ${publication}
+${schedule}
 ${section}
 
 `;

--- a/services/graphql-server/src/graphql/definitions/magazine/issue.js
+++ b/services/graphql-server/src/graphql/definitions/magazine/issue.js
@@ -20,7 +20,7 @@ type MagazineIssue {
   coverDescription: String @projection
   credit: String @projection
   publication(input: MagazineIssuePublicationInput = {}): MagazinePublication @projection @refOne(loader: "platformProduct", criteria: "magazinePublication")
-  sections(input: MagazineIssueSectionsInput = {}): MagazineSectionConnection! @projection(localField: "_id") @refMany(model: "magazine.Section", localField: "_id", foreignField: "issue.$id")
+  sections(input: MagazineIssueSectionsInput = {}): MagazineSectionConnection! @projection(localField: "_id", needs: ["publication"])
   coverImage: AssetImage @projection @refOne(loader: "platformAsset", criteria: "assetImage")
   redirects: [String]! @projection @arrayValue
 
@@ -87,6 +87,7 @@ input MagazineIssueSectionsInput {
   status: ModelStatus = active
   sort: WebsiteSectionSortInput = {}
   pagination: PaginationInput = {}
+  includeGlobal: Boolean = true
 }
 
 input MagazineIssueSortInput {

--- a/services/graphql-server/src/graphql/definitions/magazine/schedule.js
+++ b/services/graphql-server/src/graphql/definitions/magazine/schedule.js
@@ -15,6 +15,7 @@ extend type Query {
 
 extend type Mutation {
   createMagazineSchedule(input: CreateMagazineScheduleMutationInput!): MagazineSchedule!
+  deleteMagazineSchedule(input: DeleteMagazineScheduleMutationInput!): String!
 }
 
 type MagazineSchedule {
@@ -55,6 +56,10 @@ input CreateMagazineScheduleMutationInput {
   contentId: Int!
   issueId: Int!
   sectionId: Int!
+}
+
+input DeleteMagazineScheduleMutationInput {
+  id: ObjectID!
 }
 
 input MagazineScheduleQueryInput {

--- a/services/graphql-server/src/graphql/definitions/magazine/schedule.js
+++ b/services/graphql-server/src/graphql/definitions/magazine/schedule.js
@@ -1,0 +1,94 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+extend type Query {
+  magazineSchedule(input: MagazineScheduleQueryInput!): MagazineSchedule @findOne(
+    model: "magazine.Schedule",
+    using: { id: "_id" },
+  )
+  contentMagazineSchedules(input: ContentMagazineSchedulesQueryInput!): MagazineScheduleConnection! @findMany(
+    model: "magazine.Schedule",
+    using: { contentId: "content.$id" },
+  )
+}
+
+extend type Mutation {
+  createMagazineSchedule(input: CreateMagazineScheduleMutationInput!): MagazineSchedule!
+}
+
+type MagazineSchedule {
+  # fields from magazine.model::Schedule
+  id: ObjectID! @projection(localField: "_id") @value(localField: "_id")
+  publication(input: MagazineSchedulePublicationInput = {}): MagazinePublication! @projection(localField: "product") @refOne(
+    loader: "platformProduct",
+    localField: "product"
+    criteria: "magazinePublication",
+  )
+  content(input: MagazineScheduleContentInput = {}): Content! @projection @refOne(
+    loader: "platformContent",
+    criteria: "content"
+  )
+  issue(input: MagazineScheduleIssueInput = {}): MagazineIssue! @projection @refOne(loader: "magazineIssue")
+  section(input: MagazineScheduleSectionInput = {}): MagazineSection! @projection @refOne(loader: "magazineSection")
+
+  # fields from trait.platform::StatusEnabled
+  status: Int @projection
+}
+
+enum MagazineScheduleSortField {
+  id
+}
+
+type MagazineScheduleConnection @projectUsing(type: "MagazineSchedule") {
+  totalCount: Int!
+  edges: [MagazineScheduleEdge]!
+  pageInfo: PageInfo!
+}
+
+type MagazineScheduleEdge {
+  node: MagazineSchedule!
+  cursor: String!
+}
+
+input CreateMagazineScheduleMutationInput {
+  contentId: Int!
+  issueId: Int!
+  sectionId: Int!
+}
+
+input MagazineScheduleQueryInput {
+  status: ModelStatus = active
+  id: ObjectID!
+}
+
+input ContentMagazineSchedulesQueryInput {
+  contentId: Int!
+  status: ModelStatus = active
+  sort: MagazineScheduleSortInput = {}
+  pagination: PaginationInput = {}
+}
+
+input MagazineScheduleSortInput {
+  field: MagazineScheduleSortField = id
+  order: SortOrder = desc
+}
+
+input MagazineScheduleContentInput {
+  status: ModelStatus = active
+}
+
+input MagazineSchedulePublicationInput {
+  status: ModelStatus = active
+}
+
+input MagazineScheduleIssueInput {
+  status: ModelStatus = active
+}
+
+input MagazineScheduleSectionInput {
+  status: ModelStatus = active
+}
+
+
+`;

--- a/services/graphql-server/src/graphql/definitions/magazine/schedule.js
+++ b/services/graphql-server/src/graphql/definitions/magazine/schedule.js
@@ -15,6 +15,7 @@ extend type Query {
 
 extend type Mutation {
   createMagazineSchedule(input: CreateMagazineScheduleMutationInput!): MagazineSchedule!
+  updateMagazineSchedule(input: UpdateMagazineScheduleMutationInput!): MagazineSchedule!
   deleteMagazineSchedule(input: DeleteMagazineScheduleMutationInput!): String!
 }
 
@@ -93,6 +94,17 @@ input MagazineScheduleIssueInput {
 
 input MagazineScheduleSectionInput {
   status: ModelStatus = active
+}
+
+input UpdateMagazineScheduleMutationInput {
+  id: ObjectID!
+  payload: UpdateMagazineSchedulePayloadInput!
+}
+
+input UpdateMagazineSchedulePayloadInput {
+  status: Int = 1
+  issueId: Int!
+  sectionId: Int!
 }
 
 

--- a/services/graphql-server/src/graphql/definitions/magazine/section.js
+++ b/services/graphql-server/src/graphql/definitions/magazine/section.js
@@ -25,6 +25,9 @@ type MagazineSection {
   # fields directly on magazine.model::Section
   publication(input: MagazineSectionPublicationInput = {}): MagazinePublication @projection @refOne(loader: "platformProduct", criteria: "magazinePublication")
   issue(input: MagazineSectionIssueInput = {}): MagazineIssue @projection @refOne(loader: "magazineIssue")
+
+  # GraphQL only fields
+  isGlobal: Boolean @projection(localField: "publication")
 }
 
 type MagazineSectionConnection @projectUsing(type: "MagazineSection") {

--- a/services/graphql-server/src/graphql/definitions/website/index.js
+++ b/services/graphql-server/src/graphql/definitions/website/index.js
@@ -1,6 +1,7 @@
 const gql = require('graphql-tag');
 const inquirySubmission = require('./inquiry-submission');
 const option = require('./option');
+const schedule = require('./schedule');
 const section = require('./section');
 const site = require('./site');
 
@@ -8,6 +9,7 @@ module.exports = gql`
 
 ${inquirySubmission}
 ${option}
+${schedule}
 ${section}
 ${site}
 

--- a/services/graphql-server/src/graphql/definitions/website/option.js
+++ b/services/graphql-server/src/graphql/definitions/website/option.js
@@ -3,9 +3,19 @@ const gql = require('graphql-tag');
 module.exports = gql`
 
 extend type Query {
-  websiteOption(input: WebsiteOptionQueryInput!): WebsiteOption @findOne(model: "website.Option", using: { id: "_id" })
-  websiteOptions(input: WebsiteOptionsQueryInput!): WebsiteOptionConnection! @findMany(model: "website.Option")
-  websiteOptionsForSite(input: WebsiteOptionsForSiteQueryInput!): WebsiteOptionConnection! @findMany(model: "website.Option", using: { siteId: "site.$id" })
+  websiteOption(input: WebsiteOptionQueryInput!): WebsiteOption @findOne(
+    model: "website.Option",
+    withSite: true,
+    using: { id: "_id" }
+  )
+  websiteOptions(input: WebsiteOptionsQueryInput = {}): WebsiteOptionConnection! @findMany(
+    model: "website.Option",
+    withSite: true
+  )
+  websiteOptionsForSite(input: WebsiteOptionsForSiteQueryInput!): WebsiteOptionConnection! @deprecated(reason: "Use \`Query.websiteOptions\` with the \`siteId\` input instead") @findMany(
+    model: "website.Option",
+    using: { siteId: "site.$id" }
+  )
 }
 
 type WebsiteOption {
@@ -45,6 +55,7 @@ input WebsiteOptionSiteInput {
 }
 
 input WebsiteOptionsQueryInput {
+  siteId: ObjectID
   status: ModelStatus = active
   sort: WebsiteOptionSortInput = {}
   pagination: PaginationInput = {}

--- a/services/graphql-server/src/graphql/definitions/website/schedule.js
+++ b/services/graphql-server/src/graphql/definitions/website/schedule.js
@@ -9,6 +9,12 @@ extend type Query {
     withSite: true,
     siteField: "product"
   )
+  contentWebsiteSchedules(input: ContentWebsiteSchedulesQueryInput = {}): WebsiteScheduleConnection! @findMany(
+    model: "website.Schedule",
+    using: { contentId: "content.$id" },
+    withSite: true,
+    siteField: "product"
+  )
 }
 
 type WebsiteSchedule {
@@ -34,10 +40,39 @@ type WebsiteSchedule {
   status: Int @projection
 }
 
+enum WebsiteScheduleSortField {
+  id
+  startDate
+}
+
+type WebsiteScheduleConnection @projectUsing(type: "WebsiteSchedule") {
+  totalCount: Int!
+  edges: [WebsiteScheduleEdge]!
+  pageInfo: PageInfo!
+}
+
+type WebsiteScheduleEdge {
+  node: WebsiteSchedule!
+  cursor: String!
+}
+
 input WebsiteScheduleQueryInput {
   siteId: ObjectID
   status: ModelStatus = active
   id: ObjectID!
+}
+
+input ContentWebsiteSchedulesQueryInput {
+  contentId: Int!
+  status: ModelStatus = active
+  siteId: ObjectID
+  sort: WebsiteSectionSortInput = {}
+  pagination: PaginationInput = {}
+}
+
+input WebsiteScheduleSortInput {
+  field: WebsiteScheduleSortField = id
+  order: SortOrder = desc
 }
 
 input WebsiteScheduleSiteInput {

--- a/services/graphql-server/src/graphql/definitions/website/schedule.js
+++ b/services/graphql-server/src/graphql/definitions/website/schedule.js
@@ -3,13 +3,13 @@ const gql = require('graphql-tag');
 module.exports = gql`
 
 extend type Query {
-  websiteSchedule(input: WebsiteScheduleQueryInput = {}): WebsiteSchedule @findOne(
+  websiteSchedule(input: WebsiteScheduleQueryInput!): WebsiteSchedule @findOne(
     model: "website.Schedule",
     using: { id: "_id" },
     withSite: true,
     siteField: "product"
   )
-  contentWebsiteSchedules(input: ContentWebsiteSchedulesQueryInput = {}): WebsiteScheduleConnection! @findMany(
+  contentWebsiteSchedules(input: ContentWebsiteSchedulesQueryInput!): WebsiteScheduleConnection! @findMany(
     model: "website.Schedule",
     using: { contentId: "content.$id" },
     withSite: true,

--- a/services/graphql-server/src/graphql/definitions/website/schedule.js
+++ b/services/graphql-server/src/graphql/definitions/website/schedule.js
@@ -17,6 +17,11 @@ extend type Query {
   )
 }
 
+extend type Mutation {
+  quickCreateWebsiteSchedules(input: QuickCreateWebsiteSchedulesMutationInput!): [WebsiteSchedule!]!
+  deleteWebsiteSchedule(input: DeleteWebsiteScheduleMutationInput!): String!
+}
+
 type WebsiteSchedule {
   # fields from platform.model::Schedule
   id: ObjectID @projection(localField: "_id") @value(localField: "_id")
@@ -90,6 +95,15 @@ input WebsiteScheduleSectionInput {
 
 input WebsiteScheduleOptionInput {
   status: ModelStatus = active
+}
+
+input QuickCreateWebsiteSchedulesMutationInput {
+  contentId: Int!
+  sectionIds: [Int!]!
+}
+
+input DeleteWebsiteScheduleMutationInput {
+  id: ObjectID!
 }
 
 `;

--- a/services/graphql-server/src/graphql/definitions/website/schedule.js
+++ b/services/graphql-server/src/graphql/definitions/website/schedule.js
@@ -72,7 +72,7 @@ input ContentWebsiteSchedulesQueryInput {
   contentId: Int!
   status: ModelStatus = active
   siteId: ObjectID
-  sort: WebsiteSectionSortInput = {}
+  sort: WebsiteScheduleSortInput = {}
   pagination: PaginationInput = {}
 }
 

--- a/services/graphql-server/src/graphql/definitions/website/schedule.js
+++ b/services/graphql-server/src/graphql/definitions/website/schedule.js
@@ -25,21 +25,21 @@ extend type Mutation {
 
 type WebsiteSchedule {
   # fields from platform.model::Schedule
-  id: ObjectID @projection(localField: "_id") @value(localField: "_id")
-  site(input: WebsiteScheduleSiteInput = {}): WebsiteSite @projection(localField: "product") @refOne(
+  id: ObjectID! @projection(localField: "_id") @value(localField: "_id")
+  site(input: WebsiteScheduleSiteInput = {}): WebsiteSite! @projection(localField: "product") @refOne(
     loader: "platformProduct",
     localField: "product"
     withSite: true,
     siteField: "_id"
     criteria: "websiteSite",
   )
-  content(input: WebsiteScheduleContentInput = {}): Content @projection @refOne(
+  content(input: WebsiteScheduleContentInput = {}): Content! @projection @refOne(
     loader: "platformContent",
     criteria: "content"
   )
-  section(input: WebsiteScheduleSectionInput = {}): WebsiteSection @projection @refOne(loader: "websiteSection")
-  option(input: WebsiteScheduleOptionInput = {}): WebsiteOption @projection @refOne(loader: "websiteOption")
-  startDate: Date @projection
+  section(input: WebsiteScheduleSectionInput = {}): WebsiteSection! @projection @refOne(loader: "websiteSection")
+  option(input: WebsiteScheduleOptionInput = {}): WebsiteOption! @projection @refOne(loader: "websiteOption")
+  startDate: Date! @projection
   endDate: Date @projection
 
   # fields from trait.platform::StatusEnabled

--- a/services/graphql-server/src/graphql/definitions/website/schedule.js
+++ b/services/graphql-server/src/graphql/definitions/website/schedule.js
@@ -19,6 +19,7 @@ extend type Query {
 
 extend type Mutation {
   quickCreateWebsiteSchedules(input: QuickCreateWebsiteSchedulesMutationInput!): [WebsiteSchedule!]!
+  updateWebsiteSchedule(input: UpdateWebsiteScheduleMutationInput!): WebsiteSchedule!
   deleteWebsiteSchedule(input: DeleteWebsiteScheduleMutationInput!): String!
 }
 
@@ -104,6 +105,19 @@ input QuickCreateWebsiteSchedulesMutationInput {
 
 input DeleteWebsiteScheduleMutationInput {
   id: ObjectID!
+}
+
+input UpdateWebsiteScheduleMutationInput {
+  id: ObjectID!
+  payload: UpdateWebsiteSchedulePayloadInput!
+}
+
+input UpdateWebsiteSchedulePayloadInput {
+  status: Int = 1
+  sectionId: Int!
+  optionId: Int!
+  startDate: Date!
+  endDate: Date
 }
 
 `;

--- a/services/graphql-server/src/graphql/definitions/website/schedule.js
+++ b/services/graphql-server/src/graphql/definitions/website/schedule.js
@@ -1,0 +1,60 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+extend type Query {
+  websiteSchedule(input: WebsiteScheduleQueryInput = {}): WebsiteSchedule @findOne(
+    model: "website.Schedule",
+    using: { id: "_id" },
+    withSite: true,
+    siteField: "product"
+  )
+}
+
+type WebsiteSchedule {
+  # fields from platform.model::Schedule
+  id: ObjectID @projection(localField: "_id") @value(localField: "_id")
+  site(input: WebsiteScheduleSiteInput = {}): WebsiteSite @projection(localField: "product") @refOne(
+    loader: "platformProduct",
+    localField: "product"
+    withSite: true,
+    siteField: "_id"
+    criteria: "websiteSite",
+  )
+  content(input: WebsiteScheduleContentInput = {}): Content @projection @refOne(
+    loader: "platformContent",
+    criteria: "content"
+  )
+  section(input: WebsiteScheduleSectionInput = {}): WebsiteSection @projection @refOne(loader: "websiteSection")
+  option(input: WebsiteScheduleOptionInput = {}): WebsiteOption @projection @refOne(loader: "websiteOption")
+  startDate: Date @projection
+  endDate: Date @projection
+
+  # fields from trait.platform::StatusEnabled
+  status: Int @projection
+}
+
+input WebsiteScheduleQueryInput {
+  siteId: ObjectID
+  status: ModelStatus = active
+  id: ObjectID!
+}
+
+input WebsiteScheduleSiteInput {
+  siteId: ObjectID
+  status: ModelStatus = active
+}
+
+input WebsiteScheduleContentInput {
+  status: ModelStatus = active
+}
+
+input WebsiteScheduleSectionInput {
+  status: ModelStatus = active
+}
+
+input WebsiteScheduleOptionInput {
+  status: ModelStatus = active
+}
+
+`;

--- a/services/graphql-server/src/graphql/definitions/website/section.js
+++ b/services/graphql-server/src/graphql/definitions/website/section.js
@@ -66,7 +66,7 @@ type WebsiteSection {
   canonicalPath: String! @projection(localField: "alias")
   # Determines if this content item should redirect to another location.
   redirectTo: String
-  # Retrieves the flattened hierarchy for this section.
+  # Retrieves the flattened (parent) hierarchy for this section.
   hierarchy: [WebsiteSection!]! @projection(localField: "parent")
 }
 

--- a/services/graphql-server/src/graphql/definitions/website/site.js
+++ b/services/graphql-server/src/graphql/definitions/website/site.js
@@ -31,6 +31,8 @@ type WebsiteSite {
   redirects: [String]! @projection @arrayValue
 
   # fields that are new to GraphQL
+  title: String @projection(localField: "name", needs: ["shortName"])
+  shortName: String @projection
   rootSections(input: WebsiteSiteRootSectionsInput = {}): WebsiteSectionConnection! @projection(localField: "_id") @refMany(model: "website.Section", localField: "_id", foreignField: "site.$id", criteria: "rootWebsiteSection")
   host: String! @projection
   origin: String! @projection(localField: "host")

--- a/services/graphql-server/src/graphql/resolvers/email/index.js
+++ b/services/graphql-server/src/graphql/resolvers/email/index.js
@@ -1,0 +1,7 @@
+const deepAssign = require('deep-assign');
+
+const schedule = require('./schedule');
+
+module.exports = deepAssign(
+  schedule,
+);

--- a/services/graphql-server/src/graphql/resolvers/email/schedule.js
+++ b/services/graphql-server/src/graphql/resolvers/email/schedule.js
@@ -1,4 +1,18 @@
+const { BaseDB, MongoDB } = require('@base-cms/db');
+const { Base4RestPayload } = require('@base-cms/base4-rest-api');
+const { dasherize } = require('@base-cms/inflector');
+const getProjection = require('../../utils/get-projection');
+
 const validateRest = require('../../utils/validate-rest');
+
+const { ObjectID } = MongoDB;
+
+const clearSeconds = (date) => {
+  if (date) {
+    date.setSeconds(0);
+    date.setMilliseconds(0);
+  }
+};
 
 module.exports = {
   /**
@@ -13,6 +27,47 @@ module.exports = {
       validateRest(base4rest);
       await base4rest.removeOne({ model: 'email/schedule', id });
       return 'ok';
+    },
+
+    /**
+     *
+     */
+    quickCreateEmailSchedules: async (_, { input }, { basedb, base4rest, load }, info) => {
+      validateRest(base4rest);
+      const { contentId, sectionIds, deploymentDates } = input;
+
+      const [content, sections] = await Promise.all([
+        load('platformContent', contentId, { type: 1 }),
+        basedb.find('email.Section', { _id: { $in: sectionIds } }, { projection: { deployment: 1 } }),
+      ]);
+
+      const bodies = sections.reduce((arr, section) => {
+        const deploymentId = BaseDB.extractRefId(section.deployment);
+        if (!deploymentId) throw new Error(`Unable to extract a deployment ID for section ${section._id}.`);
+        deploymentDates.forEach((deploymentDate) => {
+          clearSeconds(deploymentDate);
+          const body = new Base4RestPayload({ type: 'email/schedule' });
+          body
+            .set('deploymentDate', deploymentDate)
+            .set('status', 1)
+            .setLink('product', { id: deploymentId, type: 'email/product/newsletter' })
+            .setLink('section', { id: section._id, type: 'email/section' })
+            .setLink('content', { id: content._id, type: `platform/content/${dasherize(content.type)}` });
+          arr.push(body);
+        });
+        return arr;
+      }, []);
+
+      const responses = await base4rest.insertMany({ model: 'email/schedule', bodies });
+      const ids = responses.map(({ data }) => ObjectID(data.id));
+
+      const {
+        fieldNodes,
+        schema,
+        fragments,
+      } = info;
+      const projection = getProjection(schema, schema.getType('EmailSchedule'), fieldNodes[0].selectionSet, fragments);
+      return basedb.find('email.Schedule', { _id: { $in: ids } }, { projection });
     },
   },
 };

--- a/services/graphql-server/src/graphql/resolvers/email/schedule.js
+++ b/services/graphql-server/src/graphql/resolvers/email/schedule.js
@@ -1,0 +1,18 @@
+const validateRest = require('../../utils/validate-rest');
+
+module.exports = {
+  /**
+   *
+   */
+  Mutation: {
+    /**
+     *
+     */
+    deleteEmailSchedule: async (_, { input }, { base4rest }) => {
+      const { id } = input;
+      validateRest(base4rest);
+      await base4rest.removeOne({ model: 'email/schedule', id });
+      return 'ok';
+    },
+  },
+};

--- a/services/graphql-server/src/graphql/resolvers/index.js
+++ b/services/graphql-server/src/graphql/resolvers/index.js
@@ -5,11 +5,13 @@ const { DateType, ObjectIDType } = require('../types');
 const platform = require('./platform');
 const website = require('./website');
 const magazine = require('./magazine');
+const email = require('./email');
 
 module.exports = deepAssign(
   platform,
   website,
   magazine,
+  email,
   {
     /**
      * Custom scalar types.

--- a/services/graphql-server/src/graphql/resolvers/magazine/index.js
+++ b/services/graphql-server/src/graphql/resolvers/magazine/index.js
@@ -2,10 +2,12 @@ const deepAssign = require('deep-assign');
 
 const issue = require('./issue');
 const publication = require('./publication');
+const schedule = require('./schedule');
 const section = require('./section');
 
 module.exports = deepAssign(
   issue,
   publication,
+  schedule,
   section,
 );

--- a/services/graphql-server/src/graphql/resolvers/magazine/index.js
+++ b/services/graphql-server/src/graphql/resolvers/magazine/index.js
@@ -2,8 +2,10 @@ const deepAssign = require('deep-assign');
 
 const issue = require('./issue');
 const publication = require('./publication');
+const section = require('./section');
 
 module.exports = deepAssign(
   issue,
   publication,
+  section,
 );

--- a/services/graphql-server/src/graphql/resolvers/magazine/issue.js
+++ b/services/graphql-server/src/graphql/resolvers/magazine/issue.js
@@ -1,7 +1,10 @@
+const { BaseDB } = require('@base-cms/db');
 const { magazineIssue: canonicalPathFor } = require('@base-cms/canonical-path');
 const { createTitle, createDescription } = require('../../utils/magazine-issue');
 const connectionProjection = require('../../utils/connection-projection');
 const shouldCollate = require('../../utils/should-collate');
+const applyInput = require('../../utils/apply-input');
+const formatStatus = require('../../utils/format-status');
 
 module.exports = {
   /**
@@ -13,6 +16,35 @@ module.exports = {
       title: () => createTitle(issue),
       description: () => createDescription(issue),
     }),
+
+    sections: async (issue, { input }, { basedb }, info) => {
+      const {
+        status,
+        sort,
+        pagination,
+        includeGlobal,
+      } = input;
+
+      const publicationId = BaseDB.extractRefId(issue.publication);
+
+      const $or = [{ 'issue.$id': issue._id }];
+      if (includeGlobal) $or.push({ 'publication.$id': publicationId });
+
+      const query = applyInput({
+        query: { ...formatStatus(status), $or },
+        input,
+      });
+
+      const projection = connectionProjection(info);
+      const result = await basedb.paginate('magazine.Section', {
+        query,
+        sort,
+        ...pagination,
+        collate: shouldCollate(sort.field),
+        projection,
+      });
+      return result;
+    },
   },
   /**
    *

--- a/services/graphql-server/src/graphql/resolvers/magazine/schedule.js
+++ b/services/graphql-server/src/graphql/resolvers/magazine/schedule.js
@@ -56,5 +56,15 @@ module.exports = {
       const projection = getProjection(schema, returnType, fieldNodes[0].selectionSet, fragments);
       return basedb.findOne('magazine.Schedule', { _id: id }, { projection });
     },
+
+    /**
+     *
+     */
+    deleteMagazineSchedule: async (_, { input }, { base4rest }) => {
+      const { id } = input;
+      validateRest(base4rest);
+      await base4rest.removeOne({ model: 'magazine/schedule', id });
+      return 'ok';
+    },
   },
 };

--- a/services/graphql-server/src/graphql/resolvers/magazine/schedule.js
+++ b/services/graphql-server/src/graphql/resolvers/magazine/schedule.js
@@ -1,0 +1,60 @@
+const { Base4RestPayload } = require('@base-cms/base4-rest-api');
+const { dasherize } = require('@base-cms/inflector');
+const { BaseDB, MongoDB } = require('@base-cms/db');
+
+const validateRest = require('../../utils/validate-rest');
+const getProjection = require('../../utils/get-projection');
+
+const { ObjectID } = MongoDB;
+
+module.exports = {
+  Mutation: {
+    /**
+     *
+     */
+    createMagazineSchedule: async (_, { input }, { basedb, base4rest }, info) => {
+      validateRest(base4rest);
+
+      const { contentId, issueId, sectionId } = input;
+
+      const [content, issue, section] = await Promise.all([
+        basedb.strictFindOne('platform.Content', { _id: contentId }, { projection: { type: 1 } }),
+        basedb.strictFindOne('magazine.Issue', { _id: issueId }, { projection: { publication: 1 } }),
+        basedb.strictFindOne('magazine.Section', { _id: sectionId }, { projection: { issue: 1, publication: 1 } }),
+      ]);
+
+      const publicationId = BaseDB.extractRefId(issue.publication);
+      if (!publicationId) throw new Error(`Unable to extract a publication ID for issue ${issue._id}.`);
+
+      const sectionPubId = BaseDB.extractRefId(section.publication);
+      const sectionIssueId = BaseDB.extractRefId(section.issue);
+
+      if (sectionPubId && `${sectionPubId}` !== `${publicationId}`) {
+        throw new Error('The section publication ID does not match the issue publication ID.');
+      }
+      if (sectionIssueId && `${sectionIssueId}` !== `${issue._id}`) {
+        throw new Error('The section issue ID does not match the issue ID.');
+      }
+
+      const body = new Base4RestPayload({ type: 'magazine/schedule' });
+      body
+        .set('status', 1)
+        .setLink('product', { id: publicationId, type: 'magazine/product/publication' })
+        .setLink('issue', { id: issue._id, type: 'magazine/issue' })
+        .setLink('section', { id: section._id, type: 'magazine/section' })
+        .setLink('content', { id: content._id, type: `platform/content/${dasherize(content.type)}` });
+
+      const response = await base4rest.insertOne({ model: 'magazine/schedule', body });
+      const id = ObjectID(response.data.id);
+
+      const {
+        fieldNodes,
+        returnType,
+        schema,
+        fragments,
+      } = info;
+      const projection = getProjection(schema, returnType, fieldNodes[0].selectionSet, fragments);
+      return basedb.findOne('magazine.Schedule', { _id: id }, { projection });
+    },
+  },
+};

--- a/services/graphql-server/src/graphql/resolvers/magazine/section.js
+++ b/services/graphql-server/src/graphql/resolvers/magazine/section.js
@@ -1,0 +1,8 @@
+module.exports = {
+  /**
+   *
+   */
+  MagazineSection: {
+    isGlobal: ({ publication }) => Boolean(publication),
+  },
+};

--- a/services/graphql-server/src/graphql/resolvers/website/index.js
+++ b/services/graphql-server/src/graphql/resolvers/website/index.js
@@ -1,11 +1,13 @@
 const deepAssign = require('deep-assign');
 
 const inquirySubmission = require('./inquiry-submission');
+const schedule = require('./schedule');
 const section = require('./section');
 const site = require('./site');
 
 module.exports = deepAssign(
   inquirySubmission,
+  schedule,
   section,
   site,
 );

--- a/services/graphql-server/src/graphql/resolvers/website/schedule.js
+++ b/services/graphql-server/src/graphql/resolvers/website/schedule.js
@@ -57,7 +57,7 @@ module.exports = {
         fragments,
       } = info;
       const projection = getProjection(schema, schema.getType('WebsiteSchedule'), fieldNodes[0].selectionSet, fragments);
-      return basedb.find('website.Schedule', { _id: schedule._id }, { projection });
+      return basedb.strictFindOne('website.Schedule', { _id: schedule._id }, { projection });
     },
 
     /**

--- a/services/graphql-server/src/graphql/resolvers/website/schedule.js
+++ b/services/graphql-server/src/graphql/resolvers/website/schedule.js
@@ -1,0 +1,72 @@
+const { BaseDB, MongoDB } = require('@base-cms/db');
+const { Base4RestPayload } = require('@base-cms/base4-rest-api');
+const { dasherize } = require('@base-cms/inflector');
+
+const validateRest = require('../../utils/validate-rest');
+const getProjection = require('../../utils/get-projection');
+
+const { ObjectID } = MongoDB;
+
+module.exports = {
+  /**
+   *
+   */
+  Mutation: {
+    /**
+     *
+     */
+    deleteWebsiteSchedule: async (_, { input }, { base4rest }) => {
+      const { id } = input;
+      validateRest(base4rest);
+      await base4rest.removeOne({ model: 'website/schedule', id });
+      return 'ok';
+    },
+
+    /**
+     *
+     */
+    quickCreateWebsiteSchedules: async (_, { input }, { basedb, base4rest, load }, info) => {
+      validateRest(base4rest);
+
+      const { contentId, sectionIds } = input;
+      const [content, sections] = await Promise.all([
+        load('platformContent', contentId, { status: 1, published: 1, type: 1 }),
+        basedb.find('website.Section', { _id: { $in: sectionIds } }, { projection: { site: 1 } }),
+      ]);
+
+      const startDate = content.status === 1 && content.published ? content.published : new Date();
+      const opts = new Map();
+      const bodies = await Promise.all(sections.map(async (section) => {
+        const siteId = BaseDB.extractRefId(section.site);
+        if (!siteId) throw new Error(`Unable to extract a site ID for section ${section._id}.`);
+
+        const option = opts.has(`${siteId}`)
+          ? opts.get(`${siteId}`)
+          : await basedb.strictFindOne('website.Option', { name: 'Standard', status: 1, 'site.$id': siteId }, { projection: { _id: 1 } });
+        opts.set(`${siteId}`, option);
+
+        const payload = new Base4RestPayload({ type: 'website/schedule' });
+        payload
+          .set('startDate', startDate)
+          .set('status', 1)
+          .setLink('product', { id: siteId, type: 'website/product/site' })
+          .setLink('section', { id: section._id, type: 'website/section' })
+          .setLink('option', { id: option._id, type: 'website/option' })
+          .setLink('content', { id: content._id, type: `platform/content/${dasherize(content.type)}` });
+
+        return payload;
+      }));
+
+      const responses = await base4rest.insertMany({ model: 'website/schedule', bodies });
+      const ids = responses.map(({ data }) => ObjectID(data.id));
+
+      const {
+        fieldNodes,
+        schema,
+        fragments,
+      } = info;
+      const projection = getProjection(schema, schema.getType('Content'), fieldNodes[0].selectionSet, fragments);
+      return basedb.find('website.Schedule', { _id: { $in: ids } }, { projection });
+    },
+  },
+};

--- a/services/graphql-server/src/graphql/resolvers/website/schedule.js
+++ b/services/graphql-server/src/graphql/resolvers/website/schedule.js
@@ -125,7 +125,7 @@ module.exports = {
         schema,
         fragments,
       } = info;
-      const projection = getProjection(schema, schema.getType('Content'), fieldNodes[0].selectionSet, fragments);
+      const projection = getProjection(schema, schema.getType('WebsiteSchedule'), fieldNodes[0].selectionSet, fragments);
       return basedb.find('website.Schedule', { _id: { $in: ids } }, { projection });
     },
   },

--- a/services/graphql-server/src/graphql/resolvers/website/schedule.js
+++ b/services/graphql-server/src/graphql/resolvers/website/schedule.js
@@ -8,6 +8,13 @@ const getProjection = require('../../utils/get-projection');
 
 const { ObjectID } = MongoDB;
 
+const clearSeconds = (date) => {
+  if (date) {
+    date.setSeconds(0);
+    date.setMilliseconds(0);
+  }
+};
+
 module.exports = {
   /**
    *
@@ -31,6 +38,11 @@ module.exports = {
       if (endDate && endDate.valueOf() < startDate.valueOf()) {
         throw new UserInputError('The end date cannot be before the start date.');
       }
+
+      // Ensure seconds and milliseconds are set to 0.
+      clearSeconds(startDate);
+      if (endDate) clearSeconds(endDate);
+
       const sectionSiteId = BaseDB.extractRefId(section.site);
       if (!sectionSiteId) throw new Error(`Unable to extract a site ID for section ${section._id}.`);
 

--- a/services/graphql-server/src/graphql/resolvers/website/site.js
+++ b/services/graphql-server/src/graphql/resolvers/website/site.js
@@ -24,6 +24,10 @@ module.exports = {
     assetHost: ({ assetHost }) => assetHost || defaults.assetHost,
     language: ({ language }) => ({ ...defaults.language, ...language }),
     date: ({ date }) => ({ ...defaults.date, ...date }),
+    title: ({ name, shortName }) => {
+      if (shortName) return `${name} (${shortName})`;
+      return name;
+    },
   },
 
   /**

--- a/services/graphql-server/src/graphql/utils/validate-rest.js
+++ b/services/graphql-server/src/graphql/utils/validate-rest.js
@@ -1,0 +1,3 @@
+module.exports = (rest) => {
+  if (!rest) throw new Error('This operation requires a valid Base4 REST API context.');
+};

--- a/services/graphql-server/src/routes/graphql.js
+++ b/services/graphql-server/src/routes/graphql.js
@@ -41,6 +41,7 @@ const server = new ApolloServer({
     const site = await loadSiteContext({ siteId, basedb, tenant });
 
     return {
+      tenant,
       basedb,
       site,
       load: async (loader, id, projection, criteria = {}) => {


### PR DESCRIPTION
Adds website, magazine, and email schedule mutations. These mutations utilize the Base4/Modlr REST API via the newly created `base4-rest-api` package.

The REST API client can be accessed via the GraphQL context, when all of the following conditions are true:
- An `x-base4-api-hostname` header is present in the GraphQL request (e.g. `foo.bar.com`)
- And both the `BASE4_REST_USERNAME` and `BASE4_REST_PASSWORD` env vars are set on the running `graphql-server` instance

While the Base4 API client _is_ required for running these mutations, it is _NOT_ required for normal use of the API.

Additionally, this PR adds:
- allowing a `limit: 0` value to be set for all pagination-based queries
- `insertOne` and `deleteMany` methods to the `db` client

Complete list of added GraphQL operations:
- Queries
  - `emailSchedule`
  - `contentEmailSchedules`
  - `magazineSchedule`
  - `contentMagazineSchedules`
  - `websiteSchedule`
  - `contentWebsiteSchedules`
- Mutations
  - `quickCreateEmailSchedules`
  - `updateEmailSchedule`
  - `deleteEmailSchedule`
  - `createMagazineSchedule`
  - `updateMagazineSchedule`
  - `deleteMagazineSchedule`
  - `quickCreateWebsiteSchedules`
  - `updateWebsiteSchedule`
  - `deleteWebsiteSchedule`