### PR TITLE
Event handling for Leaders Program

### DIFF
--- a/packages/marko-web-leaders/browser/index.js
+++ b/packages/marko-web-leaders/browser/index.js
@@ -4,6 +4,6 @@ export default (Browser) => {
   const { EventBus } = Browser;
   Browser.register('LeadersProgram', LeadersProgram, {
     withApollo: true,
-    on: { action: EventBus.$emit },
+    on: { action: (...args) => EventBus.$emit('leaders-action', ...args) },
   });
 };

--- a/packages/marko-web-leaders/browser/index.js
+++ b/packages/marko-web-leaders/browser/index.js
@@ -1,5 +1,9 @@
 const LeadersProgram = () => import(/* webpackChunkName: "leaders-program" */ '@base-cms/leaders-program');
 
 export default (Browser) => {
-  Browser.register('LeadersProgram', LeadersProgram, { withApollo: true });
+  const { EventBus } = Browser;
+  Browser.register('LeadersProgram', LeadersProgram, {
+    withApollo: true,
+    on: { action: EventBus.$emit },
+  });
 };

--- a/packages/marko-web/browser/index.js
+++ b/packages/marko-web/browser/index.js
@@ -8,6 +8,7 @@ const apollo = () => import(/* webpackChunkName: "apollo" */ './apollo');
 
 const providers = {};
 const requiresApollo = {};
+const listeners = {};
 
 const load = async ({
   el,
@@ -27,15 +28,16 @@ const load = async ({
     provide: providers[name],
     el,
     apolloProvider,
-    render: h => h(Component, { props, on }),
+    render: h => h(Component, { props, on: { ...on, ...listeners[name] } }),
   });
 };
 
-const register = async (name, Component, { provide, withApollo } = {}) => {
+const register = async (name, Component, { provide, withApollo, on } = {}) => {
   if (!name) throw new Error('A Vue component name must be provided.');
   if (components[name]) throw new Error(`A Vue component already exists for '${name}'`);
   components[name] = Component;
   providers[name] = provide;
+  listeners[name] = on;
   if (withApollo) requiresApollo[name] = true;
 };
 


### PR DESCRIPTION
- Support passing `on` definitions when registering browser components.
- Add `EventBus` support to `marko-web-leaders`.
- Scope/rename emitted event names for leaders program.