### PR TITLE
NewRelic error logging

### DIFF
--- a/services/google-data-api/src/index.js
+++ b/services/google-data-api/src/index.js
@@ -1,5 +1,5 @@
 const { service } = require('@base-cms/micro');
-require('./newrelic');
+const newrelic = require('./newrelic');
 
 const { name, version } = require('../package.json');
 const { connect, ping } = require('./mongodb');
@@ -8,7 +8,10 @@ const { onError } = require('./utils');
 
 const { log } = console;
 
-process.on('unhandledRejection', (e) => { throw e; });
+process.on('unhandledRejection', (e) => {
+  newrelic.noticeError(e);
+  throw e;
+});
 
 module.exports = service.json({
   init: async () => {

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -562,7 +562,7 @@ module.exports = {
     title: content => BaseDB.fillMutation(content, 'Website', 'name'),
     publication: (content, _, { site }) => {
       if (!site.exists()) throw new UserInputError('A website context must be set to generate the `ContentSitemapNewsUrl.publication` field.');
-      return site;
+      return site.obj();
     },
     images: (content, _, { basedb }) => loadSitemapImages({ content, basedb }),
   },

--- a/services/graphql-server/src/index.js
+++ b/services/graphql-server/src/index.js
@@ -1,6 +1,6 @@
 const http = require('http');
 const { createTerminus } = require('@godaddy/terminus');
-require('./newrelic');
+const newrelic = require('./newrelic');
 const { PORT, EXPOSED_PORT } = require('./env');
 const app = require('./app');
 const pkg = require('../package.json');
@@ -29,8 +29,12 @@ const run = async () => {
 // Simulate future NodeJS behavior by throwing unhandled Promise rejections.
 process.on('unhandledRejection', (e) => {
   log('> Unhandled promise rejection. Throwing error...');
+  newrelic.noticeError(e);
   throw e;
 });
 
 log(`> Booting ${pkg.name} v${pkg.version}...`);
-run().catch(e => setImmediate(() => { throw e; }));
+run().catch(e => setImmediate(() => {
+  newrelic.noticeError(e);
+  throw e;
+}));

--- a/services/hooks/src/index.js
+++ b/services/hooks/src/index.js
@@ -1,6 +1,6 @@
 const http = require('http');
 const { createTerminus } = require('@godaddy/terminus');
-require('./newrelic');
+const newrelic = require('./newrelic');
 const app = require('./app');
 const pkg = require('../package.json');
 const services = require('./services');
@@ -28,8 +28,12 @@ const run = async () => {
 // Simulate future NodeJS behavior by throwing unhandled Promise rejections.
 process.on('unhandledRejection', (e) => {
   log('> Unhandled promise rejection. Throwing error...');
+  newrelic.noticeError(e);
   throw e;
 });
 
 log(`> Booting ${pkg.name} v${pkg.version}...`);
-run().catch(e => setImmediate(() => { throw e; }));
+run().catch(e => setImmediate(() => {
+  newrelic.noticeError(e);
+  throw e;
+}));

--- a/services/oembed/src/index.js
+++ b/services/oembed/src/index.js
@@ -1,6 +1,6 @@
 const http = require('http');
 const { createTerminus } = require('@godaddy/terminus');
-require('./newrelic');
+const newrelic = require('./newrelic');
 const app = require('./app');
 const pkg = require('../package.json');
 
@@ -25,8 +25,12 @@ const run = async () => {
 // Simulate future NodeJS behavior by throwing unhandled Promise rejections.
 process.on('unhandledRejection', (e) => {
   log('> Unhandled promise rejection. Throwing error...');
+  newrelic.noticeError(e);
   throw e;
 });
 
 log(`> Booting ${pkg.name} v${pkg.version}...`);
-run().catch(e => setImmediate(() => { throw e; }));
+run().catch(e => setImmediate(() => {
+  newrelic.noticeError(e);
+  throw e;
+}));

--- a/services/rss/src/index.js
+++ b/services/rss/src/index.js
@@ -1,6 +1,6 @@
 const http = require('http');
 const { createTerminus } = require('@godaddy/terminus');
-require('./newrelic');
+const newrelic = require('./newrelic');
 const { GRAPHQL_URI, PORT, EXPOSED_PORT } = require('./env');
 const app = require('./app');
 const pkg = require('../package.json');
@@ -25,8 +25,12 @@ const run = async () => {
 // Simulate future NodeJS behavior by throwing unhandled Promise rejections.
 process.on('unhandledRejection', (e) => {
   log('> Unhandled promise rejection. Throwing error...');
+  newrelic.noticeError(e);
   throw e;
 });
 
 log(`> Booting ${pkg.name} v${pkg.version}...`);
-run().catch(e => setImmediate(() => { throw e; }));
+run().catch(e => setImmediate(() => {
+  newrelic.noticeError(e);
+  throw e;
+}));

--- a/services/sitemaps/src/index.js
+++ b/services/sitemaps/src/index.js
@@ -1,6 +1,6 @@
 const http = require('http');
 const { createTerminus } = require('@godaddy/terminus');
-require('./newrelic');
+const newrelic = require('./newrelic');
 const { GRAPHQL_URI, PORT, EXPOSED_PORT } = require('./env');
 const app = require('./app');
 const pkg = require('../package.json');
@@ -25,8 +25,12 @@ const run = async () => {
 // Simulate future NodeJS behavior by throwing unhandled Promise rejections.
 process.on('unhandledRejection', (e) => {
   log('> Unhandled promise rejection. Throwing error...');
+  newrelic.noticeError(e);
   throw e;
 });
 
 log(`> Booting ${pkg.name} v${pkg.version}...`);
-run().catch(e => setImmediate(() => { throw e; }));
+run().catch(e => setImmediate(() => {
+  newrelic.noticeError(e);
+  throw e;
+}));


### PR DESCRIPTION
Update error logging to ensure unhandled promise rejections are sent to newrelic
Ensure the site object is returned when requesting the news sitemap publication