### PR TITLE
Support preview-mode as a query param

### DIFF
--- a/packages/marko-web/middleware/with-content.js
+++ b/packages/marko-web/middleware/with-content.js
@@ -14,7 +14,7 @@ module.exports = ({
   const { apollo } = req;
 
   const additionalInput = {};
-  if (req.cookies['preview-mode']) additionalInput.status = 'any';
+  if (req.cookies['preview-mode'] || req.query['preview-mode']) additionalInput.status = 'any';
   const content = await loader(apollo, { id, additionalInput });
   const { redirectTo } = content;
   const path = get(content, 'siteContext.path');
@@ -22,7 +22,8 @@ module.exports = ({
     return res.redirect(301, redirectTo);
   }
   if (redirectOnPathMismatch && path !== req.path) {
-    return res.redirect(301, path);
+    const pathTo = req.query['preview-mode'] ? `${path}?preview-mode=true` : path;
+    return res.redirect(301, pathTo);
   }
   const pageNode = new PageNode(apollo, {
     queryFactory,


### PR DESCRIPTION
- When checking content status, also use the `preview-mode` query parameter
- When accessing a content URL such as `/21095961?preview-mode=true`, ensure that the `preview-mode` query parameter is passed when redirecting.