### PR TITLE
Add browser component inner content rendering

### DIFF
--- a/packages/marko-web/components/browser-component.marko
+++ b/packages/marko-web/components/browser-component.marko
@@ -7,5 +7,8 @@ $ const contents = `<script>CMSBrowserComponents.loadComponent('#${id}', '${inpu
 <!-- @todo The loadComponent function should be proxied, e.g. cms('loadComponent', id, name, props); -->
 
 <div id=id>
+  <if(input.renderBody)>
+    <${input.renderBody} />
+  </if>
   $!{contents}
 </div>


### PR DESCRIPTION
Which will be replaced once the browser/Vue component is initialized. Allows for server-side content to be visible before the client-side component renders.