### PR TITLE
Remove leading and trailing slashes from section aliases

### DIFF
--- a/packages/marko-web/middleware/with-website-section.js
+++ b/packages/marko-web/middleware/with-website-section.js
@@ -11,8 +11,9 @@ module.exports = ({
 } = {}) => asyncRoute(async (req, res) => {
   const alias = isFn(aliasResolver) ? await aliasResolver(req, res) : req.params.alias;
   const { apollo } = req;
+  const cleanedAlias = alias.replace(/\/+$/, '').replace(/$\/+/, '');
 
-  const section = await loader(apollo, { alias });
+  const section = await loader(apollo, { alias: cleanedAlias });
   const { redirectTo, canonicalPath } = section;
   if (redirectTo) {
     return res.redirect(301, redirectTo);
@@ -23,7 +24,7 @@ module.exports = ({
   const pageNode = new PageNode(apollo, {
     queryFactory,
     queryFragment,
-    variables: { input: { alias } },
+    variables: { input: { alias: cleanedAlias } },
     resultField: 'websiteSectionAlias',
   });
   return res.marko(template, { ...section, pageNode });

--- a/packages/marko-web/middleware/with-website-section.js
+++ b/packages/marko-web/middleware/with-website-section.js
@@ -11,7 +11,7 @@ module.exports = ({
 } = {}) => asyncRoute(async (req, res) => {
   const alias = isFn(aliasResolver) ? await aliasResolver(req, res) : req.params.alias;
   const { apollo } = req;
-  const cleanedAlias = alias.replace(/\/+$/, '').replace(/$\/+/, '');
+  const cleanedAlias = alias.replace(/\/+$/, '').replace(/^\/+/, '');
 
   const section = await loader(apollo, { alias: cleanedAlias });
   const { redirectTo, canonicalPath } = section;


### PR DESCRIPTION
Ensures that `section-name/` and `/section-name` aliaes still load and do not 404.