### PR TITLE
Add `Taxonomy.hierarchy` field

### DIFF
--- a/multi-site.md
+++ b/multi-site.md
@@ -1,6 +1,7 @@
 # Content Mange
 
 ## Punch List
+- [ ] Ensure _all_ base-cms services boot as a part of testing
 - [ ] Update _all_ post import scripts to support multi-site
 - [ ] All sites/services should boot and return a 200 when testing
 - [ ] Use relative imgix component for site logos

--- a/services/graphql-server/src/graphql/definitions/platform/taxonomy.js
+++ b/services/graphql-server/src/graphql/definitions/platform/taxonomy.js
@@ -28,6 +28,10 @@ type Taxonomy {
   urlPath: String
     @projection(localField: "mutations.Website.urlPath")
     @value(localField: "mutations.Website.urlPath")
+
+  # GraphQL-only fields.
+  # Retrieves the flattened (parent) hierarchy for this taxonomy.
+  hierarchy: [Taxonomy!]! @projection(localField: "parent")
 }
 
 type TaxonomyConnection @projectUsing(type: "Taxonomy") {

--- a/services/graphql-server/src/graphql/resolvers/platform/index.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/index.js
@@ -2,8 +2,10 @@ const deepAssign = require('deep-assign');
 
 const asset = require('./asset');
 const content = require('./content');
+const taxonomy = require('./taxonomy');
 
 module.exports = deepAssign(
   asset,
   content,
+  taxonomy,
 );

--- a/services/graphql-server/src/graphql/resolvers/platform/taxonomy.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/taxonomy.js
@@ -1,0 +1,39 @@
+const { BaseDB } = require('@base-cms/db');
+const getProjection = require('../../utils/get-projection');
+const getGraphType = require('../../utils/get-graph-type');
+
+const loadHierarchy = async (taxonomy, load, projection, taxonomies = []) => {
+  const ref = BaseDB.get(taxonomy, 'parent');
+  const parentId = BaseDB.extractRefId(ref);
+  if (!parentId) return taxonomies;
+  const parent = await load('platformTaxonomy', parentId, projection, { status: 1 });
+  if (!parent) return taxonomies;
+  taxonomies.push(parent);
+  return loadHierarchy(parent, load, projection, taxonomies);
+};
+
+module.exports = {
+  /**
+   *
+   */
+  Taxonomy: {
+    hierarchy: async (taxonomy, _, { load }, info) => {
+      const {
+        returnType,
+        fieldNodes,
+        schema,
+        fragments,
+      } = info;
+      const projection = getProjection(
+        schema,
+        getGraphType(returnType),
+        fieldNodes[0].selectionSet,
+        fragments,
+      );
+      projection.parent = 1;
+      const thisTaxonomy = await load('platformTaxonomy', taxonomy._id, projection, { status: 1 });
+      const taxonomies = await loadHierarchy(taxonomy, load, projection, [thisTaxonomy]);
+      return taxonomies.reverse();
+    },
+  },
+};


### PR DESCRIPTION
Returns the flattened, parent taxonomy list. Provides the same functionality as the `WebsiteSection.hierarchy` field.

```graphql
query {
  taxonomy(input: {
    id: 3119
  }) {
    id
    name
    hierarchy {
      id
      name
    }
  }
}
```

```json
{
  "data": {
    "taxonomy": {
      "id": 3119,
      "name": "Slurry Seal Equipment & Materials",
      "hierarchy": [
        {
          "id": 48919,
          "name": "Pavement Preservation & Maintenance"
        },
        {
          "id": 3119,
          "name": "Slurry Seal Equipment & Materials"
        }
      ]
    }
}
```