### PR TITLE
Add excludeContentTypes and deprecate contentTypes

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -256,7 +256,9 @@ input AllPublishedContentQueryInput {
   siteId: ObjectID
   since: Date
   sectionId: Int
-  contentTypes: [ContentType!] = []
+  contentTypes: [ContentType!] = [] @deprecated(reason: "Use \`AllPublishedContentQueryInput.includeContentTypes\` instead.")
+  includeContentTypes: [ContentType!] = []
+  excludeContentTypes: [ContentType!] = []
   requiresImage: Boolean = false
   sectionBubbling: Boolean = true
   sort: ContentSortInput = { field: published, order: desc }

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -535,7 +535,9 @@ module.exports = {
       const {
         since,
         sectionId,
-        contentTypes,
+        contentTypes: deprecatedContentTypes,
+        includeContentTypes,
+        excludeContentTypes,
         requiresImage,
         sectionBubbling,
         sort,
@@ -544,7 +546,10 @@ module.exports = {
         ending,
       } = input;
 
-      const query = getPublishedCriteria({ since, contentTypes });
+      // @deprecated Prefer includeContentTypes over contentTypes.
+      const contentTypes = includeContentTypes.length
+        ? includeContentTypes : deprecatedContentTypes;
+      const query = getPublishedCriteria({ since, contentTypes, excludeContentTypes });
 
       const siteId = input.siteId || site.id();
       if (siteId) query['mutations.Website.primarySite'] = siteId;


### PR DESCRIPTION
Add `AllPublishedContentQueryInput.excludeContentTypes` and deprecate `AllPublishedContentQueryInput.contentTypes` in preference of `includeContentTypes`.