### PR TITLE
Update plugins to use new component registration

### DIFF
--- a/packages/marko-web-gam/browser/index.js
+++ b/packages/marko-web-gam/browser/index.js
@@ -1,5 +1,5 @@
 const GAMFixedAdBottom = () => import(/* webpackChunkName: "gam-fixed-ad-bottom" */ './fixed-ad-bottom.vue');
 
 export default (Browser) => {
-  Browser.registerComponent('GAMFixedAdBottom', GAMFixedAdBottom);
+  Browser.register('GAMFixedAdBottom', GAMFixedAdBottom);
 };

--- a/packages/marko-web-gcse/browser/index.js
+++ b/packages/marko-web-gcse/browser/index.js
@@ -1,5 +1,5 @@
 const SimpleSearchBox = () => import(/* webpackChunkName: "gcse-simple-search-box" */ './simple-search-box.vue');
 
 export default (Browser) => {
-  Browser.registerComponent('GCSESimpleSearchBox', SimpleSearchBox);
+  Browser.register('GCSESimpleSearchBox', SimpleSearchBox);
 };

--- a/packages/marko-web-gtm/browser/index.js
+++ b/packages/marko-web-gtm/browser/index.js
@@ -3,6 +3,8 @@ import GTMTrackLoadMore from './track-load-more.vue';
 
 export default (Browser) => {
   const { EventBus } = Browser;
-  Browser.registerComponent('GTMTrackInViewEvent', GTMTrackInViewEvent);
-  Browser.registerComponent('GTMTrackLoadMore', GTMTrackLoadMore, { EventBus });
+  Browser.register('GTMTrackInViewEvent', GTMTrackInViewEvent);
+  Browser.register('GTMTrackLoadMore', GTMTrackLoadMore, {
+    provide: { EventBus },
+  });
 };

--- a/packages/marko-web-reveal-ad/browser/index.js
+++ b/packages/marko-web-reveal-ad/browser/index.js
@@ -1,5 +1,5 @@
 const RevealAdListener = () => import(/* webpackChunkName: "reveal-ad-listener" */ './listener.vue');
 
 export default (Browser) => {
-  Browser.registerComponent('RevealAdListener', RevealAdListener);
+  Browser.register('RevealAdListener', RevealAdListener);
 };

--- a/packages/marko-web-theme-default/browser/index.js
+++ b/packages/marko-web-theme-default/browser/index.js
@@ -1,5 +1,5 @@
 const MenuToggleButton = () => import(/* webpackChunkName: "theme-menu-toggle-button" */ './menu-toggle-button.vue');
 
 export default (Browser) => {
-  Browser.registerComponent('DefaultThemeMenuToggleButton', MenuToggleButton);
+  Browser.register('DefaultThemeMenuToggleButton', MenuToggleButton);
 };

--- a/packages/web-cli/src/generator/templates/core/browser/index.js
+++ b/packages/web-cli/src/generator/templates/core/browser/index.js
@@ -4,7 +4,7 @@ import Browser from '@base-cms/marko-web/browser';
 /*
 import SomeComponent from './some-component.vue';
 
-Browser.registerComponent('SomeComponentName', SomeComponent);
+Browser.register('SomeComponentName', SomeComponent);
 
 This component would now be loadable within server-side templates via.
 <cms-browser-component name="SomeComponentName" props={ someProp: 'someValue' } />


### PR DESCRIPTION
Plugin Vue components now use the `Browser.register` function instead of the deprecated `Browser.registerComponent`.