### PR TITLE
Add inner contents render and support ad slot collapse

### DIFF
--- a/packages/marko-web-gam/components/define-display-ad.marko
+++ b/packages/marko-web-gam/components/define-display-ad.marko
@@ -42,6 +42,9 @@ $ const classNames = [blockName, ...BEM.applyModifiers(blockName, input.modifier
     ...attrs
   >
     <marko-web-gam-ad-wrapper id=id enabled=withWrapper block-name=blockName>
+      <if(input.renderBody)>
+        <${input.renderBody} block-name=blockName />
+      </if>
       <script>googletag.cmd.push(function() { ${calls.join(" ")} });</script>
     </marko-web-gam-ad-wrapper>
   </div>

--- a/packages/marko-web-gam/components/define-display-ad.marko
+++ b/packages/marko-web-gam/components/define-display-ad.marko
@@ -1,13 +1,21 @@
 import { BEM, warn } from "@base-cms/utils";
 import { getAsObject } from "@base-cms/object-path";
+import defaultValue from "@base-cms/marko-core/utils/default-value";
 import generateId from "../utils/generate-id";
 import buildSlots from "../utils/build-slots";
 import slotStyle from "../utils/slot-size-style";
 
 $ const { isArray } = Array;
-$ const { path, inc, targeting, withWrapper } = input;
+$ const {
+  path,
+  inc,
+  targeting,
+  withWrapper,
+  collapseBeforeAdFetch,
+} = input;
 $ const id = input.id || generateId({ inc });
 
+$ const collapse = defaultValue(input.collapse, true);
 $ const size = typeof input.size === "string" ? [input.size] : (isArray(input.size) ? input.size : []);
 $ const applyStyle = input.applyStyle == null ? false : input.applyStyle;
 $ const style = applyStyle ? slotStyle(size) : null;
@@ -19,6 +27,8 @@ $ const slots = {
     size,
     sizeMapping: input.sizeMapping,
     targeting,
+    collapse,
+    collapseBeforeAdFetch: input.collapseBeforeAdFetch,
   },
 };
 $ calls.push(...buildSlots(slots));
@@ -29,6 +39,8 @@ $ const attrs = {
   "data-gam-path": path,
   "data-gam-size": JSON.stringify(size),
   "data-gam-targeting": targeting ? JSON.stringify(targeting) : undefined,
+  "data-gam-collapse": collapse,
+  ...(collapseBeforeAdFetch && { "data-gam-collapse-before-ad-fetch": true }),
 };
 
 $ const blockName = input.blockName || "ad-container";

--- a/packages/marko-web-gam/components/display-ad.marko
+++ b/packages/marko-web-gam/components/display-ad.marko
@@ -22,6 +22,9 @@ $ if (slot) {
     ...attrs
   >
     <marko-web-gam-ad-wrapper id=id enabled=withWrapper block-name=blockName>
+      <if(input.renderBody)>
+        <${input.renderBody} block-name=blockName />
+      </if>
       <script>googletag.cmd.push(function() { googletag.display('${id}'); });</script>
     </marko-web-gam-ad-wrapper>
   </div>

--- a/packages/marko-web-gam/components/marko.json
+++ b/packages/marko-web-gam/components/marko.json
@@ -48,6 +48,8 @@
     "@size": "expression",
     "@size-mapping": "array",
     "@targeting": "object",
+    "@collapse": "boolean",
+    "@collapse-before-ad-fetch": "boolean",
     "@apply-style": {
       "type": "boolean",
       "default-value": false

--- a/packages/marko-web-gam/package.json
+++ b/packages/marko-web-gam/package.json
@@ -18,6 +18,7 @@
     "scrollmagic": "^2.0.7"
   },
   "peerDependencies": {
+    "@base-cms/marko-core": "^1.0.0-rc.1",
     "@base-cms/marko-web": "^1.0.0-rc.1"
   },
   "publishConfig": {

--- a/packages/marko-web-gam/utils/build-slots.js
+++ b/packages/marko-web-gam/utils/build-slots.js
@@ -1,8 +1,16 @@
 const { isObject } = require('@base-cms/utils');
+const defaultValue = require('@base-cms/marko-core/utils/default-value');
 const buildTargeting = require('./build-targeting');
 const buildSizeMapping = require('./build-size-mapping');
 
 const { isArray } = Array;
+
+const buildCollapse = (collapse, collapseBeforeAdFetch) => {
+  const args = [defaultValue(collapse, true) ? 'true' : 'false'];
+  if (collapseBeforeAdFetch === true) args.push('true');
+  if (collapseBeforeAdFetch === false) args.push('false');
+  return `setCollapseEmptyDiv(${args.join(', ')})`;
+};
 
 module.exports = (slots) => {
   if (!isObject(slots)) return [];
@@ -15,10 +23,13 @@ module.exports = (slots) => {
       size,
       sizeMapping,
       targeting,
+      collapse,
+      collapseBeforeAdFetch,
     }) => [
       `googletag.defineSlot('${path}', ${JSON.stringify(size)}, '${id}')`,
       buildTargeting(targeting),
       buildSizeMapping(sizeMapping),
+      buildCollapse(collapse, collapseBeforeAdFetch),
       'addService(googletag.pubads());',
     ].filter(v => v).join('.'));
 };


### PR DESCRIPTION
Ad slots now support inner content rendering and can enable (default) or disable being hidden (collapsed).