### PR TITLE
Reduce size of embedded images when not full

### DIFF
--- a/services/graphql-server/src/graphql/utils/embedded-image-tags.js
+++ b/services/graphql-server/src/graphql/utils/embedded-image-tags.js
@@ -18,7 +18,8 @@ module.exports = async (body, { imageHost, basedb }) => {
       tag.setValid(false);
       return tag;
     }
-    const size = tag.get('size', '640').replace('w', '');
+    const defaultSize = ['left', 'right'].includes(tag.get('align')) ? '320' : '640';
+    const size = tag.get('size', defaultSize).replace('w', '');
 
     tag.set('alt', createAltFor(image));
     tag.set('src', createSrcFor(imageHost, image, {


### PR DESCRIPTION
Reduce w/h from 640px to 320px when an embedded image is aligned left or right.