### PR TITLE
Update canonicalPath references to siteContext.path

### DIFF
--- a/packages/db/src/utils/index.js
+++ b/packages/db/src/utils/index.js
@@ -1,0 +1,3 @@
+const iterateCursor = require('./iterate-cursor');
+
+module.exports = { iterateCursor };

--- a/packages/db/src/utils/iterate-cursor.js
+++ b/packages/db/src/utils/iterate-cursor.js
@@ -1,0 +1,15 @@
+/**
+ * Iterates over a MongoDB cursor, allowing an awaitable callback function.
+ *
+ * @param {Cursor} cursor The MongoDB cursor object.
+ * @param {function} cb The function to call on each document. Can be async.
+ */
+const iterateCursor = async (cursor, cb) => {
+  if (await cursor.hasNext()) {
+    const doc = await cursor.next();
+    await cb(doc);
+    await iterateCursor(cursor, cb);
+  }
+};
+
+module.exports = iterateCursor;

--- a/packages/db/utils.js
+++ b/packages/db/utils.js
@@ -1,0 +1,1 @@
+module.exports = require('./src/utils');

--- a/packages/marko-web-gtm/components/context/content.marko
+++ b/packages/marko-web-gtm/components/context/content.marko
@@ -11,7 +11,9 @@ fragment ContentContextFragment on Content {
   id
   type
   name
-  canonicalPath
+  siteContext {
+    path
+  }
   published
   createdBy {
     id

--- a/packages/marko-web-gtm/components/context/dynamic-page.marko
+++ b/packages/marko-web-gtm/components/context/dynamic-page.marko
@@ -11,7 +11,9 @@ fragment DynamicPageContextFragment on ContentPage {
   id
   name
   alias
-  canonicalPath
+  siteContext {
+    path
+  }
 }
 `;
 

--- a/packages/marko-web-gtm/context/content.js
+++ b/packages/marko-web-gtm/context/content.js
@@ -1,4 +1,4 @@
-const { getAsObject, getAsArray } = require('@base-cms/object-path');
+const { getAsObject, getAsArray, get } = require('@base-cms/object-path');
 const { asObject } = require('@base-cms/utils');
 
 module.exports = ({ obj }) => {
@@ -23,7 +23,7 @@ module.exports = ({ obj }) => {
   }));
   return {
     page_type: 'content',
-    canonical_path: content.canonicalPath,
+    canonical_path: get(content, 'siteContext.path'),
     content: {
       id: content.id,
       type: content.type,

--- a/packages/marko-web-gtm/context/dynamic-page.js
+++ b/packages/marko-web-gtm/context/dynamic-page.js
@@ -1,10 +1,11 @@
+const { get } = require('@base-cms/object-path');
 const { asObject } = require('@base-cms/utils');
 
 module.exports = ({ obj }) => {
   const page = asObject(obj);
   return {
     page_type: 'dynamic-page',
-    canonical_path: page.canonicalPath,
+    canonical_path: get(page, 'siteContext.path'),
     page: {
       id: page.id,
       name: page.name,

--- a/packages/marko-web-native-x/utils/convert-ad-to-content.js
+++ b/packages/marko-web-native-x/utils/convert-ad-to-content.js
@@ -8,7 +8,12 @@ module.exports = (ad = {}, { sectionName = 'Sponsored' } = {}) => {
     type: 'text-ad',
     teaser: creative.teaser,
     published: campaign.createdAt,
-    canonicalPath: ad.href,
+    canonicalPath: ad.href, // @deprecated. Use siteContext.path instead
+    siteContext: {
+      path: ad.href,
+      canonicalUrl: ad.href,
+      __typename: 'ContentSiteContext',
+    },
     primaryImage: {
       id: image.id,
       alt: creative.title,

--- a/packages/marko-web/components/element/object-link.js
+++ b/packages/marko-web/components/element/object-link.js
@@ -1,7 +1,12 @@
 const { isObject } = require('@base-cms/utils');
 const { get } = require('@base-cms/object-path');
 
-const defaultHref = obj => get(obj, 'canonicalPath');
+/**
+ * Use `siteContext.path` first and then fallback to `canonicalPath`.
+ * Content uses the former, other models use the latter.
+ * This should be made consistent across all types at some point.
+ */
+const defaultHref = obj => get(obj, 'siteContext.path', get(obj, 'canonicalPath'));
 
 /**
  * Converts `marko-web-obj` link input into "standard" `marko-web-link` input.

--- a/packages/marko-web/components/page/metadata/content.marko
+++ b/packages/marko-web/components/page/metadata/content.marko
@@ -9,8 +9,10 @@ $ const queryFragment = gql`
 fragment ContentPageMetadataFragment on Content {
   id
   type
-  canonicalPath
-  canonicalUrl
+  siteContext {
+    path
+    canonicalUrl
+  }
   metadata {
     title
     description
@@ -31,8 +33,8 @@ fragment ContentPageMetadataFragment on Content {
       type: node.type,
       title: get(node, "metadata.title"),
       description: get(node, "metadata.description"),
-      canonicalPath: node.canonicalPath,
-      canonicalUrl: node.canonicalUrl,
+      canonicalPath: get(node, "siteContext.path"),
+      canonicalUrl: get(node, "siteContext.canonicalUrl"),
       imageSrc: get(node, "metadata.image.src"),
     };
     $ const publishedDate = get(node, "metadata.publishedDate");

--- a/packages/marko-web/components/page/metadata/dynamic-page.marko
+++ b/packages/marko-web/components/page/metadata/dynamic-page.marko
@@ -8,7 +8,10 @@ $ const { alias } = input;
 $ const queryFragment = gql`
 fragment DynamicPageMetadataFragment on ContentPage {
   id
-  canonicalPath
+  siteContext {
+    path
+    canonicalUrl
+  }
   metadata {
     title
     description
@@ -21,7 +24,7 @@ fragment DynamicPageMetadataFragment on ContentPage {
     $ const metadata = {
       title: get(node, "metadata.title"),
       description: get(node, "metadata.description"),
-      canonicalPath: node.canonicalPath,
+      canonicalPath: get(node, "siteContext.path"),
     };
     <common ...metadata />
     <meta property="og:type" content="website" />

--- a/packages/marko-web/middleware/with-content.js
+++ b/packages/marko-web/middleware/with-content.js
@@ -1,3 +1,4 @@
+const { get } = require('@base-cms/object-path');
 const { asyncRoute, isFunction: isFn } = require('@base-cms/utils');
 const { content: loader } = require('@base-cms/web-common/page-loaders');
 const { blockContent: queryFactory } = require('@base-cms/web-common/query-factories');
@@ -15,12 +16,13 @@ module.exports = ({
   const additionalInput = {};
   if (req.cookies['preview-mode']) additionalInput.status = 'any';
   const content = await loader(apollo, { id, additionalInput });
-  const { redirectTo, canonicalPath } = content;
+  const { redirectTo } = content;
+  const path = get(content, 'siteContext.path');
   if (redirectTo) {
     return res.redirect(301, redirectTo);
   }
-  if (redirectOnPathMismatch && canonicalPath !== req.path) {
-    return res.redirect(301, canonicalPath);
+  if (redirectOnPathMismatch && path !== req.path) {
+    return res.redirect(301, path);
   }
   const pageNode = new PageNode(apollo, {
     queryFactory,

--- a/packages/marko-web/middleware/with-dynamic-page.js
+++ b/packages/marko-web/middleware/with-dynamic-page.js
@@ -19,7 +19,6 @@ module.exports = ({
   if (redirectTo) {
     return res.redirect(301, redirectTo);
   }
-  // @todo change me
   if (redirectOnPathMismatch && path !== req.path) {
     return res.redirect(301, path);
   }

--- a/packages/marko-web/middleware/with-dynamic-page.js
+++ b/packages/marko-web/middleware/with-dynamic-page.js
@@ -1,3 +1,4 @@
+const { get } = require('@base-cms/object-path');
 const { asyncRoute, isFunction: isFn } = require('@base-cms/utils');
 const { dynamicPage: loader } = require('@base-cms/web-common/page-loaders');
 const { blockDynamicPage: queryFactory } = require('@base-cms/web-common/query-factories');
@@ -13,12 +14,14 @@ module.exports = ({
   const { apollo } = req;
 
   const page = await loader(apollo, { alias });
-  const { redirectTo, canonicalPath } = page;
+  const { redirectTo } = page;
+  const path = get(page, 'siteContext.path');
   if (redirectTo) {
     return res.redirect(301, redirectTo);
   }
-  if (redirectOnPathMismatch && canonicalPath !== req.path) {
-    return res.redirect(301, canonicalPath);
+  // @todo change me
+  if (redirectOnPathMismatch && path !== req.path) {
+    return res.redirect(301, path);
   }
   const pageNode = new PageNode(apollo, {
     queryFactory,

--- a/packages/web-common/src/gql/fragments/block-all-author-content.js
+++ b/packages/web-common/src/gql/fragments/block-all-author-content.js
@@ -5,7 +5,9 @@ module.exports = gql`
 fragment BlockAllAuthorContentFragment on Content {
   id
   type
-  canonicalPath
+  siteContext {
+    path
+  }
 }
 
 `;

--- a/packages/web-common/src/gql/fragments/block-all-company-content.js
+++ b/packages/web-common/src/gql/fragments/block-all-company-content.js
@@ -5,7 +5,9 @@ module.exports = gql`
 fragment BlockAllCompanyContentFragment on Content {
   id
   type
-  canonicalPath
+  siteContext {
+    path
+  }
 }
 
 `;

--- a/packages/web-common/src/gql/fragments/block-all-published-content.js
+++ b/packages/web-common/src/gql/fragments/block-all-published-content.js
@@ -5,7 +5,9 @@ module.exports = gql`
 fragment BlockAllPublishedContentFragment on Content {
   id
   type
-  canonicalPath
+  siteContext {
+    path
+  }
 }
 
 `;

--- a/packages/web-common/src/gql/fragments/block-magazine-scheduled-content.js
+++ b/packages/web-common/src/gql/fragments/block-magazine-scheduled-content.js
@@ -5,7 +5,9 @@ module.exports = gql`
 fragment BlockMagazineScheduledContentFragment on Content {
   id
   type
-  canonicalPath
+  siteContext {
+    path
+  }
 }
 
 `;

--- a/packages/web-common/src/gql/fragments/block-published-related-content.js
+++ b/packages/web-common/src/gql/fragments/block-published-related-content.js
@@ -5,7 +5,9 @@ module.exports = gql`
 fragment BlockPublishedRelatedContentFragment on Content {
   id
   type
-  canonicalPath
+  siteContext {
+    path
+  }
 }
 
 `;

--- a/packages/web-common/src/gql/fragments/block-website-scheduled-content.js
+++ b/packages/web-common/src/gql/fragments/block-website-scheduled-content.js
@@ -5,7 +5,9 @@ module.exports = gql`
 fragment BlockWebsiteScheduledContentFragment on Content {
   id
   type
-  canonicalPath
+  siteContext {
+    path
+  }
 }
 
 `;

--- a/packages/web-common/src/gql/fragments/with-content.js
+++ b/packages/web-common/src/gql/fragments/with-content.js
@@ -6,7 +6,9 @@ fragment WithContentFragment on Content {
   id
   type
   redirectTo
-  canonicalPath
+  siteContext {
+    path
+  }
 }
 
 `;

--- a/packages/web-common/src/gql/fragments/with-dynamic-page.js
+++ b/packages/web-common/src/gql/fragments/with-dynamic-page.js
@@ -6,7 +6,9 @@ fragment WithDynamicPageFragment on ContentPage {
   id
   alias
   redirectTo
-  canonicalPath
+  siteContext {
+    path
+  }
 }
 
 `;

--- a/services/example-website-bzb/server/api/fragments/content-list.js
+++ b/services/example-website-bzb/server/api/fragments/content-list.js
@@ -8,7 +8,9 @@ fragment WebsiteContentListFragment on Content {
   typeTitled: type(input: { format: titleize })
   shortName
   teaser(input: { maxLength: 500, useFallback: false, truncatedSuffix: "" })
-  canonicalPath
+  siteContext {
+    path
+  }
   published
   primarySection {
     id

--- a/services/example-website-bzb/server/api/fragments/content-page.js
+++ b/services/example-website-bzb/server/api/fragments/content-page.js
@@ -10,7 +10,9 @@ fragment ContentPageFragment on Content {
   company {
     id
     name
-    canonicalPath
+    siteContext {
+      path
+    }
   }
   primarySection {
     id
@@ -62,7 +64,9 @@ fragment ContentPageFragment on Content {
         node {
           id
           name
-          canonicalPath
+          siteContext {
+            path
+          }
         }
       }
     }
@@ -102,7 +106,9 @@ fragment ContentPageFragment on Content {
           id
           name
           type
-          canonicalPath
+          siteContext {
+            path
+          }
         }
       }
     }
@@ -112,7 +118,9 @@ fragment ContentPageFragment on Content {
           id
           name
           type
-          canonicalPath
+          siteContext {
+            path
+          }
         }
       }
     }
@@ -122,7 +130,9 @@ fragment ContentPageFragment on Content {
           id
           name
           type
-          canonicalPath
+          siteContext {
+            path
+          }
         }
       }
     }

--- a/services/example-website-bzb/server/components/nodes/content-list.marko
+++ b/services/example-website-bzb/server/components/nodes/content-list.marko
@@ -12,7 +12,7 @@ $ const primarySection = getAsObject(content, "primarySection");
       fluid=false
       ar="16:9"
       width=128
-      link={ href: content.canonicalPath }
+      link={ href: get(content, "siteContext.path") }
     />
   </if>
   <@body>

--- a/services/example-website-lfw/server/api/fragments/content-contact-us.js
+++ b/services/example-website-lfw/server/api/fragments/content-contact-us.js
@@ -6,7 +6,9 @@ fragment WebsiteContentContactUsFragment on Content {
   id
   type
   name
-  canonicalPath
+  siteContext {
+    path
+  }
   primaryImage {
     id
     src

--- a/services/example-website-lfw/server/api/fragments/content-list.js
+++ b/services/example-website-lfw/server/api/fragments/content-list.js
@@ -8,14 +8,18 @@ fragment WebsiteContentListFragment on Content {
   typeTitled: type(input: { format: titleize })
   shortName
   teaser(input: { maxLength: 500, useFallback: false, truncatedSuffix: "" })
-  canonicalPath
+  siteContext {
+    path
+  }
   published
   publishedDate(input: { format: "MMM Do, YYYY" })
   company {
     id
     type
     name
-    canonicalPath
+    siteContext {
+      path
+    }
   }
   primarySection {
     id
@@ -39,7 +43,9 @@ fragment WebsiteContentListFragment on Content {
           id
           name
           type
-          canonicalPath
+          siteContext {
+            path
+          }
         }
       }
     }

--- a/services/example-website-lfw/server/api/fragments/content-page.js
+++ b/services/example-website-lfw/server/api/fragments/content-page.js
@@ -10,7 +10,9 @@ fragment ContentPageFragment on Content {
   company {
     id
     name
-    canonicalPath
+    siteContext {
+      path
+    }
   }
   primarySection {
     id
@@ -58,7 +60,9 @@ fragment ContentPageFragment on Content {
         node {
           id
           name
-          canonicalPath
+          siteContext {
+            path
+          }
         }
       }
     }
@@ -98,7 +102,9 @@ fragment ContentPageFragment on Content {
           id
           name
           type
-          canonicalPath
+          siteContext {
+            path
+          }
         }
       }
     }
@@ -108,7 +114,9 @@ fragment ContentPageFragment on Content {
           id
           name
           type
-          canonicalPath
+          siteContext {
+            path
+          }
         }
       }
     }
@@ -118,7 +126,9 @@ fragment ContentPageFragment on Content {
           id
           name
           type
-          canonicalPath
+          siteContext {
+            path
+          }
         }
       }
     }

--- a/services/example-website-lfw/server/components/nodes/contact-us-list.marko
+++ b/services/example-website-lfw/server/components/nodes/contact-us-list.marko
@@ -1,4 +1,4 @@
-import { getAsObject } from "@base-cms/object-path";
+import { getAsObject, get } from "@base-cms/object-path";
 
 $ const content = getAsObject(input, "node");
 $ const primaryImage = getAsObject(content, "primaryImage");
@@ -10,7 +10,7 @@ $ const primaryImage = getAsObject(content, "primaryImage");
     fluid=false
     ar=null
     width=150
-    link={ href: content.canonicalPath }
+    link={ href: get(content, "siteContext.path") }
     use-placeholder=false
   />
   <@body>

--- a/services/example-website-lfw/server/components/nodes/content-card.marko
+++ b/services/example-website-lfw/server/components/nodes/content-card.marko
@@ -1,4 +1,4 @@
-import { getAsObject } from "@base-cms/object-path";
+import { getAsObject, get } from "@base-cms/object-path";
 
 $ const content = getAsObject(input, "node");
 $ const primaryImage = getAsObject(content, "primaryImage");
@@ -23,7 +23,7 @@ $ const { linkAttrs } = input;
       fluid=true
       ar="21:9"
       width=(input.imageWidth || 300)
-      link={ href: content.canonicalPath, attrs: linkAttrs }
+      link={ href: get(content, "siteContext.path"), attrs: linkAttrs }
     />
   </if>
   <@body>

--- a/services/example-website-lfw/server/components/nodes/content-list.marko
+++ b/services/example-website-lfw/server/components/nodes/content-list.marko
@@ -1,4 +1,4 @@
-import { getAsObject } from "@base-cms/object-path";
+import { getAsObject, get } from "@base-cms/object-path";
 
 $ const content = getAsObject(input, "node");
 $ const primaryImage = getAsObject(content, "primaryImage");
@@ -23,7 +23,7 @@ $ const { linkAttrs } = input;
       ar="1:1"
       width=75
       align="middle"
-      link={ href: content.canonicalPath, attrs: linkAttrs }
+      link={ href: get(content, "siteContext.path"), attrs: linkAttrs }
     />
   </if>
   <@body>

--- a/services/rss/src/api/content-fragment.js
+++ b/services/rss/src/api/content-fragment.js
@@ -6,7 +6,9 @@ fragment RSSItemContentFragment on Content {
   id
   name
   teaser(input: { useFallback: false, maxLength: null })
-  canonicalPath
+  siteContext {
+    url
+  }
   publishedDate(input: { format: "ddd, DD MMM YYYY HH:mm:ss ZZ" })
   primarySection {
     id

--- a/services/rss/src/utils/create-item.js
+++ b/services/rss/src/utils/create-item.js
@@ -4,15 +4,16 @@ const { getAsObject } = require('@base-cms/object-path');
 module.exports = ({
   name,
   teaser,
-  canonicalPath,
+  siteContext,
   publishedDate,
   authors,
   primarySection,
 }, website) => {
+  const { url } = siteContext;
   const parts = [
     `<title>${xml.encode(name)}</title>`,
-    `<link>${website.origin}${canonicalPath}</link>`,
-    `<guid isPermaLink="true">${website.origin}${canonicalPath}</guid>`,
+    `<link>${url}</link>`,
+    `<guid isPermaLink="true">${url}</guid>`,
   ];
   if (teaser) parts.push(`<description>${xml.encode(teaser)}</description>`);
   if (publishedDate) parts.push(`<pubDate>${publishedDate}</pubDate>`);


### PR DESCRIPTION
Updates references to the `Content.canonicalPath` and `Content.canonicalUrl` fields (which are deprecated) and updates them to use `Content.siteContext.path` and `Content.siteContext.canonicalUrl` respectively. This was also handled for the `ContentPage` type.

Since `WebsiteSection`, `MagazineIssue` and other GraphQL types still use the `canonicalUrl` field, the core `object-link.js` utility still allows its use, but will attempt to load `siteContext.path` before trying `canonicalPath`.

The RSS service query fragments were also updated to reflect this change, as well as common middlewares and fragments. GTM context fragments were also adjusted, as well as the NativeX "convert ad to content" functionality.

It is **highly** recommended to update website references to this field when upgrading to this version.

In unrelated news, a _working_ `iterateCursor` utility was added to the `db` package. :)