### PR TITLE
Move deprecated input to comment

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -256,7 +256,8 @@ input AllPublishedContentQueryInput {
   siteId: ObjectID
   since: Date
   sectionId: Int
-  contentTypes: [ContentType!] = [] @deprecated(reason: "Use \`AllPublishedContentQueryInput.includeContentTypes\` instead.")
+  # @deprecated. Use \`AllPublishedContentQueryInput.includeContentTypes\` instead.
+  contentTypes: [ContentType!] = []
   includeContentTypes: [ContentType!] = []
   excludeContentTypes: [ContentType!] = []
   requiresImage: Boolean = false


### PR DESCRIPTION
Currently, the GraphQL spec does not support deprecation on input fields, though it is supposedly forthcoming.