### PR TITLE
Create “smarter” taxonomies query

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/taxonomy.js
+++ b/services/graphql-server/src/graphql/definitions/platform/taxonomy.js
@@ -3,12 +3,22 @@ const gql = require('graphql-tag');
 module.exports = gql`
 
 extend type Query {
-  taxonomy(input: TaxonomyQueryInput!): Taxonomy @findOne(model: "platform.Taxonomy", using: { id: "_id" }, criteria: "taxonomy")
-  taxonomies(input: TaxonomiesQueryInput = {}): TaxonomyConnection! @findMany(model: "platform.Taxonomy", criteria: "taxonomy")
-  taxonomiesOfType(input: TaxonomiesOfTypeQueryInput!): TaxonomyConnection! @findMany(model: "platform.Taxonomy", using: { type: "type" })
-  rootTaxonomies(input: RootTaxonomiesQueryInput = {}): TaxonomyConnection! @findMany(model: "platform.Taxonomy", criteria: "rootTaxonomies")
-  rootTaxonomiesOfType(input: RootTaxonomiesOfTypeQueryInput!): TaxonomyConnection! @findMany(model: "platform.Taxonomy", using: { type: "type" }, criteria: "rootTaxonomiesOfType")
-  matchTaxonomies(input: MatchTaxonomiesQueryInput!): TaxonomyConnection! @matchMany(model: "platform.Taxonomy", criteria: "taxonomy")
+  taxonomy(input: TaxonomyQueryInput!): Taxonomy
+    @findOne(model: "platform.Taxonomy", using: { id: "_id" }, criteria: "taxonomy")
+
+  taxonomies(input: TaxonomiesQueryInput = {}): TaxonomyConnection!
+
+  taxonomiesOfType(input: TaxonomiesOfTypeQueryInput!): TaxonomyConnection!
+    @findMany(model: "platform.Taxonomy", using: { type: "type" })
+
+  rootTaxonomies(input: RootTaxonomiesQueryInput = {}): TaxonomyConnection!
+    @findMany(model: "platform.Taxonomy", criteria: "rootTaxonomies")
+
+  rootTaxonomiesOfType(input: RootTaxonomiesOfTypeQueryInput!): TaxonomyConnection!
+    @findMany(model: "platform.Taxonomy", using: { type: "type" }, criteria: "rootTaxonomiesOfType")
+
+  matchTaxonomies(input: MatchTaxonomiesQueryInput!): TaxonomyConnection!
+    @matchMany(model: "platform.Taxonomy", criteria: "taxonomy")
 }
 
 type Taxonomy {
@@ -81,6 +91,11 @@ input TaxonomyQueryInput {
 }
 
 input TaxonomiesQueryInput {
+  includeIds: [Int!] = []
+  excludeIds: [Int!] = []
+  includeTypes: [TaxonomyType!] = []
+  excludeTypes: [TaxonomyType!] = []
+  rootOnly: Boolean = false
   status: ModelStatus = active
   sort: TaxonomySortInput = {}
   pagination: PaginationInput = {}

--- a/services/graphql-server/src/graphql/resolvers/platform/taxonomy.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/taxonomy.js
@@ -1,6 +1,12 @@
 const { BaseDB } = require('@base-cms/db');
+
 const getProjection = require('../../utils/get-projection');
 const getGraphType = require('../../utils/get-graph-type');
+const criteriaFor = require('../../utils/criteria-for');
+const applyInput = require('../../utils/apply-input');
+const formatStatus = require('../../utils/format-status');
+const connectionProjection = require('../../utils/connection-projection');
+const shouldCollate = require('../../utils/should-collate');
 
 const loadHierarchy = async (taxonomy, load, projection, taxonomies = []) => {
   const ref = BaseDB.get(taxonomy, 'parent');
@@ -34,6 +40,48 @@ module.exports = {
       const thisTaxonomy = await load('platformTaxonomy', taxonomy._id, projection, { status: 1 });
       const taxonomies = await loadHierarchy(taxonomy, load, projection, [thisTaxonomy]);
       return taxonomies.reverse();
+    },
+  },
+
+  /**
+   *
+   */
+  Query: {
+    taxonomies: async (_, { input }, { basedb }, info) => {
+      const {
+        includeIds,
+        excludeIds,
+        includeTypes,
+        excludeTypes,
+        rootOnly,
+        status,
+        sort,
+        pagination,
+      } = input;
+
+      const query = applyInput({
+        query: { ...criteriaFor('taxonomy'), ...formatStatus(status) },
+        input,
+      });
+
+      if (includeTypes.length) query.type.$in = includeTypes;
+      if (excludeTypes.length) query.type.$nin = excludeTypes;
+      if (rootOnly) query['parent.$id'] = { $exists: false };
+      if (includeIds.length || excludeIds.length) {
+        query._id = {};
+        if (includeIds.length) query._id.$in = includeIds;
+        if (excludeIds.length) query._id.$nin = excludeIds;
+      }
+
+      const projection = connectionProjection(info);
+      const result = await basedb.paginate('platform.Taxonomy', {
+        query,
+        sort,
+        projection,
+        collate: shouldCollate(sort.field),
+        ...pagination,
+      });
+      return result;
     },
   },
 };


### PR DESCRIPTION
Adjusts the `TaxonomiesQueryInput` definition to include more filterability via include/exclude taxonomy ids, include/exclude types, and a `rootOnly` flag. This essentially replaces the need for the `rootTaxonomies`, `taxonomiesOfType`, and `rootTaxonomiesOfType` queries. It also provides support for returning a set of taxonomies by a list of IDs.

The new input is as follows:

```graphql
input TaxonomiesQueryInput {
  includeIds: [Int!] = []
  excludeIds: [Int!] = []
  includeTypes: [TaxonomyType!] = []
  excludeTypes: [TaxonomyType!] = []
  rootOnly: Boolean = false
  status: ModelStatus = active
  sort: TaxonomySortInput = {}
  pagination: PaginationInput = {}
}
```