### PR TITLE
Add `attrs` input support to GAM ad components

### DIFF
--- a/packages/marko-web-gam/components/define-display-ad.marko
+++ b/packages/marko-web-gam/components/define-display-ad.marko
@@ -1,4 +1,5 @@
 import { BEM, warn } from "@base-cms/utils";
+import { getAsObject } from "@base-cms/object-path";
 import generateId from "../utils/generate-id";
 import buildSlots from "../utils/build-slots";
 import slotStyle from "../utils/slot-size-style";
@@ -24,6 +25,7 @@ $ calls.push(...buildSlots(slots));
 $ calls.push(`googletag.display('${id}');`);
 
 $ const attrs = {
+  ...getAsObject(input.attrs),
   'data-gam-path': path,
   'data-gam-size': JSON.stringify(size),
   'data-gam-targeting': targeting ? JSON.stringify(targeting) : undefined,

--- a/packages/marko-web-gam/components/define-display-ad.marko
+++ b/packages/marko-web-gam/components/define-display-ad.marko
@@ -8,7 +8,7 @@ $ const { isArray } = Array;
 $ const { path, inc, targeting, withWrapper } = input;
 $ const id = input.id || generateId({ inc });
 
-$ const size = typeof input.size === 'string' ? [input.size] : (isArray(input.size) ? input.size : []);
+$ const size = typeof input.size === "string" ? [input.size] : (isArray(input.size) ? input.size : []);
 $ const applyStyle = input.applyStyle == null ? false : input.applyStyle;
 $ const style = applyStyle ? slotStyle(size) : null;
 
@@ -26,9 +26,9 @@ $ calls.push(`googletag.display('${id}');`);
 
 $ const attrs = {
   ...getAsObject(input.attrs),
-  'data-gam-path': path,
-  'data-gam-size': JSON.stringify(size),
-  'data-gam-targeting': targeting ? JSON.stringify(targeting) : undefined,
+  "data-gam-path": path,
+  "data-gam-size": JSON.stringify(size),
+  "data-gam-targeting": targeting ? JSON.stringify(targeting) : undefined,
 };
 
 $ const blockName = input.blockName || "ad-container";

--- a/packages/marko-web-gam/components/display-ad.marko
+++ b/packages/marko-web-gam/components/display-ad.marko
@@ -9,9 +9,9 @@ $ const slots = getAsObject(input.slots);
 $ const slot = slots[id];
 $ const attrs = getAsObject(input.attrs);
 $ if (slot) {
-  attrs['data-gam-path'] = slot.path;
-  attrs['data-gam-size'] = JSON.stringify(slot.size);
-  attrs['data-gam-targeting'] = slot.targeting ? JSON.stringify(slot.targeting) : undefined;
+  attrs["data-gam-path"] = slot.path;
+  attrs["data-gam-size"] = JSON.stringify(slot.size);
+  attrs["data-gam-targeting"] = slot.targeting ? JSON.stringify(slot.targeting) : undefined;
 }
 
 <if(id)>

--- a/packages/marko-web-gam/components/display-ad.marko
+++ b/packages/marko-web-gam/components/display-ad.marko
@@ -7,13 +7,11 @@ $ const classNames = [blockName, ...BEM.applyModifiers(blockName, input.modifier
 
 $ const slots = getAsObject(input.slots);
 $ const slot = slots[id];
-$ let attrs = {};
+$ const attrs = getAsObject(input.attrs);
 $ if (slot) {
-  attrs = {
-    'data-gam-path': slot.path,
-    'data-gam-size': JSON.stringify(slot.size),
-    'data-gam-targeting': slot.targeting ? JSON.stringify(slot.targeting) : undefined,
-  };
+  attrs['data-gam-path'] = slot.path;
+  attrs['data-gam-size'] = JSON.stringify(slot.size);
+  attrs['data-gam-targeting'] = slot.targeting ? JSON.stringify(slot.targeting) : undefined;
 }
 
 <if(id)>

--- a/packages/marko-web-gam/components/marko.json
+++ b/packages/marko-web-gam/components/marko.json
@@ -54,6 +54,7 @@
     },
     "@class": "string",
     "@modifiers": "array",
+    "@attrs": "object",
     "@block-name": {
       "type": "string",
       "default-value": "ad-container"
@@ -66,6 +67,7 @@
     "@class": "string",
     "@style": "string",
     "@modifiers": "array",
+    "@attrs": "object",
     "@block-name": {
       "type": "string",
       "default-value": "ad-container"


### PR DESCRIPTION
Userland element attributes, when supplied, will now be applied to GAM ad display components.