### PR TITLE
Website section related taxonomy

### DIFF
--- a/packages/marko-core/components/queries/index.marko
+++ b/packages/marko-core/components/queries/index.marko
@@ -14,6 +14,7 @@ import RelatedPublishedContent from "./related-published-content";
 import WebsiteOptionedContent from "./website-optioned-content";
 import WebsiteScheduledContent from "./website-scheduled-content";
 import WebsiteSection from "./website-section";
+import WebsiteSections from "./website-sections";
 import shouldCollapse from "../../utils/should-collapse";
 
 $ const map = {
@@ -33,6 +34,7 @@ $ const map = {
   "website-optioned-content": WebsiteOptionedContent,
   "website-scheduled-content": WebsiteScheduledContent,
   "website-section": WebsiteSection,
+  "website-sections": WebsiteSections,
 };
 $ const name = input.name;
 $ const collapsible = shouldCollapse(input.collapsible);

--- a/packages/marko-core/components/queries/marko.json
+++ b/packages/marko-core/components/queries/marko.json
@@ -45,6 +45,9 @@
   "<marko-web-query-website-section>": {
     "template": "./website-section.marko"
   },
+  "<marko-web-query-website-sections>": {
+    "template": "./website-sections.marko"
+  },
   "<marko-web-query-dynamic-page>": {
     "template": "./dynamic-page.marko"
   },

--- a/packages/marko-core/components/queries/website-sections.marko
+++ b/packages/marko-core/components/queries/website-sections.marko
@@ -1,0 +1,3 @@
+import { websiteSections as loader } from "@base-cms/web-common/block-loaders";
+
+<loader loader=loader ...input />

--- a/packages/web-common/src/block-loaders/index.js
+++ b/packages/web-common/src/block-loaders/index.js
@@ -14,6 +14,7 @@ const allAuthorContent = require('./all-author-content');
 const allCompanyContent = require('./all-company-content');
 const websiteOptionedContent = require('./website-optioned-content');
 const websiteSection = require('./website-section');
+const websiteSections = require('./website-sections');
 
 module.exports = {
   content,
@@ -32,4 +33,5 @@ module.exports = {
   allCompanyContent,
   websiteOptionedContent,
   websiteSection,
+  websiteSections,
 };

--- a/packages/web-common/src/block-loaders/website-sections.js
+++ b/packages/web-common/src/block-loaders/website-sections.js
@@ -1,0 +1,31 @@
+const buildQuery = require('../gql/query-factories/block-website-sections');
+
+/**
+ * @param {ApolloClient} apolloClient The Apollo GraphQL client that will perform the query.
+ * @param {object} params
+ * @param {string} [params.status] The section status to query.
+ * @param {number[]} [params.taxonomyIds] The section 'relatedTaxonomy.$id' values to query.
+ * @param {object} sort The sort clause to apply ({ sortField, sortValue })
+ * @param {string} [params.queryName] An optional name to append to the query.
+ * @param {string} [params.queryFragment] The `graphql-tag` fragment
+ *                                        to apply to the `websiteSections` query.
+ */
+module.exports = async (apolloClient, {
+  status,
+  taxonomyIds,
+  queryName,
+  queryFragment,
+  sort,
+} = {}) => {
+  const query = buildQuery({ queryFragment, queryName });
+  const input = { status, sort, taxonomyIds };
+  const variables = { input };
+
+  const { data } = await apolloClient.query({ query, variables });
+  if (!data || !data.websiteSections) return { nodes: [], pageInfo: {} };
+  const { pageInfo } = data.websiteSections;
+  const nodes = data.websiteSections.edges
+    .map(edge => (edge && edge.node ? edge.node : null))
+    .filter(c => c);
+  return { nodes, pageInfo };
+};

--- a/packages/web-common/src/gql/fragments/block-website-sections.js
+++ b/packages/web-common/src/gql/fragments/block-website-sections.js
@@ -1,0 +1,11 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment BlockWebsiteSectionsFragment on WebsiteSection {
+  id
+  alias
+  name
+}
+
+`;

--- a/packages/web-common/src/gql/query-factories/block-website-sections.js
+++ b/packages/web-common/src/gql/query-factories/block-website-sections.js
@@ -12,7 +12,7 @@ const { extractFragmentData } = require('../../utils');
 module.exports = ({ queryFragment, queryName = '' } = {}) => {
   const { spreadFragmentName, processedFragment } = extractFragmentData(queryFragment);
   return gql`
-    query BlockWebsiteSections${queryName}($input: WebsiteSectionsQueryInput!) {
+    query BlockWebsiteSections${queryName}($input: WebsiteSectionsQueryInput = {}) {
       websiteSections(input: $input) {
         edges {
           node {

--- a/packages/web-common/src/gql/query-factories/block-website-sections.js
+++ b/packages/web-common/src/gql/query-factories/block-website-sections.js
@@ -1,0 +1,32 @@
+const gql = require('graphql-tag');
+const defaultFragment = require('../fragments/block-website-sections');
+const { extractFragmentData } = require('../../utils');
+
+/**
+ * Builds the `BlockWebsiteSections` GraphQL operation.
+ *
+ * @param {object} params
+ * @param {string} [params.queryFragment] The `graphql-tag` fragment
+ *                                        to apply to the `websiteSections` query.
+ */
+module.exports = ({ queryFragment, queryName = '' } = {}) => {
+  const { spreadFragmentName, processedFragment } = extractFragmentData(queryFragment);
+  return gql`
+    query BlockWebsiteSections${queryName}($input: WebsiteSectionsQueryInput!) {
+      websiteSections(input: $input) {
+        edges {
+          node {
+            ...BlockWebsiteSectionsFragment
+            ${spreadFragmentName}
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+    ${defaultFragment}
+    ${processedFragment}
+  `;
+};

--- a/packages/web-common/src/gql/query-factories/index.js
+++ b/packages/web-common/src/gql/query-factories/index.js
@@ -2,6 +2,7 @@ const blockContent = require('./block-content');
 const blockDynamicPage = require('./block-dynamic-page');
 const blockWebsiteScheduledContent = require('./block-website-scheduled-content');
 const blockWebsiteSection = require('./block-website-section');
+const blockWebsiteSections = require('./block-website-sections');
 const blockMagazineIssue = require('./block-magazine-issue');
 const blockMagazinePublication = require('./block-magazine-publication');
 const blockMagazinePublications = require('./block-magazine-publications');
@@ -25,6 +26,7 @@ module.exports = {
   blockDynamicPage,
   blockWebsiteScheduledContent,
   blockWebsiteSection,
+  blockWebsiteSections,
   blockMagazineIssue,
   blockMagazinePublication,
   blockMagazinePublications,

--- a/services/graphql-server/src/graphql/definitions/website/section.js
+++ b/services/graphql-server/src/graphql/definitions/website/section.js
@@ -33,6 +33,11 @@ extend type Query {
     using: { ids: "_id" }
   )
   websiteSectionSitemapUrls(input: WebsiteSectionSitemapUrlsQueryInput = {}): [WebsiteSectionSitemapUrl!]!
+  websiteSectionsFromRelatedTaxonomy(input: WebsiteSectionsFromRelatedTaxonomyQueryInput!): WebsiteSectionConnection! @findMany(
+    model: "website.Section",
+    withSite: true,
+    using: { taxonomyIds: "relatedTaxonomy.$id" }
+  )
 }
 
 type WebsiteSection {
@@ -143,6 +148,13 @@ input RootWebsiteSectionsQueryInput {
 input WebsiteSectionsFromIdsQueryInput {
   siteId: ObjectID
   ids: [Int!]
+  sort: WebsiteSectionSortInput = {}
+  pagination: PaginationInput = {}
+}
+
+input WebsiteSectionsFromRelatedTaxonomyQueryInput {
+  siteId: ObjectID
+  taxonomyIds: [Int!]
   sort: WebsiteSectionSortInput = {}
   pagination: PaginationInput = {}
 }

--- a/services/graphql-server/src/graphql/definitions/website/section.js
+++ b/services/graphql-server/src/graphql/definitions/website/section.js
@@ -20,7 +20,8 @@ extend type Query {
   )
   websiteSections(input: WebsiteSectionsQueryInput = {}): WebsiteSectionConnection! @findMany(
     model: "website.Section",
-    withSite: true
+    withSite: true,
+    using: { taxonomyIds: "relatedTaxonomy.$id" },
   )
   rootWebsiteSections(input: RootWebsiteSectionsQueryInput = {}): WebsiteSectionConnection! @findMany(
     model: "website.Section",
@@ -33,11 +34,6 @@ extend type Query {
     using: { ids: "_id" }
   )
   websiteSectionSitemapUrls(input: WebsiteSectionSitemapUrlsQueryInput = {}): [WebsiteSectionSitemapUrl!]!
-  websiteSectionsFromRelatedTaxonomy(input: WebsiteSectionsFromRelatedTaxonomyQueryInput!): WebsiteSectionConnection! @findMany(
-    model: "website.Section",
-    withSite: true,
-    using: { taxonomyIds: "relatedTaxonomy.$id" }
-  )
 }
 
 type WebsiteSection {
@@ -133,6 +129,7 @@ input WebsiteSectionRedirectQueryInput {
 
 input WebsiteSectionsQueryInput {
   siteId: ObjectID
+  taxonomyIds: [Int!] # filter against relatedTaxonomy.$id
   status: ModelStatus = active
   sort: WebsiteSectionSortInput = {}
   pagination: PaginationInput = {}
@@ -148,13 +145,6 @@ input RootWebsiteSectionsQueryInput {
 input WebsiteSectionsFromIdsQueryInput {
   siteId: ObjectID
   ids: [Int!]
-  sort: WebsiteSectionSortInput = {}
-  pagination: PaginationInput = {}
-}
-
-input WebsiteSectionsFromRelatedTaxonomyQueryInput {
-  siteId: ObjectID
-  taxonomyIds: [Int!]
   sort: WebsiteSectionSortInput = {}
   pagination: PaginationInput = {}
 }


### PR DESCRIPTION
- [GraphQL] Adds support for querying website Section models using the `relatedTaxonomy` field.
- [Web Common] Adds support for querying multiple website sections
- [Marko Core] Adds marko-web-query component utilizing `website-sections` query.