### PR TITLE
Float logos right instead of left to prevent weird wrapping

### DIFF
--- a/packages/marko-web-theme-default/scss/components/_page-image.scss
+++ b/packages/marko-web-theme-default/scss/components/_page-image.scss
@@ -31,8 +31,8 @@
   &--primary-image-inline {
     float: left;
     margin-top: calc((#{$theme-page-body-line-height} - 1) * .5em);
-    margin-right: .75rem;
     margin-bottom: 0;
+    margin-left: .75rem;
 
     @include media-breakpoint-down($theme-responsive-text-breakpoint) {
       margin-top: calc((#{$theme-page-body-line-height-sm} - 1) * .5em);

--- a/packages/marko-web-theme-default/scss/components/_page-image.scss
+++ b/packages/marko-web-theme-default/scss/components/_page-image.scss
@@ -29,7 +29,7 @@
   }
 
   &--primary-image-inline {
-    float: left;
+    float: right;
     margin-top: calc((#{$theme-page-body-line-height} - 1) * .5em);
     margin-bottom: 0;
     margin-left: .75rem;

--- a/packages/marko-web-theme-default/scss/components/_page-image.scss
+++ b/packages/marko-web-theme-default/scss/components/_page-image.scss
@@ -48,6 +48,12 @@
       }
     }
   }
+
+  &--primary-image-inline-left {
+    float: left;
+    margin-right: .75rem;
+    margin-left: 0;
+  }
 }
 
 [data-embed-type="image"] {


### PR DESCRIPTION
### Before:
<img width="1207" alt="Screen Shot 2019-11-04 at 8 35 06 AM" src="https://user-images.githubusercontent.com/2855198/68129287-e635ef80-fede-11e9-8ca9-66b109bb22f4.png">

### After:
<img width="1197" alt="Screen Shot 2019-11-04 at 8 34 54 AM" src="https://user-images.githubusercontent.com/2855198/68129568-678d8200-fedf-11e9-9eba-965ab90e022e.png">
