### PR TITLE
Allow Sitemaps / Google News input variables via headers

### DIFF
--- a/packages/marko-web/express/index.js
+++ b/packages/marko-web/express/index.js
@@ -97,7 +97,7 @@ module.exports = (config = {}) => {
   loadMore(app);
 
   // Register sitemaps.
-  sitemaps(app, headers);
+  sitemaps(app, { ...config.sitemapsHeaders, ...headers });
 
   // Register RSS Feeds.
   rss(app, headers);

--- a/packages/marko-web/start-server.js
+++ b/packages/marko-web/start-server.js
@@ -31,6 +31,7 @@ module.exports = async ({
   embeddedMediaHandlers,
   onAsyncBlockError,
   redirectHandler,
+  sitemapsHeaders,
 
   // Terminus settings.
   timeout = 1000,
@@ -63,6 +64,7 @@ module.exports = async ({
     fragments,
     sitePackage,
     embeddedMediaHandlers,
+    sitemapsHeaders,
   });
 
   // Await required services here...

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -250,6 +250,9 @@ input ContentSitemapUrlsQueryInput {
 
 input ContentSitemapNewsUrlsQueryInput {
   siteId: ObjectID
+  includeContentTypes: [ContentType!] = [News, PressRelease, Blog]
+  excludeContentTypes: [ContentType!] = []
+  taxonomyIds: [Int!] = []
 }
 
 input AllPublishedContentQueryInput {

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -701,9 +701,18 @@ module.exports = {
     },
 
     contentSitemapNewsUrls: async (_, { input }, { basedb, site }) => {
-      const contentTypes = ['News', 'PressRelease', 'Blog'];
-      const query = getPublishedCriteria({ contentTypes });
+      const {
+        includeContentTypes,
+        excludeContentTypes,
+        taxonomyIds,
+      } = input;
+      const query = getPublishedCriteria({
+        contentTypes: includeContentTypes,
+        excludeContentTypes,
+      });
+
       query.$and.push({ published: { $gte: moment().subtract(2, 'days').toDate() } });
+      if (taxonomyIds.length) query['taxonomy.$id'] = { $in: taxonomyIds };
 
       const siteId = input.siteId || site.id();
       if (siteId) query['mutations.Website.primarySite'] = siteId;

--- a/services/sitemaps/src/routes/google-news.js
+++ b/services/sitemaps/src/routes/google-news.js
@@ -4,10 +4,18 @@ const moment = require('moment');
 const createImage = require('../utils/create-image');
 const URLSet = require('../utils/urlset');
 
+const parseJson = (value) => {
+  try {
+    return JSON.parse(value);
+  } catch (e) {
+    return null;
+  }
+};
+
 const query = gql`
 
-query ContentSitemapNewsUrls {
-  contentSitemapNewsUrls {
+query ContentSitemapNewsUrls($input: ContentSitemapNewsUrlsQueryInput = {}) {
+  contentSitemapNewsUrls(input: $input) {
     id
     loc
     title
@@ -54,8 +62,11 @@ const createUrl = (website, {
 };
 
 module.exports = asyncRoute(async (req, res) => {
+  const input = parseJson(req.get('x-google-news-input') || '{}');
+  const variables = input ? { input } : undefined;
+
   const { apollo, websiteContext: website } = res.locals;
-  const { data } = await apollo.query({ query });
+  const { data } = await apollo.query({ query, variables });
   const { contentSitemapNewsUrls } = data;
 
   const urlset = new URLSet();


### PR DESCRIPTION
Input variables can now be established on website server boot. The input is sent via a JSON encoded header. Currently, Google News sitemaps will accept input via the `x-google-news-input` header. For example, in the root server file for a website:

```js
const newrelic = require('newrelic');
const { startServer } = require('@base-cms/marko-web');
const routes = require('./server/routes');
const siteConfig = require('./config/site');
const coreConfig = require('./config/core');
const document = require('./server/components/document');
const components = require('./server/components');
const fragments = require('./server/fragments');

const { log } = console;

module.exports = startServer({
  rootDir: __dirname,
  coreConfig,
  siteConfig,
  routes,
  document,
  components,
  fragments,
  onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
  onAsyncBlockError: e => newrelic.noticeError(e),
  sitemapsHeaders: {
    'x-google-news-input': JSON.stringify({ includeContentTypes: [], taxonomyIds: [2008779] }),
  },
}).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));
```

The `ContentSitemapNewsUrlsQueryInput` now supports including/excluding content types and filter by taxonomy IDs.