### PR TITLE
Add suppression options to Taxonomy.fullName

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/taxonomy.js
+++ b/services/graphql-server/src/graphql/definitions/platform/taxonomy.js
@@ -24,7 +24,7 @@ extend type Query {
 type Taxonomy {
   id: Int! @projection(localField: "_id") @value(localField: "_id")
   name: String @projection
-  fullName: String @projection
+  fullName(input: TaxonomyFullNameInput = {}): String @projection
   description: String @projection
   type: String @projection
   status: Int @projection
@@ -83,6 +83,11 @@ enum TaxonomySortField {
 enum TaxonomyMatchField {
   name
   fullName
+}
+
+input TaxonomyFullNameInput {
+  suppressType: Boolean = false
+  suppressId: Boolean = false
 }
 
 input TaxonomyQueryInput {

--- a/services/graphql-server/src/graphql/resolvers/platform/taxonomy.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/taxonomy.js
@@ -23,6 +23,15 @@ module.exports = {
    *
    */
   Taxonomy: {
+    fullName: ({ fullName }, { input }) => {
+      const { suppressType, suppressId } = input;
+      if (!fullName) return fullName;
+      let name = fullName;
+      if (suppressType) name = name.replace(/^[a-z]+?:\s/i, '');
+      if (suppressId) name = name.replace(/\s\([0-9]+?\)$/i, '');
+      return name;
+    },
+
     hierarchy: async (taxonomy, _, { load }, info) => {
       const {
         returnType,


### PR DESCRIPTION
Can suppress the taxonomy type and/or ID from the full name using the following input:

```graphql
input TaxonomyFullNameInput {
  suppressType: Boolean = false
  suppressId: Boolean = false
}
```