### PR TITLE
Add dynamic import support for Vue components

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@2fd/graphdoc": "^2.4.0",
     "apollo-client": "^2.6.4",
+    "babel-eslint": "^10.0.3",
     "chai": "^4.2.0",
     "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.2.0",

--- a/packages/marko-web-gam/browser/.eslintrc.js
+++ b/packages/marko-web-gam/browser/.eslintrc.js
@@ -15,4 +15,7 @@ module.exports = {
       },
     }],
   },
+  parserOptions: {
+    parser: 'babel-eslint',
+  },
 };

--- a/packages/marko-web-gam/browser/index.js
+++ b/packages/marko-web-gam/browser/index.js
@@ -1,4 +1,4 @@
-import GAMFixedAdBottom from './fixed-ad-bottom.vue';
+const GAMFixedAdBottom = () => import(/* webpackChunkName: "gam-fixed-ad-bottom" */ './fixed-ad-bottom.vue');
 
 export default (Browser) => {
   Browser.registerComponent('GAMFixedAdBottom', GAMFixedAdBottom);

--- a/packages/marko-web-gcse/browser/.eslintrc.js
+++ b/packages/marko-web-gcse/browser/.eslintrc.js
@@ -15,4 +15,7 @@ module.exports = {
       },
     }],
   },
+  parserOptions: {
+    parser: 'babel-eslint',
+  },
 };

--- a/packages/marko-web-gcse/browser/index.js
+++ b/packages/marko-web-gcse/browser/index.js
@@ -1,4 +1,4 @@
-import SimpleSearchBox from './simple-search-box.vue';
+const SimpleSearchBox = () => import(/* webpackChunkName: "gcse-simple-search-box" */ './simple-search-box.vue');
 
 export default (Browser) => {
   Browser.registerComponent('GCSESimpleSearchBox', SimpleSearchBox);

--- a/packages/marko-web-reveal-ad/browser/.eslintrc.js
+++ b/packages/marko-web-reveal-ad/browser/.eslintrc.js
@@ -15,4 +15,7 @@ module.exports = {
       },
     }],
   },
+  parserOptions: {
+    parser: 'babel-eslint',
+  },
 };

--- a/packages/marko-web-reveal-ad/browser/index.js
+++ b/packages/marko-web-reveal-ad/browser/index.js
@@ -1,5 +1,5 @@
-import Listener from './listener.vue';
+const RevealAdListener = () => import(/* webpackChunkName: "reveal-ad-listener" */ './listener.vue');
 
 export default (Browser) => {
-  Browser.registerComponent('RevealAdListener', Listener);
+  Browser.registerComponent('RevealAdListener', RevealAdListener);
 };

--- a/packages/marko-web-theme-default/browser/.eslintrc.js
+++ b/packages/marko-web-theme-default/browser/.eslintrc.js
@@ -15,4 +15,7 @@ module.exports = {
       },
     }],
   },
+  parserOptions: {
+    parser: 'babel-eslint',
+  },
 };

--- a/packages/marko-web-theme-default/browser/index.js
+++ b/packages/marko-web-theme-default/browser/index.js
@@ -1,4 +1,4 @@
-import MenuToggleButton from './menu-toggle-button.vue';
+const MenuToggleButton = () => import(/* webpackChunkName: "theme-menu-toggle-button" */ './menu-toggle-button.vue');
 
 export default (Browser) => {
   Browser.registerComponent('DefaultThemeMenuToggleButton', MenuToggleButton);

--- a/packages/marko-web/browser/.eslintrc.js
+++ b/packages/marko-web/browser/.eslintrc.js
@@ -15,4 +15,7 @@ module.exports = {
       },
     }],
   },
+  parserOptions: {
+    parser: 'babel-eslint',
+  },
 };

--- a/packages/marko-web/browser/components/index.js
+++ b/packages/marko-web/browser/components/index.js
@@ -1,15 +1,12 @@
 import LoadMoreTrigger from './load-more-trigger.vue';
-import OEmbed from './oembed.vue';
 import TriggerInViewEvent from './trigger-in-view-event.vue';
-import FormDotComGatedDownload from './gated-download/form-dot-com.vue';
-import WufooGatedDownload from './gated-download/wufoo.vue';
 
 const components = {
-  LoadMoreTrigger,
-  OEmbed,
-  TriggerInViewEvent,
-  FormDotComGatedDownload,
-  WufooGatedDownload,
+  LoadMoreTrigger, // usage _very_ frequent, do not dynamically import.
+  OEmbed: () => import(/* webpackChunkName: "oembed" */ './oembed.vue'),
+  TriggerInViewEvent, // usage _very_ frequent, do not dynamically import.
+  FormDotComGatedDownload: () => import(/* webpackChunkName: "form-dot-com" */ './gated-download/form-dot-com.vue'),
+  WufooGatedDownload: () => import(/* webpackChunkName: "wufoo-gated-download" */ './gated-download/wufoo.vue'),
 };
 
 export default components;

--- a/packages/marko-web/config/asset-manifest.js
+++ b/packages/marko-web/config/asset-manifest.js
@@ -1,0 +1,43 @@
+const { join } = require('path');
+
+class AssetManifest {
+  constructor({ distDir } = {}) {
+    this.distDir = distDir;
+  }
+
+  js() {
+    if (!this.scripts) {
+      const { js } = this.load();
+      this.scripts = [js['main.js']];
+    }
+    return this.scripts;
+  }
+
+  css() {
+    if (!this.stylesheets) {
+      const { css } = this.load();
+      this.stylesheets = [css['index.css']];
+    }
+    return this.stylesheets;
+  }
+
+  load() {
+    if (!this.manifest) {
+      this.manifest = {
+        js: this.loadDataFor('js'),
+        css: this.loadDataFor('css'),
+      };
+    }
+    return this.manifest;
+  }
+
+  loadDataFor(type) {
+    const { distDir } = this;
+    const distFolder = distDir.split('/').pop();
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    const json = require(join(distDir, type, 'manifest.json'));
+    return Object.keys(json).reduce((o, k) => ({ ...o, [k]: join('/', distFolder, type, json[k]) }), {});
+  }
+}
+
+module.exports = AssetManifest;

--- a/packages/marko-web/config/core.js
+++ b/packages/marko-web/config/core.js
@@ -1,7 +1,17 @@
 const { get } = require('@base-cms/object-path');
 const AbstractConfig = require('./abstract-config');
+const AssetManifest = require('./asset-manifest');
 
 class CoreConfig extends AbstractConfig {
+  /**
+   *
+   * @param {object} config
+   */
+  constructor(config) {
+    super(config);
+    this.assets = new AssetManifest({ distDir: this.get('distDir') })
+  }
+
   setWebsiteContext(context) {
     this.websiteContext = context;
   }
@@ -44,25 +54,12 @@ class CoreConfig extends AbstractConfig {
     return this.website('name', '');
   }
 
-  loadManifest() {
-    const distDir = this.get('distDir');
-    // eslint-disable-next-line global-require, import/no-dynamic-require
-    if (!this.manifest) this.manifest = require(`${distDir}/rev-manifest.json`);
-    return this.manifest;
-  }
-
   sources() {
-    if (!this.scripts) {
-      this.scripts = Object.values(this.loadManifest()).filter(f => /\.js$/.test(f)).map(f => `/dist/${f}`);
-    }
-    return this.scripts;
+    return this.assets.js();
   }
 
   styles() {
-    if (!this.stylesheets) {
-      this.stylesheets = Object.values(this.loadManifest()).filter(f => /\.css$/.test(f)).map(f => `/dist/${f}`);
-    }
-    return this.stylesheets;
+    return this.assets.css();
   }
 }
 

--- a/packages/marko-web/config/core.js
+++ b/packages/marko-web/config/core.js
@@ -9,7 +9,7 @@ class CoreConfig extends AbstractConfig {
    */
   constructor(config) {
     super(config);
-    this.assets = new AssetManifest({ distDir: this.get('distDir') })
+    this.assets = new AssetManifest({ distDir: this.get('distDir') });
   }
 
   setWebsiteContext(context) {

--- a/packages/marko-web/package.json
+++ b/packages/marko-web/package.json
@@ -35,9 +35,6 @@
     "moment": "^2.24.0",
     "vue": "^2.6.10"
   },
-  "devDependencies": {
-    "babel-eslint": "^10.0.3"
-  },
   "peerDependencies": {
     "@base-cms/marko-core": "^1.0.0-beta.4"
   },

--- a/packages/marko-web/package.json
+++ b/packages/marko-web/package.json
@@ -35,6 +35,9 @@
     "moment": "^2.24.0",
     "vue": "^2.6.10"
   },
+  "devDependencies": {
+    "babel-eslint": "^10.0.3"
+  },
   "peerDependencies": {
     "@base-cms/marko-core": "^1.0.0-beta.4"
   },

--- a/packages/web-cli/package.json
+++ b/packages/web-cli/package.json
@@ -63,6 +63,7 @@
     "vue-template-compiler": "^2.6.10",
     "webpack": "^4.39.3",
     "webpack-config-utils": "^2.3.1",
+    "webpack-manifest-plugin": "^2.2.0",
     "webpack-stream": "^5.2.1",
     "yargs": "^14.1.0"
   },

--- a/packages/web-cli/package.json
+++ b/packages/web-cli/package.json
@@ -22,6 +22,7 @@
     "@base-cms/express-apollo": "^1.0.0-beta.7",
     "@base-cms/marko-web": "^1.0.0-beta.19",
     "autoprefixer": "^9.6.1",
+    "babel-eslint": "^10.0.3",
     "babel-loader": "^8.0.6",
     "chalk": "^2.4.2",
     "core-js": "^2.6.9",

--- a/packages/web-cli/src/gulp/js.js
+++ b/packages/web-cli/src/gulp/js.js
@@ -1,5 +1,6 @@
 /* eslint-disable global-require */
 const VueLoaderPlugin = require('vue-loader/lib/plugin');
+const ManifestPlugin = require('webpack-manifest-plugin');
 const path = require('path');
 const pump = require('pump');
 const webpack = require('webpack-stream');
@@ -63,7 +64,8 @@ module.exports = cwd => (cb) => {
         library: 'CMSBrowserComponents',
         libraryExport: 'default',
         libraryTarget: 'umd',
-        filename: 'index.js',
+        filename: 'index.[contenthash:8].js',
+        chunkFilename: '[name].[contenthash:8].js',
         publicPath: '/dist/js/',
       },
       module: {
@@ -114,19 +116,10 @@ module.exports = cwd => (cb) => {
       },
       plugins: [
         new VueLoaderPlugin(),
+        new ManifestPlugin({
+          publicPath: '',
+        }),
       ],
-      // @todo Explore splitting vendor code vs. core website code vs. userland website code
-      // optimization: {
-      //   splitChunks: {
-      //     cacheGroups: {
-      //       commons: {
-      //         test: /[\\/]node_modules[\\/]/,
-      //         name: 'vendor',
-      //         chunks: 'initial',
-      //       },
-      //     },
-      //   },
-      // },
     }, wp),
     dest('dist/js', { cwd }),
   ], e => completeTask(e, cb));

--- a/packages/web-cli/src/gulp/manifest.js
+++ b/packages/web-cli/src/gulp/manifest.js
@@ -7,9 +7,10 @@ const completeTask = require('../utils/task-callback');
 
 module.exports = cwd => (cb) => {
   pump([
-    src('dist/**/*', { cwd }),
+    src('dist/css/*', { cwd }),
     revall.revision({
-      includeFilesInManifest: ['.css', '.js'],
+      fileNameManifest: 'manifest.json',
+      includeFilesInManifest: ['.css'],
       transformFilename: (file, hash) => {
         const base = basename(file.path);
         const mapname = basename(file.path, '.map');
@@ -19,18 +20,10 @@ module.exports = cwd => (cb) => {
         const suffix = base.replace(prefix, '');
         return `${prefix}.${hash.substr(0, 8)}${suffix}`;
       },
-      annotator: (contents, path) => ([{ contents, path }]), // provide file path.
-      replacer: (fragment, replaceRegExp, newReference) => {
-        // Prevent replacing generic "index" values.
-        if (`${replaceRegExp}` !== '/(\'|")(index)()(\'|"|$)/g') {
-          // eslint-disable-next-line no-param-reassign
-          fragment.contents = fragment.contents.replace(replaceRegExp, `$1${newReference}$3$4`);
-        }
-      },
     }),
     del(),
-    dest('dist', { cwd }),
+    dest('dist/css', { cwd }),
     revall.manifestFile(),
-    dest('dist', { cwd }),
+    dest('dist/css', { cwd }),
   ], e => completeTask(e, cb));
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6065,6 +6065,15 @@ fs-extra@^0.30.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
+fs-extra@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
@@ -8230,7 +8239,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@~4.17.10:
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@~4.17.10:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -13382,6 +13391,16 @@ webpack-config-utils@^2.3.1:
   integrity sha512-0uC5uj7sThFTePTQjfpe5Wqcbw3KSCxqswOmW96lwk2ZI2CU098rWY2ZqOVGJQYJ3hfEltmjcLNkKutw8LJAlg==
   dependencies:
     webpack-combine-loaders "2.0.4"
+
+webpack-manifest-plugin@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-manifest-plugin/-/webpack-manifest-plugin-2.2.0.tgz#19ca69b435b0baec7e29fbe90fb4015de2de4f16"
+  integrity sha512-9S6YyKKKh/Oz/eryM1RyLVDVmy3NSPV0JXMRhZ18fJsq+AwGxUY34X54VNwkzYcEmEkDwNxuEOboCZEebJXBAQ==
+  dependencies:
+    fs-extra "^7.0.0"
+    lodash ">=3.5 <5"
+    object.entries "^1.1.0"
+    tapable "^1.0.0"
 
 webpack-sources@^1.1.0, webpack-sources@^1.3.0:
   version "1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -828,25 +828,7 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.2.2", "@babel/types@^7.3.3":
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.3.3.tgz#6c44d1cdac2a7625b624216657d5bc6c107ab436"
-  integrity sha512-2tACZ80Wg09UnPg5uGAOUvvInaqLk3l/IAhQzlxLQOIXacr6bMsra5SH6AWw/hIDRCSbCdHP2KzSOD+cT7TzMQ==
-  dependencies:
-    esutils "^2.0.2"
-    lodash "^4.17.11"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.4.4", "@babel/types@^7.5.5", "@babel/types@^7.6.0":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.1.tgz#53abf3308add3ac2a2884d539151c57c4b3ac648"
-  integrity sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==
-  dependencies:
-    esutils "^2.0.2"
-    lodash "^4.17.13"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.7.0":
+"@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.2.2", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.5.5", "@babel/types@^7.6.0", "@babel/types@^7.7.0":
   version "7.7.1"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.7.1.tgz#8b08ea368f2baff236613512cf67109e76285827"
   integrity sha512-kN/XdANDab9x1z5gcjDc9ePpxexkt+1EQ2MQUiM4XnMvQfvp87/+6kY4Ko2maLXH+tei/DgJ/ybFITeqqRwDiA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,6 +92,16 @@
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
+"@babel/generator@^7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.7.0.tgz#c6d4d1f7a0d6e139cbd01aca73170b0bff5425b4"
+  integrity sha512-1wdJ6UxHyL1XoJQ119JmvuRX27LRih7iYStMPZOWAjQqeAabFg3dYXKMpgihma+to+0ADsTVVt6oRyUxWZw6Mw==
+  dependencies:
+    "@babel/types" "^7.7.0"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
 "@babel/helper-annotate-as-pure@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz#323d39dd0b50e10c7c06ca7d7638e6864d8c5c32"
@@ -142,12 +152,28 @@
     "@babel/template" "^7.1.0"
     "@babel/types" "^7.0.0"
 
+"@babel/helper-function-name@^7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz#44a5ad151cfff8ed2599c91682dda2ec2c8430a3"
+  integrity sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.7.0"
+    "@babel/template" "^7.7.0"
+    "@babel/types" "^7.7.0"
+
 "@babel/helper-get-function-arity@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
   integrity sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==
   dependencies:
     "@babel/types" "^7.0.0"
+
+"@babel/helper-get-function-arity@^7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz#c604886bc97287a1d1398092bc666bc3d7d7aa2d"
+  integrity sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==
+  dependencies:
+    "@babel/types" "^7.7.0"
 
 "@babel/helper-hoist-variables@^7.4.4":
   version "7.4.4"
@@ -263,6 +289,13 @@
   dependencies:
     "@babel/types" "^7.4.4"
 
+"@babel/helper-split-export-declaration@^7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz#1365e74ea6c614deeb56ebffabd71006a0eb2300"
+  integrity sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==
+  dependencies:
+    "@babel/types" "^7.7.0"
+
 "@babel/helper-wrap-function@^7.1.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz#c4e0012445769e2815b55296ead43a958549f6fa"
@@ -290,6 +323,11 @@
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^4.0.0"
+
+"@babel/parser@^7.0.0", "@babel/parser@^7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.0.tgz#232618f6e8947bc54b407fa1f1c91a22758e7159"
+  integrity sha512-GqL+Z0d7B7ADlQBMXlJgvXEbtt5qlqd1YQ5fr12hTSfh7O/vgrEIvJxU2e7aSVrEUn75zTZ6Nd0s8tthrlZnrQ==
 
 "@babel/parser@^7.2.2":
   version "7.3.3"
@@ -736,6 +774,30 @@
     "@babel/parser" "^7.6.0"
     "@babel/types" "^7.6.0"
 
+"@babel/template@^7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.7.0.tgz#4fadc1b8e734d97f56de39c77de76f2562e597d0"
+  integrity sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.7.0"
+    "@babel/types" "^7.7.0"
+
+"@babel/traverse@^7.0.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.7.0.tgz#9f5744346b8d10097fd2ec2eeffcaf19813cbfaf"
+  integrity sha512-ea/3wRZc//e/uwCpuBX2itrhI0U9l7+FsrKWyKGNyvWbuMcCG7ATKY2VI4wlg2b2TA39HHwIxnvmXvtiKsyn7w==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.7.0"
+    "@babel/helper-function-name" "^7.7.0"
+    "@babel/helper-split-export-declaration" "^7.7.0"
+    "@babel/parser" "^7.7.0"
+    "@babel/types" "^7.7.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/traverse@^7.1.0":
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.2.3.tgz#7ff50cefa9c7c0bd2d81231fdac122f3957748d8"
@@ -779,6 +841,15 @@
   version "7.6.1"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.1.tgz#53abf3308add3ac2a2884d539151c57c4b3ac648"
   integrity sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.7.0":
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.7.1.tgz#8b08ea368f2baff236613512cf67109e76285827"
+  integrity sha512-kN/XdANDab9x1z5gcjDc9ePpxexkt+1EQ2MQUiM4XnMvQfvp87/+6kY4Ko2maLXH+tei/DgJ/ybFITeqqRwDiA==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.13"
@@ -2898,6 +2969,18 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+
+babel-eslint@^10.0.3:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.3.tgz#81a2c669be0f205e19462fed2482d33e4687a88a"
+  integrity sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    eslint-visitor-keys "^1.0.0"
+    resolve "^1.12.0"
 
 babel-loader@^8.0.6:
   version "8.0.6"
@@ -11278,7 +11361,7 @@ resolve@^1.10.0, resolve@^1.3.2, resolve@^1.8.1:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.11.0:
+resolve@^1.11.0, resolve@^1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==


### PR DESCRIPTION
Vue components can now be dynamically imported via the `import()` syntax. This ensures that component JS is only loaded by the browser when it's  _used_, as opposed to including it globally on all pages, on-load. This reduced the overall on-load JS size from ~720kb (un-minified, dev code, with all plugins enabled) to ~570kb - for about a 20% reduction. The `babel-eslint` parser was added to handle the `import()` syntax.

This feature will "shine" when used by custom website components and large, third-party libraries - as the dynamic import capability will also be available within implementing website code.

To facilitate this, Webpack (within the `web-cli` package) handles the file chunking, hashing, and manifest generation for JS files. The Gulp `manifest` command now only generates hashed versions of the main CSS file. An `AssetManifest` class was added to `marko-web` to process these manifest files and include the appropriate, on-load assets to the HTML document.

For more information about dynamic imports and code splitting, see the following:
https://webpack.js.org/guides/code-splitting/#dynamic-imports
https://vuejs.org/v2/guide/components-dynamic-async.html#Async-Components