### PR TITLE
Favor Youtube channelId over username

### DIFF
--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -34,16 +34,15 @@ const retrieveYoutubePlaylistId = async ({ youtube }) => {
 
   const id = get(youtube, 'channelId');
   const forUsername = get(youtube, 'username');
-  if (id || forUsername) {
-    const payload = {
-      part: 'contentDetails',
-      ...(id && { id }),
-      ...(forUsername && { forUsername }),
-    };
-    const response = await googleDataApiClient.request('youtube.channelList', payload);
-    return get(response, 'items.0.contentDetails.relatedPlaylists.uploads');
+  if (!id && !forUsername) return null;
+  const payload = { part: 'contentDetails' };
+  if (id) {
+    payload.id = id;
+  } else {
+    payload.forUsername = forUsername;
   }
-  return undefined;
+  const response = await googleDataApiClient.request('youtube.channelList', payload);
+  return get(response, 'items.0.contentDetails.relatedPlaylists.uploads');
 };
 
 const { isArray } = Array;


### PR DESCRIPTION
Chooses to use the Youtube Channel ID over the username, if both are present. If both are sent to the Google Data API, the request will not be successful.