### PR TITLE
Register load more middleware after onStart hook

### DIFF
--- a/packages/marko-web/express/index.js
+++ b/packages/marko-web/express/index.js
@@ -11,7 +11,6 @@ const loadObject = require('./load-object');
 const loadDocument = require('./load-document');
 const oembed = require('./oembed');
 const rss = require('./rss');
-const loadMore = require('./load-more');
 const sitemaps = require('./sitemaps');
 const { version } = require('../package.json');
 const websiteContext = require('./website-context');
@@ -92,9 +91,6 @@ module.exports = (config = {}) => {
 
   // Register public files.
   app.use(express.static(path.join(serverDir, 'public')));
-
-  // Register load more.
-  loadMore(app);
 
   // Register sitemaps.
   sitemaps(app, { ...config.sitemapsHeaders, ...headers });

--- a/packages/marko-web/start-server.js
+++ b/packages/marko-web/start-server.js
@@ -5,6 +5,7 @@ const { createTerminus } = require('@godaddy/terminus');
 const { isFunction: isFn } = require('@base-cms/utils');
 const errorHandlers = require('./express/error-handlers');
 const express = require('./express');
+const loadMore = require('./express/load-more');
 
 if (!process.env.LIVERELOAD_PORT) {
   process.env.LIVERELOAD_PORT = 4010;
@@ -69,6 +70,9 @@ module.exports = async ({
 
   // Await required services here...
   if (isFn(onStart)) await onStart(app);
+
+  // Register load more after onStart to ensure userland middleware is available.
+  loadMore(app);
 
   // Load website routes.
   if (!isFn(routes)) throw new Error('A routes function is required.');


### PR DESCRIPTION
This ensures that any userland middleware is available in load more templates.