### PR TITLE
Add content-embed-code node element

### DIFF
--- a/packages/marko-web-theme-default/scss/components/_node.scss
+++ b/packages/marko-web-theme-default/scss/components/_node.scss
@@ -136,6 +136,17 @@
     }
   }
 
+  &__content-embed-code {
+    @include theme-embed-responsive($theme-primary-media-video-aspect-ratio-x, $theme-primary-media-video-aspect-ratio-y);
+
+    iframe,
+    embed,
+    object,
+    video {
+      @include theme-embed-responsive-item();
+    }
+  }
+
   &--card {
     @include theme-card();
   }


### PR DESCRIPTION
Apply responsive embed mixin to `node__content-embed-code`

Ref: base-cms-websites/endeavor-business-media#147