### PR TITLE
Add mutation to create images from a url

### DIFF
--- a/packages/base4-rest-api/src/client.js
+++ b/packages/base4-rest-api/src/client.js
@@ -120,6 +120,16 @@ class Base4RestApiClient {
     });
   }
 
+  async uploadImageFromUrl({ url } = {}) {
+    if (!url) throw new Error('An image URL must be passed to upload.');
+    return this.fetch({
+      method: 'post',
+      type: 'upload',
+      body: { uri: url },
+      endpoint: '-embedded',
+    });
+  }
+
   async fetch({
     method,
     type,
@@ -161,6 +171,7 @@ class Base4RestApiClient {
   }
 
   buildUrl({ type, endpoint } = {}) {
+    if (type === 'upload') return `${this.uri}/upload${cleanPath(endpoint)}`;
     if (!['persistence', 'search'].includes(type)) throw new Error(`The API resource type '${type}' is not supported.`);
     if (!endpoint) throw new Error('An API endpoint is required.');
     return `${this.uri}/${cleanPath(this.baseEndpoint)}/${type}/${cleanPath(endpoint)}`;

--- a/packages/base4-rest-api/src/client.js
+++ b/packages/base4-rest-api/src/client.js
@@ -124,9 +124,9 @@ class Base4RestApiClient {
     if (!url) throw new Error('An image URL must be passed to upload.');
     return this.fetch({
       method: 'post',
-      type: 'upload',
+      type: 'custom',
       body: { uri: url },
-      endpoint: '-embedded',
+      endpoint: 'upload-embedded',
     });
   }
 
@@ -171,9 +171,9 @@ class Base4RestApiClient {
   }
 
   buildUrl({ type, endpoint } = {}) {
-    if (type === 'upload') return `${this.uri}/upload${cleanPath(endpoint)}`;
-    if (!['persistence', 'search'].includes(type)) throw new Error(`The API resource type '${type}' is not supported.`);
+    if (!['persistence', 'search', 'custom'].includes(type)) throw new Error(`The API resource type '${type}' is not supported.`);
     if (!endpoint) throw new Error('An API endpoint is required.');
+    if (type === 'custom') return `${this.uri}/${cleanPath(endpoint)}`;
     return `${this.uri}/${cleanPath(this.baseEndpoint)}/${type}/${cleanPath(endpoint)}`;
   }
 

--- a/services/graphql-server/src/graphql/definitions/platform/asset.js
+++ b/services/graphql-server/src/graphql/definitions/platform/asset.js
@@ -6,6 +6,10 @@ extend type Query {
   assetImage(input: AssetImageQueryInput!): AssetImage @findOne(model: "platform.Asset", using: { id: "_id" }, criteria: "assetImage")
 }
 
+extend type Mutation {
+  createAssetImageFromUrl(input: CreateAssetImageFromUrlMutationInput!): AssetImage! @requiresAuth
+}
+
 type AssetImage {
   # from platform.model::Asset
   id: ObjectID! @projection(localField: "_id") @value(localField: "_id")
@@ -69,6 +73,10 @@ enum AssetImageSortField {
 
 input AssetImageQueryInput {
   id: ObjectID!
+}
+
+input CreateAssetImageFromUrlMutationInput {
+  url: String!
 }
 
 input AssetImageSortInput {


### PR DESCRIPTION
Adds a mutation to handle uploading an image to Base using the Base4Rest client.

```gql
mutation CreateAssetImageFromUrl($input: CreateAssetImageFromUrlMutationInput!){
  createAssetImageFromUrl(input:$input){
    id
    src
  }
}
```
```json
{
  "input": {
    "url": "https://cuf-uploads.s3.amazonaws.com/pmmi_all/eeea637c-14ea-4cba-8809-930777bc3c47/1901_f1_1.jpg"
  },
}
```