### PR TITLE
Add directive query builders and enhance websiteSections query

### DIFF
--- a/services/graphql-server/src/graphql/definitions/index.js
+++ b/services/graphql-server/src/graphql/definitions/index.js
@@ -12,7 +12,14 @@ scalar ObjectID
 
 directive @applyInterfaceFields on OBJECT
 directive @arrayValue(localField: String) on FIELD_DEFINITION
-directive @findMany(model: String!, using: JSON, withSite: Boolean = false, siteField: String = "site.$id", criteria: String) on FIELD_DEFINITION
+directive @findMany(
+  model: String!, # The model name to query, e.g. platform.Content or website.Schedule
+  using: JSON, # A query input-to-document map. The key represents the input and the key represents to doc field to apply the input value to.
+  withSite: Boolean = false, # when true, will apply the siteId context (if present) to the query
+  siteField: String = "site.$id", # the document field to apply the siteId to
+  criteria: String # A query criteria key name to apply. If present in utils/criteria-for.js, will apply the criteria found to the query.
+  queryBuilder: String # A query builder key. If present in query-builders/index.js, will invoke the function which must return a query object.
+) on FIELD_DEFINITION
 directive @findOne(model: String!, using: JSON, withSite: Boolean = false, siteField: String = "site.$id", criteria: String) on FIELD_DEFINITION
 directive @matchMany(model: String!, using: JSON, withSite: Boolean = false, siteField: String = "site.$id", criteria: String) on FIELD_DEFINITION
 directive @momentFormat(localField: String) on FIELD_DEFINITION

--- a/services/graphql-server/src/graphql/definitions/index.js
+++ b/services/graphql-server/src/graphql/definitions/index.js
@@ -12,15 +12,25 @@ scalar ObjectID
 
 directive @applyInterfaceFields on OBJECT
 directive @arrayValue(localField: String) on FIELD_DEFINITION
+
 directive @findMany(
-  model: String!, # The model name to query, e.g. platform.Content or website.Schedule
-  using: JSON, # A query input-to-document map. The key represents the input and the key represents to doc field to apply the input value to.
-  withSite: Boolean = false, # when true, will apply the siteId context (if present) to the query
-  siteField: String = "site.$id", # the document field to apply the siteId to
-  criteria: String # A query criteria key name to apply. If present in utils/criteria-for.js, will apply the criteria found to the query.
-  queryBuilder: String # A query builder key. If present in query-builders/index.js, will invoke the function which must return a query object.
+  model: String!, # The model name to query, e.g. platform.Content or website.Schedule.
+  using: JSON, # A query input-to-document map. The key represents the input and the value represents the doc field to apply the input value to.
+  withSite: Boolean = false, # When true, will apply the siteId context (if present) to the query.
+  siteField: String = "site.$id", # The document field to apply the siteId to.
+  criteria: String, # A query criteria key. If present in utils/criteria-for.js, will apply the criteria found to the query.
+  queryBuilder: String, # A query builder key. If present in query-builders/index.js, will invoke the function and return the modified query object.
 ) on FIELD_DEFINITION
-directive @findOne(model: String!, using: JSON, withSite: Boolean = false, siteField: String = "site.$id", criteria: String) on FIELD_DEFINITION
+
+directive @findOne(
+  model: String!,
+  using: JSON,
+  withSite: Boolean = false,
+  siteField: String = "site.$id",
+  criteria: String,
+  queryBuilder: String,
+) on FIELD_DEFINITION
+
 directive @matchMany(model: String!, using: JSON, withSite: Boolean = false, siteField: String = "site.$id", criteria: String) on FIELD_DEFINITION
 directive @momentFormat(localField: String) on FIELD_DEFINITION
 directive @mutatedValue(localField: String) on FIELD_DEFINITION

--- a/services/graphql-server/src/graphql/definitions/magazine/issue.js
+++ b/services/graphql-server/src/graphql/definitions/magazine/issue.js
@@ -4,8 +4,16 @@ module.exports = gql`
 
 extend type Query {
   magazineIssue(input: MagazineIssueQueryInput!): MagazineIssue @findOne(model: "magazine.Issue", using: { id: "_id" })
-  magazineIssues(input: MagazineIssuesQueryInput = {}): MagazineIssueConnection! @findMany(model: "magazine.Issue")
-  magazineActiveIssues(input: MagazineActiveIssuesQueryInput = {}): MagazineIssueConnection!
+  magazineIssues(input: MagazineIssuesQueryInput = {}): MagazineIssueConnection!
+    @findMany(model: "magazine.Issue")
+
+  magazineActiveIssues(input: MagazineActiveIssuesQueryInput!): MagazineIssueConnection!
+    @findMany(
+      model: "magazine.Issue",
+      queryBuilder: "magazineActiveIssues",
+    )
+
+
   magazineLatestIssue(input: MagazineLatestIssueQueryInput!): MagazineIssue
 }
 

--- a/services/graphql-server/src/graphql/definitions/magazine/issue.js
+++ b/services/graphql-server/src/graphql/definitions/magazine/issue.js
@@ -3,9 +3,16 @@ const gql = require('graphql-tag');
 module.exports = gql`
 
 extend type Query {
-  magazineIssue(input: MagazineIssueQueryInput!): MagazineIssue @findOne(model: "magazine.Issue", using: { id: "_id" })
+  magazineIssue(input: MagazineIssueQueryInput!): MagazineIssue
+    @findOne(
+      model: "magazine.Issue",
+      using: { id: "_id" },
+    )
+
   magazineIssues(input: MagazineIssuesQueryInput = {}): MagazineIssueConnection!
-    @findMany(model: "magazine.Issue")
+    @findMany(
+      model: "magazine.Issue",
+    )
 
   magazineActiveIssues(input: MagazineActiveIssuesQueryInput!): MagazineIssueConnection!
     @findMany(
@@ -13,8 +20,11 @@ extend type Query {
       queryBuilder: "magazineActiveIssues",
     )
 
-
   magazineLatestIssue(input: MagazineLatestIssueQueryInput!): MagazineIssue
+    @findOne(
+      model: "magazine.Issue",
+      queryBuilder: "magazineLatestIssue",
+    )
 }
 
 type MagazineIssue {

--- a/services/graphql-server/src/graphql/definitions/platform/taxonomy.js
+++ b/services/graphql-server/src/graphql/definitions/platform/taxonomy.js
@@ -4,7 +4,11 @@ module.exports = gql`
 
 extend type Query {
   taxonomy(input: TaxonomyQueryInput!): Taxonomy
-    @findOne(model: "platform.Taxonomy", using: { id: "_id" }, criteria: "taxonomy")
+    @findOne(
+      model: "platform.Taxonomy",
+      using: { id: "_id" },
+      criteria: "taxonomy",
+    )
 
   taxonomies(input: TaxonomiesQueryInput = {}): TaxonomyConnection!
     @findMany(
@@ -36,7 +40,10 @@ extend type Query {
     )
 
   matchTaxonomies(input: MatchTaxonomiesQueryInput!): TaxonomyConnection!
-    @matchMany(model: "platform.Taxonomy", criteria: "taxonomy")
+    @matchMany(
+      model: "platform.Taxonomy",
+      criteria: "taxonomy",
+    )
 }
 
 type Taxonomy {

--- a/services/graphql-server/src/graphql/definitions/platform/taxonomy.js
+++ b/services/graphql-server/src/graphql/definitions/platform/taxonomy.js
@@ -14,7 +14,11 @@ extend type Query {
     )
 
   taxonomiesOfType(input: TaxonomiesOfTypeQueryInput!): TaxonomyConnection!
-    @findMany(model: "platform.Taxonomy", using: { type: "type" })
+    @deprecated(reason: "Use \`Query.taxonomies\` with \`input.includeTypes = []\` instead.")
+    @findMany(
+      model: "platform.Taxonomy",
+      using: { type: "type" },
+    )
 
   rootTaxonomies(input: RootTaxonomiesQueryInput = {}): TaxonomyConnection!
     @findMany(model: "platform.Taxonomy", criteria: "rootTaxonomies")

--- a/services/graphql-server/src/graphql/definitions/platform/taxonomy.js
+++ b/services/graphql-server/src/graphql/definitions/platform/taxonomy.js
@@ -28,7 +28,12 @@ extend type Query {
     )
 
   rootTaxonomiesOfType(input: RootTaxonomiesOfTypeQueryInput!): TaxonomyConnection!
-    @findMany(model: "platform.Taxonomy", using: { type: "type" }, criteria: "rootTaxonomiesOfType")
+    @deprecated(reason: "Use \`Query.taxonomies\` with \`input.rootOnly = true\` and \`input.includeTypes = []\` instead.")
+    @findMany(
+      model: "platform.Taxonomy",
+      using: { type: "type" },
+      criteria: "rootTaxonomiesOfType",
+    )
 
   matchTaxonomies(input: MatchTaxonomiesQueryInput!): TaxonomyConnection!
     @matchMany(model: "platform.Taxonomy", criteria: "taxonomy")

--- a/services/graphql-server/src/graphql/definitions/platform/taxonomy.js
+++ b/services/graphql-server/src/graphql/definitions/platform/taxonomy.js
@@ -7,6 +7,11 @@ extend type Query {
     @findOne(model: "platform.Taxonomy", using: { id: "_id" }, criteria: "taxonomy")
 
   taxonomies(input: TaxonomiesQueryInput = {}): TaxonomyConnection!
+    @findMany(
+      model: "platform.Taxonomy",
+      criteria: "taxonomy"
+      queryBuilder: "taxonomies",
+    )
 
   taxonomiesOfType(input: TaxonomiesOfTypeQueryInput!): TaxonomyConnection!
     @findMany(model: "platform.Taxonomy", using: { type: "type" })

--- a/services/graphql-server/src/graphql/definitions/platform/taxonomy.js
+++ b/services/graphql-server/src/graphql/definitions/platform/taxonomy.js
@@ -21,7 +21,11 @@ extend type Query {
     )
 
   rootTaxonomies(input: RootTaxonomiesQueryInput = {}): TaxonomyConnection!
-    @findMany(model: "platform.Taxonomy", criteria: "rootTaxonomies")
+    @deprecated(reason: "Use \`Query.taxonomies\` with \`input.rootOnly = true\` instead.")
+    @findMany(
+      model: "platform.Taxonomy",
+      criteria: "rootTaxonomies",
+    )
 
   rootTaxonomiesOfType(input: RootTaxonomiesOfTypeQueryInput!): TaxonomyConnection!
     @findMany(model: "platform.Taxonomy", using: { type: "type" }, criteria: "rootTaxonomiesOfType")

--- a/services/graphql-server/src/graphql/definitions/website/section.js
+++ b/services/graphql-server/src/graphql/definitions/website/section.js
@@ -18,11 +18,8 @@ extend type Query {
     withSite: true,
     using: { alias: "redirects" }
   )
-  websiteSections(input: WebsiteSectionsQueryInput = {}): WebsiteSectionConnection! @findMany(
-    model: "website.Section",
-    withSite: true,
-    using: { taxonomyIds: "relatedTaxonomy.$id" },
-  )
+  websiteSections(input: WebsiteSectionsQueryInput = {}): WebsiteSectionConnection!
+
   rootWebsiteSections(input: RootWebsiteSectionsQueryInput = {}): WebsiteSectionConnection! @findMany(
     model: "website.Section",
     withSite: true,
@@ -129,7 +126,10 @@ input WebsiteSectionRedirectQueryInput {
 
 input WebsiteSectionsQueryInput {
   siteId: ObjectID
-  taxonomyIds: [Int!] # filter against relatedTaxonomy.$id
+  includeIds: [Int!] = []
+  excludeIds: [Int!] = []
+  rootOnly: Boolean = false
+  taxonomyIds: [Int!] = []
   status: ModelStatus = active
   sort: WebsiteSectionSortInput = {}
   pagination: PaginationInput = {}

--- a/services/graphql-server/src/graphql/definitions/website/section.js
+++ b/services/graphql-server/src/graphql/definitions/website/section.js
@@ -25,16 +25,22 @@ extend type Query {
       queryBuilder: "websiteSections",
     )
 
-  rootWebsiteSections(input: RootWebsiteSectionsQueryInput = {}): WebsiteSectionConnection! @findMany(
-    model: "website.Section",
-    withSite: true,
-    criteria: "rootWebsiteSection"
-  )
-  websiteSectionsFromIds(input: WebsiteSectionsFromIdsQueryInput!): WebsiteSectionConnection! @findMany(
-    model: "website.Section",
-    withSite: true,
-    using: { ids: "_id" }
-  )
+  rootWebsiteSections(input: RootWebsiteSectionsQueryInput = {}): WebsiteSectionConnection!
+    @findMany(
+      model: "website.Section",
+      withSite: true,
+      criteria: "rootWebsiteSection"
+    )
+    @deprecated(reason: "Use \`Query.websiteSections\` with \`input.rootOnly = true\` instead.")
+
+  websiteSectionsFromIds(input: WebsiteSectionsFromIdsQueryInput!): WebsiteSectionConnection!
+    @findMany(
+      model: "website.Section",
+      withSite: true,
+      using: { ids: "_id" }
+    )
+    @deprecated(reason: "Use \`Query.websiteSections\` with \`input.includeIds = []\` instead.")
+
   websiteSectionSitemapUrls(input: WebsiteSectionSitemapUrlsQueryInput = {}): [WebsiteSectionSitemapUrl!]!
 }
 

--- a/services/graphql-server/src/graphql/definitions/website/section.js
+++ b/services/graphql-server/src/graphql/definitions/website/section.js
@@ -19,6 +19,11 @@ extend type Query {
     using: { alias: "redirects" }
   )
   websiteSections(input: WebsiteSectionsQueryInput = {}): WebsiteSectionConnection!
+    @findMany(
+      model: "website.Section",
+      withSite: true,
+      queryBuilder: "websiteSections",
+    )
 
   rootWebsiteSections(input: RootWebsiteSectionsQueryInput = {}): WebsiteSectionConnection! @findMany(
     model: "website.Section",

--- a/services/graphql-server/src/graphql/definitions/website/section.js
+++ b/services/graphql-server/src/graphql/definitions/website/section.js
@@ -3,21 +3,27 @@ const gql = require('graphql-tag');
 module.exports = gql`
 
 extend type Query {
-  websiteSection(input: WebsiteSectionQueryInput!): WebsiteSection @findOne(
-    model: "website.Section",
-    withSite: true,
-    using: { id: "_id" }
-  )
-  websiteSectionAlias(input: WebsiteSectionAliasQueryInput!): WebsiteSection @findOne(
-    model: "website.Section",
-    withSite: true,
-    using: { alias: "alias" }
-  )
-  websiteSectionRedirect(input: WebsiteSectionRedirectQueryInput!): WebsiteSection @findOne(
-    model: "website.Section",
-    withSite: true,
-    using: { alias: "redirects" }
-  )
+  websiteSection(input: WebsiteSectionQueryInput!): WebsiteSection
+    @findOne(
+      model: "website.Section",
+      withSite: true,
+      using: { id: "_id" }
+    )
+
+  websiteSectionAlias(input: WebsiteSectionAliasQueryInput!): WebsiteSection
+    @findOne(
+      model: "website.Section",
+      withSite: true,
+      using: { alias: "alias" }
+    )
+
+  websiteSectionRedirect(input: WebsiteSectionRedirectQueryInput!): WebsiteSection
+    @findOne(
+      model: "website.Section",
+      withSite: true,
+      using: { alias: "redirects" }
+    )
+
   websiteSections(input: WebsiteSectionsQueryInput = {}): WebsiteSectionConnection!
     @findMany(
       model: "website.Section",

--- a/services/graphql-server/src/graphql/definitions/website/section.js
+++ b/services/graphql-server/src/graphql/definitions/website/section.js
@@ -32,20 +32,20 @@ extend type Query {
     )
 
   rootWebsiteSections(input: RootWebsiteSectionsQueryInput = {}): WebsiteSectionConnection!
+    @deprecated(reason: "Use \`Query.websiteSections\` with \`input.rootOnly = true\` instead.")
     @findMany(
       model: "website.Section",
       withSite: true,
       criteria: "rootWebsiteSection"
     )
-    @deprecated(reason: "Use \`Query.websiteSections\` with \`input.rootOnly = true\` instead.")
 
   websiteSectionsFromIds(input: WebsiteSectionsFromIdsQueryInput!): WebsiteSectionConnection!
+    @deprecated(reason: "Use \`Query.websiteSections\` with \`input.includeIds = []\` instead.")
     @findMany(
       model: "website.Section",
       withSite: true,
       using: { ids: "_id" }
     )
-    @deprecated(reason: "Use \`Query.websiteSections\` with \`input.includeIds = []\` instead.")
 
   websiteSectionSitemapUrls(input: WebsiteSectionSitemapUrlsQueryInput = {}): [WebsiteSectionSitemapUrl!]!
 }

--- a/services/graphql-server/src/graphql/directives/find-many.js
+++ b/services/graphql-server/src/graphql/directives/find-many.js
@@ -29,7 +29,6 @@ class FindManyDirective extends SchemaDirectiveVisitor {
 
       const {
         status,
-        sort,
         pagination,
       } = input;
 
@@ -42,8 +41,8 @@ class FindManyDirective extends SchemaDirectiveVisitor {
         ...(withSite && siteId && { siteId, siteField }),
       });
 
-      const query = await buildQuery(queryBuilder, {
-        query: applied,
+      const { query, sort } = await buildQuery(queryBuilder, {
+        currentValues: { query: applied, sort: input.sort },
         variables,
         ctx,
         info,

--- a/services/graphql-server/src/graphql/directives/find-many.js
+++ b/services/graphql-server/src/graphql/directives/find-many.js
@@ -44,7 +44,7 @@ class FindManyDirective extends SchemaDirectiveVisitor {
 
       const query = await buildQuery(queryBuilder, {
         query: applied,
-        variables: { input },
+        variables,
         ctx,
         info,
       });

--- a/services/graphql-server/src/graphql/directives/find-one.js
+++ b/services/graphql-server/src/graphql/directives/find-one.js
@@ -44,14 +44,14 @@ class FindOneDirective extends SchemaDirectiveVisitor {
         ...(withSite && siteId && { siteId, siteField }),
       });
 
-      const query = await buildQuery(queryBuilder, {
-        query: applied,
+      const { query, sort } = await buildQuery(queryBuilder, {
+        currentValues: { query: applied, sort: input.sort },
         variables,
         ctx,
         info,
       });
 
-      const result = await basedb.findOne(model, query, { projection });
+      const result = await basedb.findOne(model, query, { projection, sort });
       return result;
     };
   }

--- a/services/graphql-server/src/graphql/directives/find-one.js
+++ b/services/graphql-server/src/graphql/directives/find-one.js
@@ -3,6 +3,7 @@ const formatStatus = require('../utils/format-status');
 const criteriaFor = require('../utils/criteria-for');
 const applyInput = require('../utils/apply-input');
 const getProjection = require('../utils/get-projection');
+const buildQuery = require('../query-builders');
 
 class FindOneDirective extends SchemaDirectiveVisitor {
   /**
@@ -11,7 +12,10 @@ class FindOneDirective extends SchemaDirectiveVisitor {
    */
   visitFieldDefinition(field) {
     // eslint-disable-next-line no-param-reassign
-    field.resolve = async (_, { input = {} }, { basedb, site }, info) => {
+    field.resolve = async (_, variables, ctx, info) => {
+      const { basedb, site } = ctx;
+      const { input = {} } = variables;
+
       const {
         fieldNodes,
         returnType,
@@ -26,17 +30,25 @@ class FindOneDirective extends SchemaDirectiveVisitor {
         criteria,
         withSite,
         siteField,
+        queryBuilder,
       } = this.args;
 
       const { status } = input;
 
       const siteId = input.siteId || site.id();
 
-      const query = applyInput({
+      const applied = applyInput({
         query: { ...criteriaFor(criteria), ...formatStatus(status) },
         using,
         input,
         ...(withSite && siteId && { siteId, siteField }),
+      });
+
+      const query = await buildQuery(queryBuilder, {
+        query: applied,
+        variables,
+        ctx,
+        info,
       });
 
       const result = await basedb.findOne(model, query, { projection });

--- a/services/graphql-server/src/graphql/directives/find-one.js
+++ b/services/graphql-server/src/graphql/directives/find-one.js
@@ -51,7 +51,10 @@ class FindOneDirective extends SchemaDirectiveVisitor {
         info,
       });
 
-      const result = await basedb.findOne(model, query, { projection, sort });
+      const result = await basedb.findOne(model, query, {
+        projection,
+        ...(sort && { sort: { [sort.field]: sort.order === 'desc' ? -1 : 1 } }),
+      });
       return result;
     };
   }

--- a/services/graphql-server/src/graphql/query-builders/index.js
+++ b/services/graphql-server/src/graphql/query-builders/index.js
@@ -1,0 +1,27 @@
+const websiteSections = require('./website-sections');
+
+/**
+ * Each function will receive the following args:
+ *
+ * The current query.
+ * The GraphQL variables object.
+ * The GraphQL context object.
+ * The GraphQL info object.
+ *
+ * Functions can be async, as they are awaited by the directives.
+ */
+const builders = {
+  websiteSections,
+};
+
+module.exports = async (key, {
+  query,
+  variables,
+  ctx,
+  info,
+} = {}) => {
+  if (!key) return query;
+  const fn = builders[key];
+  if (fn) return fn(query, variables, ctx, info);
+  return query;
+};

--- a/services/graphql-server/src/graphql/query-builders/index.js
+++ b/services/graphql-server/src/graphql/query-builders/index.js
@@ -5,13 +5,13 @@ const websiteSections = require('./website-sections');
 /**
  * Each function will receive the following args:
  *
- * The current query.
+ * The current operation values object - includes query and sort.
  * The GraphQL variables object.
  * The GraphQL context object.
  * The GraphQL info object.
  *
  * Functions can be async, as they are awaited by the directives.
- * Each function should return the modified query object.
+ * Each function must return an object containing the new query and sort.
  */
 const builders = {
   magazineActiveIssues,
@@ -20,13 +20,19 @@ const builders = {
 };
 
 module.exports = async (key, {
-  query,
-  variables,
+  currentValues = {},
+  variables = {},
   ctx,
   info,
 } = {}) => {
-  if (!key) return query;
+  if (!key) return currentValues;
   const fn = builders[key];
-  if (fn) return fn(query, variables, ctx, info);
-  return query;
+  if (fn) {
+    const { query, sort } = await fn(currentValues, variables, ctx, info);
+    return {
+      query: query || currentValues.query,
+      sort: sort || currentValues.sort,
+    };
+  }
+  return currentValues;
 };

--- a/services/graphql-server/src/graphql/query-builders/index.js
+++ b/services/graphql-server/src/graphql/query-builders/index.js
@@ -1,3 +1,4 @@
+const magazineActiveIssues = require('./magazine-active-issues');
 const taxonomies = require('./taxonomies');
 const websiteSections = require('./website-sections');
 
@@ -13,6 +14,7 @@ const websiteSections = require('./website-sections');
  * Each function should return the modified query object.
  */
 const builders = {
+  magazineActiveIssues,
   taxonomies,
   websiteSections,
 };

--- a/services/graphql-server/src/graphql/query-builders/index.js
+++ b/services/graphql-server/src/graphql/query-builders/index.js
@@ -1,4 +1,5 @@
 const magazineActiveIssues = require('./magazine-active-issues');
+const magazineLatestIssue = require('./magazine-latest-issue');
 const taxonomies = require('./taxonomies');
 const websiteSections = require('./website-sections');
 
@@ -15,6 +16,7 @@ const websiteSections = require('./website-sections');
  */
 const builders = {
   magazineActiveIssues,
+  magazineLatestIssue,
   taxonomies,
   websiteSections,
 };

--- a/services/graphql-server/src/graphql/query-builders/index.js
+++ b/services/graphql-server/src/graphql/query-builders/index.js
@@ -1,3 +1,4 @@
+const taxonomies = require('./taxonomies');
 const websiteSections = require('./website-sections');
 
 /**
@@ -9,8 +10,10 @@ const websiteSections = require('./website-sections');
  * The GraphQL info object.
  *
  * Functions can be async, as they are awaited by the directives.
+ * Each function should return the modified query object.
  */
 const builders = {
+  taxonomies,
   websiteSections,
 };
 

--- a/services/graphql-server/src/graphql/query-builders/magazine-active-issues.js
+++ b/services/graphql-server/src/graphql/query-builders/magazine-active-issues.js
@@ -1,0 +1,14 @@
+module.exports = (currentQuery, { input }) => {
+  const query = { ...currentQuery };
+
+  const {
+    publicationId,
+    excludeIssueIds,
+  } = input;
+
+  query.mailDate = { $lte: new Date() };
+  query['publication.$id'] = publicationId;
+  if (excludeIssueIds.length) query._id = { $nin: excludeIssueIds };
+
+  return query;
+};

--- a/services/graphql-server/src/graphql/query-builders/magazine-active-issues.js
+++ b/services/graphql-server/src/graphql/query-builders/magazine-active-issues.js
@@ -1,14 +1,14 @@
-module.exports = (currentQuery, { input }) => {
-  const query = { ...currentQuery };
+module.exports = ({ query }, { input }) => {
+  const q = { ...query };
 
   const {
     publicationId,
     excludeIssueIds,
   } = input;
 
-  query.mailDate = { $lte: new Date() };
-  query['publication.$id'] = publicationId;
-  if (excludeIssueIds.length) query._id = { $nin: excludeIssueIds };
+  q.mailDate = { $lte: new Date() };
+  q['publication.$id'] = publicationId;
+  if (excludeIssueIds.length) q._id = { $nin: excludeIssueIds };
 
-  return query;
+  return { query: q };
 };

--- a/services/graphql-server/src/graphql/query-builders/magazine-latest-issue.js
+++ b/services/graphql-server/src/graphql/query-builders/magazine-latest-issue.js
@@ -1,0 +1,10 @@
+module.exports = ({ query }, { input }) => {
+  const q = { ...query };
+
+  const { publicationId } = input;
+
+  q.mailDate = { $lte: new Date() };
+  q['publication.$id'] = publicationId;
+
+  return { query: q };
+};

--- a/services/graphql-server/src/graphql/query-builders/taxonomies.js
+++ b/services/graphql-server/src/graphql/query-builders/taxonomies.js
@@ -1,5 +1,5 @@
-module.exports = (currentQuery, { input }) => {
-  const query = { ...currentQuery };
+module.exports = ({ query }, { input }) => {
+  const q = { ...query };
 
   const {
     includeIds,
@@ -9,14 +9,14 @@ module.exports = (currentQuery, { input }) => {
     rootOnly,
   } = input;
 
-  if (includeTypes.length) query.type.$in = includeTypes;
-  if (excludeTypes.length) query.type.$nin = excludeTypes;
-  if (rootOnly) query['parent.$id'] = { $exists: false };
+  if (includeTypes.length) q.type.$in = includeTypes;
+  if (excludeTypes.length) q.type.$nin = excludeTypes;
+  if (rootOnly) q['parent.$id'] = { $exists: false };
   if (includeIds.length || excludeIds.length) {
-    query._id = {};
-    if (includeIds.length) query._id.$in = includeIds;
-    if (excludeIds.length) query._id.$nin = excludeIds;
+    q._id = {};
+    if (includeIds.length) q._id.$in = includeIds;
+    if (excludeIds.length) q._id.$nin = excludeIds;
   }
 
-  return query;
+  return { query: q };
 };

--- a/services/graphql-server/src/graphql/query-builders/taxonomies.js
+++ b/services/graphql-server/src/graphql/query-builders/taxonomies.js
@@ -1,0 +1,22 @@
+module.exports = (currentQuery, { input }) => {
+  const query = { ...currentQuery };
+
+  const {
+    includeIds,
+    excludeIds,
+    includeTypes,
+    excludeTypes,
+    rootOnly,
+  } = input;
+
+  if (includeTypes.length) query.type.$in = includeTypes;
+  if (excludeTypes.length) query.type.$nin = excludeTypes;
+  if (rootOnly) query['parent.$id'] = { $exists: false };
+  if (includeIds.length || excludeIds.length) {
+    query._id = {};
+    if (includeIds.length) query._id.$in = includeIds;
+    if (excludeIds.length) query._id.$nin = excludeIds;
+  }
+
+  return query;
+};

--- a/services/graphql-server/src/graphql/query-builders/website-sections.js
+++ b/services/graphql-server/src/graphql/query-builders/website-sections.js
@@ -1,4 +1,3 @@
-
 module.exports = (currentQuery, { input }) => {
   const query = { ...currentQuery };
 

--- a/services/graphql-server/src/graphql/query-builders/website-sections.js
+++ b/services/graphql-server/src/graphql/query-builders/website-sections.js
@@ -1,0 +1,21 @@
+
+module.exports = (currentQuery, { input }) => {
+  const query = { ...currentQuery };
+
+  const {
+    includeIds,
+    excludeIds,
+    rootOnly,
+    taxonomyIds,
+  } = input;
+
+  if (rootOnly) query['parent.$id'] = { $exists: false };
+  if (taxonomyIds.length) query['relatedTaxonomy.$id'] = { $in: taxonomyIds };
+  if (includeIds.length || excludeIds.length) {
+    query._id = {};
+    if (includeIds.length) query._id.$in = includeIds;
+    if (excludeIds.length) query._id.$nin = excludeIds;
+  }
+
+  return query;
+};

--- a/services/graphql-server/src/graphql/query-builders/website-sections.js
+++ b/services/graphql-server/src/graphql/query-builders/website-sections.js
@@ -1,5 +1,5 @@
-module.exports = (currentQuery, { input }) => {
-  const query = { ...currentQuery };
+module.exports = ({ query }, { input }) => {
+  const q = { ...query };
 
   const {
     includeIds,
@@ -8,13 +8,13 @@ module.exports = (currentQuery, { input }) => {
     taxonomyIds,
   } = input;
 
-  if (rootOnly) query['parent.$id'] = { $exists: false };
-  if (taxonomyIds.length) query['relatedTaxonomy.$id'] = { $in: taxonomyIds };
+  if (rootOnly) q['parent.$id'] = { $exists: false };
+  if (taxonomyIds.length) q['relatedTaxonomy.$id'] = { $in: taxonomyIds };
   if (includeIds.length || excludeIds.length) {
-    query._id = {};
-    if (includeIds.length) query._id.$in = includeIds;
-    if (excludeIds.length) query._id.$nin = excludeIds;
+    q._id = {};
+    if (includeIds.length) q._id.$in = includeIds;
+    if (excludeIds.length) q._id.$nin = excludeIds;
   }
 
-  return query;
+  return { query: q };
 };

--- a/services/graphql-server/src/graphql/resolvers/magazine/issue.js
+++ b/services/graphql-server/src/graphql/resolvers/magazine/issue.js
@@ -46,23 +46,4 @@ module.exports = {
       return result;
     },
   },
-  /**
-   *
-   */
-  Query: {
-    /**
-     *
-     */
-    magazineLatestIssue: async (_, { input }, { basedb }) => {
-      const { publicationId, sort: { field, order } } = input;
-      const mailDate = new Date();
-      const query = {
-        status: 1,
-        mailDate: { $lte: mailDate },
-        'publication.$id': publicationId,
-      };
-      const sort = { [field]: order === 'desc' ? -1 : 1 };
-      return basedb.findOne('magazine.Issue', query, { sort });
-    },
-  },
 };

--- a/services/graphql-server/src/graphql/resolvers/magazine/issue.js
+++ b/services/graphql-server/src/graphql/resolvers/magazine/issue.js
@@ -53,35 +53,6 @@ module.exports = {
     /**
      *
      */
-    magazineActiveIssues: async (_, { input }, { basedb }, info) => {
-      const {
-        publicationId,
-        excludeIssueIds,
-        sort,
-        pagination,
-      } = input;
-
-      const projection = connectionProjection(info);
-      const query = {
-        status: 1,
-        mailDate: { $lte: new Date() },
-        'publication.$id': publicationId,
-      };
-      if (excludeIssueIds.length) {
-        query._id = { $nin: excludeIssueIds };
-      }
-      return basedb.paginate('magazine.Issue', {
-        query,
-        sort,
-        projection,
-        collate: shouldCollate(sort.field),
-        ...pagination,
-      });
-    },
-
-    /**
-     *
-     */
     magazineLatestIssue: async (_, { input }, { basedb }) => {
       const { publicationId, sort: { field, order } } = input;
       const mailDate = new Date();

--- a/services/graphql-server/src/graphql/resolvers/platform/taxonomy.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/taxonomy.js
@@ -2,11 +2,6 @@ const { BaseDB } = require('@base-cms/db');
 
 const getProjection = require('../../utils/get-projection');
 const getGraphType = require('../../utils/get-graph-type');
-const criteriaFor = require('../../utils/criteria-for');
-const applyInput = require('../../utils/apply-input');
-const formatStatus = require('../../utils/format-status');
-const connectionProjection = require('../../utils/connection-projection');
-const shouldCollate = require('../../utils/should-collate');
 
 const loadHierarchy = async (taxonomy, load, projection, taxonomies = []) => {
   const ref = BaseDB.get(taxonomy, 'parent');
@@ -49,48 +44,6 @@ module.exports = {
       const thisTaxonomy = await load('platformTaxonomy', taxonomy._id, projection, { status: 1 });
       const taxonomies = await loadHierarchy(taxonomy, load, projection, [thisTaxonomy]);
       return taxonomies.reverse();
-    },
-  },
-
-  /**
-   *
-   */
-  Query: {
-    taxonomies: async (_, { input }, { basedb }, info) => {
-      const {
-        includeIds,
-        excludeIds,
-        includeTypes,
-        excludeTypes,
-        rootOnly,
-        status,
-        sort,
-        pagination,
-      } = input;
-
-      const query = applyInput({
-        query: { ...criteriaFor('taxonomy'), ...formatStatus(status) },
-        input,
-      });
-
-      if (includeTypes.length) query.type.$in = includeTypes;
-      if (excludeTypes.length) query.type.$nin = excludeTypes;
-      if (rootOnly) query['parent.$id'] = { $exists: false };
-      if (includeIds.length || excludeIds.length) {
-        query._id = {};
-        if (includeIds.length) query._id.$in = includeIds;
-        if (excludeIds.length) query._id.$nin = excludeIds;
-      }
-
-      const projection = connectionProjection(info);
-      const result = await basedb.paginate('platform.Taxonomy', {
-        query,
-        sort,
-        projection,
-        collate: shouldCollate(sort.field),
-        ...pagination,
-      });
-      return result;
     },
   },
 };

--- a/services/graphql-server/src/graphql/resolvers/website/section.js
+++ b/services/graphql-server/src/graphql/resolvers/website/section.js
@@ -2,10 +2,6 @@ const { BaseDB } = require('@base-cms/db');
 const { UserInputError } = require('apollo-server-express');
 const { websiteSection: canonicalPathFor } = require('@base-cms/canonical-path');
 
-const connectionProjection = require('../../utils/connection-projection');
-const shouldCollate = require('../../utils/should-collate');
-const applyInput = require('../../utils/apply-input');
-const formatStatus = require('../../utils/format-status');
 const getProjection = require('../../utils/get-projection');
 const getGraphType = require('../../utils/get-graph-type');
 const { createTitle, createDescription } = require('../../utils/website-section');
@@ -107,46 +103,6 @@ module.exports = {
    *
    */
   Query: {
-    /**
-     *
-     */
-    websiteSections: async (_, { input }, { basedb, site }, info) => {
-      const {
-        includeIds,
-        excludeIds,
-        rootOnly,
-        taxonomyIds,
-        status,
-        sort,
-        pagination,
-      } = input;
-
-      const siteId = input.siteId || site.id();
-      const query = applyInput({
-        query: { ...formatStatus(status) },
-        input,
-        ...(siteId && { siteId }),
-      });
-
-      if (rootOnly) query['parent.$id'] = { $exists: false };
-      if (taxonomyIds.length) query['relatedTaxonomy.$id'] = { $in: taxonomyIds };
-      if (includeIds.length || excludeIds.length) {
-        query._id = {};
-        if (includeIds.length) query._id.$in = includeIds;
-        if (excludeIds.length) query._id.$nin = excludeIds;
-      }
-
-      const projection = connectionProjection(info);
-      const result = await basedb.paginate('website.Section', {
-        query,
-        sort,
-        projection,
-        collate: shouldCollate(sort.field),
-        ...pagination,
-      });
-      return result;
-    },
-
     /**
      *
      */


### PR DESCRIPTION
The `@findOne` and `@findMany` now support the `queryBuilder` argument. When set, these directives will attempt to load a function (of the same name as the argument) from the `graphql/query-builders/index.js` file. The builder function can customize the `query` and/or `sort` values before the directive uses them to query the database. If the query builder arg is unspecified (or specified and not found), the query/sort values are passed through unchanged. Query builders can be async, and receive the current input variables, GraphQL context, and GraphQL info objects as arguments.

In addition, the `Query.websiteSections` input was enhanced to include:
```graphql
input WebsiteSectionsQueryInput {
  siteId: ObjectID
  includeIds: [Int!] = []
  excludeIds: [Int!] = []
  rootOnly: Boolean = false
  taxonomyIds: [Int!] = []
  status: ModelStatus = active
  sort: WebsiteSectionSortInput = {}
  pagination: PaginationInput = {}
}
```
As such, the following website section queries were marked as **deprecated**:
- `rootWebsiteSections`: Use `Query.websiteSections` with `input.rootOnly = true` instead.
- `websiteSectionsFromIds`: Use `Query.websiteSections` with `input.includeIds = []` instead.

Finally, these taxonomy queries were also **deprecated**:
- `taxonomiesOfType`: Use `Query.taxonomies` with `input.includeTypes = []` instead.
- `rootTaxonomies`: Use `Query.taxonomies` with `input.rootOnly = true` instead
- `rootTaxonomiesOfType`: Use `Query.taxonomies` with `input.rootOnly = true` and `input.includeTypes = []` instead.