### PR TITLE
Add Apollo GraphQL support to client-side Vue components

### DIFF
--- a/packages/express-apollo/src/create-client.js
+++ b/packages/express-apollo/src/create-client.js
@@ -2,7 +2,7 @@ const fetch = require('node-fetch');
 const { ApolloClient } = require('apollo-client');
 const { InMemoryCache } = require('apollo-cache-inmemory');
 const { createHttpLink } = require('apollo-link-http');
-const fragmentMatcher = require('./fragment-matcher');
+const fragmentMatcher = require('@base-cms/graphql-fragment-types/fragment-matcher');
 
 const rootConfig = {
   connectToDevTools: false,

--- a/packages/express-apollo/src/fragment-matcher.js
+++ b/packages/express-apollo/src/fragment-matcher.js
@@ -1,4 +1,0 @@
-const { IntrospectionFragmentMatcher } = require('apollo-cache-inmemory');
-const introspectionQueryResultData = require('@base-cms/graphql-fragment-types');
-
-module.exports = new IntrospectionFragmentMatcher({ introspectionQueryResultData });

--- a/packages/graphql-fragment-types/fragment-matcher.js
+++ b/packages/graphql-fragment-types/fragment-matcher.js
@@ -1,0 +1,1 @@
+module.exports = require('./src/fragment-matcher');

--- a/packages/graphql-fragment-types/package.json
+++ b/packages/graphql-fragment-types/package.json
@@ -12,6 +12,9 @@
   "dependencies": {
     "node-fetch": "^2.6.0"
   },
+  "peerDependencies": {
+    "apollo-cache-inmemory": "^1.6.0"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/graphql-fragment-types/src/fragment-matcher.js
+++ b/packages/graphql-fragment-types/src/fragment-matcher.js
@@ -1,0 +1,4 @@
+const { IntrospectionFragmentMatcher } = require('apollo-cache-inmemory');
+const introspectionQueryResultData = require('./index');
+
+module.exports = new IntrospectionFragmentMatcher({ introspectionQueryResultData });

--- a/packages/marko-web/browser/apollo.js
+++ b/packages/marko-web/browser/apollo.js
@@ -4,7 +4,7 @@ import { createHttpLink } from 'apollo-link-http';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import fragmentMatcher from '@base-cms/graphql-fragment-types/fragment-matcher';
 
-export default () => new VueApollo({
+export default new VueApollo({
   defaultClient: new ApolloClient({
     link: createHttpLink({ uri: '/__graphql' }),
     cache: new InMemoryCache({ fragmentMatcher }),

--- a/packages/marko-web/browser/apollo.js
+++ b/packages/marko-web/browser/apollo.js
@@ -1,0 +1,12 @@
+import VueApollo from 'vue-apollo';
+import { ApolloClient } from 'apollo-client';
+import { createHttpLink } from 'apollo-link-http';
+import { InMemoryCache } from 'apollo-cache-inmemory';
+import fragmentMatcher from '@base-cms/graphql-fragment-types/fragment-matcher';
+
+export default () => new VueApollo({
+  defaultClient: new ApolloClient({
+    link: createHttpLink({ uri: '/__graphql' }),
+    cache: new InMemoryCache({ fragmentMatcher }),
+  }),
+});

--- a/packages/marko-web/browser/index.js
+++ b/packages/marko-web/browser/index.js
@@ -6,23 +6,46 @@ import './lazysizes';
 
 const providers = {};
 
-const loadComponent = (el, name, props) => {
+const load = async ({
+  el,
+  name,
+  props,
+  on,
+} = {}) => {
+  if (!el || !name) throw new Error('A Vue component name and element must be provided.');
   const Component = components[name];
   if (!Component) throw new Error(`No Vue component found for '${name}'`);
   new Vue({
     provide: providers[name],
     el,
-    render: h => h(Component, { props }),
+    render: h => h(Component, { props, on }),
   });
 };
 
-const registerComponent = (name, Component, provide) => {
+const register = async (name, Component, { provide } = {}) => {
+  if (!name) throw new Error('A Vue component name must be provided.');
   if (components[name]) throw new Error(`A Vue component already exists for '${name}'`);
   components[name] = Component;
   providers[name] = provide;
 };
 
+/**
+ * @deprecated Use `load` instead.
+ */
+const loadComponent = (el, name, props) => {
+  load({ el, name, props });
+};
+
+/**
+ * @deprecated Use `register` instead.
+ */
+const registerComponent = (name, Component, provide) => {
+  register(name, Component, { provide });
+};
+
 export default {
+  load,
+  register,
   loadComponent,
   registerComponent,
   EventBus,

--- a/packages/marko-web/browser/vue.js
+++ b/packages/marko-web/browser/vue.js
@@ -1,3 +1,6 @@
 import Vue from 'vue';
+import VueApollo from 'vue-apollo';
+
+Vue.use(VueApollo);
 
 export default Vue;

--- a/packages/marko-web/express/graphql-proxy.js
+++ b/packages/marko-web/express/graphql-proxy.js
@@ -1,0 +1,17 @@
+const proxy = require('express-http-proxy');
+
+module.exports = (app, { graphqlUri, headers }) => {
+  const mountPoint = '/__graphql';
+  const opts = {
+    proxyReqPathResolver: ({ originalUrl }) => originalUrl.replace(mountPoint, ''),
+    proxyReqOptDecorator: (reqOpts, req) => {
+      const proxyHeaders = {
+        ...reqOpts.headers,
+        ...headers,
+        'x-forwarded-proto': req.protocol,
+      };
+      return { ...reqOpts, headers: proxyHeaders };
+    },
+  };
+  app.use(mountPoint, proxy(graphqlUri, opts));
+};

--- a/packages/marko-web/express/index.js
+++ b/packages/marko-web/express/index.js
@@ -5,6 +5,7 @@ const marko = require('marko/express');
 const path = require('path');
 const helmet = require('helmet');
 const apollo = require('./apollo');
+const graphqlProxy = require('./graphql-proxy');
 const embeddedMedia = require('./embedded-media');
 const loadObject = require('./load-object');
 const loadDocument = require('./load-document');
@@ -23,6 +24,7 @@ module.exports = (config = {}) => {
     tenantKey,
     siteId,
     sitePackage,
+    graphqlUri,
   } = config;
   const distDir = path.resolve(rootDir, 'dist');
   const app = express();
@@ -68,13 +70,14 @@ module.exports = (config = {}) => {
     next();
   });
 
-  // Register apollo.
+  // Register apollo client and server proxy.
   const headers = buildRequestHeaders({ tenantKey, siteId });
-  apollo(app, config.graphqlUri, {
+  apollo(app, graphqlUri, {
     name: sitePackage.name,
     version: sitePackage.version,
     link: { headers },
   });
+  graphqlProxy(app, { graphqlUri, headers });
 
   // Set website context.
   app.use(websiteContext(app.locals.config));

--- a/packages/marko-web/package.json
+++ b/packages/marko-web/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@base-cms/embedded-media": "^1.0.0-beta.1",
     "@base-cms/express-apollo": "^1.0.0-beta.7",
+    "@base-cms/graphql-fragment-types": "^1.0.0-beta.7",
     "@base-cms/image": "^1.0.0-beta.1",
     "@base-cms/inflector": "^1.0.0-beta.1",
     "@base-cms/object-path": "^1.0.0-beta.4",
@@ -23,6 +24,10 @@
     "@base-cms/utils": "^1.0.0-beta.4",
     "@base-cms/web-common": "^1.0.0-beta.19",
     "@godaddy/terminus": "^4.2.0",
+    "apollo-cache-inmemory": "^1.6.3",
+    "apollo-client": "^2.6.4",
+    "apollo-link": "^1.2.13",
+    "apollo-link-http": "^1.5.16",
     "cookie-parser": "^1.4.4",
     "express": "^4.17.1",
     "express-http-proxy": "^1.5.1",
@@ -33,7 +38,8 @@
     "jquery": "^3.4.1",
     "marko": "^4.18.13",
     "moment": "^2.24.0",
-    "vue": "^2.6.10"
+    "vue": "^2.6.10",
+    "vue-apollo": "^3.0.0"
   },
   "peerDependencies": {
     "@base-cms/marko-core": "^1.0.0-beta.4"


### PR DESCRIPTION
Browser Vue components can (optionally) opt-in to the BaseCMS GraphQL front-end client. To do so, the `withApollo` option must be set to true when registering a component: 

```js
Browser.register('ComponentName', Component, { withApollo: true });
```

This flag ensures that the global Dollar Apollo has the appropriate Apollo provider and client for the Vue instance. Queries can now be made inside the component using `this.$apollo`.

In order to facilitate client-side requests (and reduce configuration overhead), the `marko-web` Express server will accept GraphQL queries on `/__graphql`. This will proxy all operations to the pre-configured, "under-the-hood" GraphQL instance that the server is already using to perform backend queries of the API. For example: `https://www.laserfocusworld.com/__graphql` will accept operations just like `https://aerilon.graphql-staging.base-cms.io/`, but without the need to send context headers (i.e. tenant key and site ID).

The Apollo provider is dynamically imported and, as such, is split from the main JS file. Additionally, the provider code will only be requested by the browser when an Apollo-dependent component is loaded. This ensures that the Apollo JS is only loaded on pages where these components are actually used.

**Deprecation Notice:** The `Browser.registerComponent` and `Browser.loadComponent` functions were deprecated in favor of `Browser.register` and `Browser.load`, respectively. The old functions still exist (and are BC), but do _not_ support the new `withApollo` option. Userland code should replace these calls with the new functions ASAP.

Finally, the `fragment-matcher` functionality was moved to the common, GraphQL fragment types package for easier re-use.