### PR TITLE
Use Base4 API `uri` value instead of hostname

### DIFF
--- a/packages/base4-rest-api/src/client.js
+++ b/packages/base4-rest-api/src/client.js
@@ -9,14 +9,14 @@ const { isArray } = Array;
 
 class Base4RestApiClient {
   constructor({
-    hostname,
+    uri,
     username,
     password,
     baseEndpoint = '/api/2.0rcpi',
     options,
   } = {}) {
-    if (!hostname || !username || !password) throw new Error('A hostname, username, and password are required for the Base REST API.');
-    this.hostname = hostname.replace('http://', '').replace('https://', '').replace(/\/+$/, '');
+    if (!uri || !username || !password) throw new Error('A uri, username, and password are required for the Base REST API.');
+    this.uri = uri.replace(/\/+$/, '');
     this.username = username;
     this.password = password;
     this.baseEndpoint = baseEndpoint;
@@ -163,7 +163,7 @@ class Base4RestApiClient {
   buildUrl({ type, endpoint } = {}) {
     if (!['persistence', 'search'].includes(type)) throw new Error(`The API resource type '${type}' is not supported.`);
     if (!endpoint) throw new Error('An API endpoint is required.');
-    return `https://${this.hostname}/${cleanPath(this.baseEndpoint)}/${type}/${cleanPath(endpoint)}`;
+    return `${this.uri}/${cleanPath(this.baseEndpoint)}/${type}/${cleanPath(endpoint)}`;
   }
 
   buildOptionHeaders() {

--- a/services/graphql-server/src/create-rest-client.js
+++ b/services/graphql-server/src/create-rest-client.js
@@ -1,14 +1,14 @@
 const { Base4RestApiClient } = require('@base-cms/base4-rest-api');
 const { BASE4_REST_USERNAME: username, BASE4_REST_PASSWORD: password } = require('./env');
 
-module.exports = ({ hostname, options } = {}) => {
-  if (!hostname) return undefined;
+module.exports = ({ uri, options } = {}) => {
+  if (!uri) return undefined;
 
   if (!username || !password) {
     throw new Error('The Base4 REST API username and password env variables are required!');
   }
   return new Base4RestApiClient({
-    hostname,
+    uri,
     username,
     password,
     options,

--- a/services/graphql-server/src/routes/graphql.js
+++ b/services/graphql-server/src/routes/graphql.js
@@ -47,7 +47,7 @@ const server = new ApolloServer({
 
     // Load the (optional) Base4 REST API client.
     // Some GraphQL mutations require this.
-    const base4rest = createBaseRestClient({ hostname: req.get('x-base4-api-hostname') });
+    const base4rest = createBaseRestClient({ uri: req.get('x-base4-api-uri') });
 
     return {
       tenant,


### PR DESCRIPTION
The Base4 REST API client now requires a uri parameter (e.g. `https://foo.com`) instead of a hostname. As such, the GraphQL context header was changed from `x-base4-api-hostname` to `x-base4-api-uri`.

This was implemented in order to accomodate dev environments where `https` isn’t always available.