### PR TITLE
Contact mutations

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/types/company.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/types/company.js
@@ -155,7 +155,7 @@ input UpdateContentCompanyPublicContactsMutationInput {
 }
 
 input UpdateContentCompanyPublicContactsPayloadMutationInput {
-  ids: [Int!]!
+  contactIds: [Int!]!
 }
 
 `;

--- a/services/graphql-server/src/graphql/definitions/platform/content/types/company.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/types/company.js
@@ -10,6 +10,7 @@ extend type Mutation {
   updateContentCompany(input: UpdateContentCompanyMutationInput!): ContentCompany @requiresAuth
   updateContentCompanyImages(input: UpdateContentCompanyImagesMutationInput!): ContentCompany @requiresAuth
   updateContentCompanySocialLinks(input: UpdateContentCompanySocialLinksMutationInput!): ContentCompany @requiresAuth
+  updateContentCompanyPublicContacts(input: UpdateContentCompanyPublicContactsMutationInput!): ContentCompany @requiresAuth
 }
 
 type ContentCompany implements Content & PrimaryCategory & Contactable & Addressable & SocialLinkable & Inquirable & OrganizationContactable @applyInterfaceFields {
@@ -146,6 +147,15 @@ input ContentCompanySortInput {
 
 input ContentCompanyYoutubeVideosInput {
   pagination: PaginationInput = {}
+}
+
+input UpdateContentCompanyPublicContactsMutationInput {
+  id: Int!
+  payload: UpdateContentCompanyPublicContactsPayloadMutationInput = {}
+}
+
+input UpdateContentCompanyPublicContactsPayloadMutationInput {
+  ids: [Int!]!
 }
 
 `;

--- a/services/graphql-server/src/graphql/definitions/platform/content/types/contact.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/types/contact.js
@@ -6,6 +6,10 @@ extend type Query {
   contentContact(input: ContentContactQueryInput!): ContentContact @findOne(model: "platform.Content", using: { id: "_id" }, criteria: "contentContact")
 }
 
+extend type Mutation {
+  createContentContact(input: CreateContentContactMutationInput!): ContentContact! @requiresAuth
+}
+
 type ContentContact implements Content & Contactable & Addressable & SocialLinkable @applyInterfaceFields {
   # GraphQL-only fields
   # @todo Implement
@@ -58,6 +62,17 @@ input ContentContactOwnedContentInput {
 input ContentContactSortInput {
   field: ContentContactSortField = id
   order: SortOrder = desc
+}
+
+input CreateContentContactMutationInput {
+  payload: CreateContentContactPayloadMutationInput = {}
+}
+
+input CreateContentContactPayloadMutationInput {
+  firstName: String
+  lastName: String
+  title: String
+  status: Int = 2
 }
 
 `;

--- a/services/graphql-server/src/graphql/definitions/platform/content/types/contact.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/types/contact.js
@@ -8,6 +8,7 @@ extend type Query {
 
 extend type Mutation {
   createContentContact(input: CreateContentContactMutationInput!): ContentContact! @requiresAuth
+  updateContentContact(input: UpdateContentContactMutationInput!): ContentContact! @requiresAuth
 }
 
 type ContentContact implements Content & Contactable & Addressable & SocialLinkable @applyInterfaceFields {
@@ -73,6 +74,18 @@ input CreateContentContactPayloadMutationInput {
   lastName: String
   title: String
   status: Int = 2
+}
+
+input UpdateContentContactMutationInput {
+  id: Int!
+  payload: UpdateContentContactPayloadMutationInput = {}
+}
+
+input UpdateContentContactPayloadMutationInput {
+  firstName: String
+  lastName: String
+  title: String
+  status: Int
 }
 
 `;

--- a/services/graphql-server/src/graphql/definitions/platform/content/types/contact.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/types/contact.js
@@ -9,6 +9,7 @@ extend type Query {
 extend type Mutation {
   createContentContact(input: CreateContentContactMutationInput!): ContentContact! @requiresAuth
   updateContentContact(input: UpdateContentContactMutationInput!): ContentContact! @requiresAuth
+  updateContentContactImages(input: UpdateContentContactImagesMutationInput!): ContentContact! @requiresAuth
 }
 
 type ContentContact implements Content & Contactable & Addressable & SocialLinkable @applyInterfaceFields {
@@ -86,6 +87,16 @@ input UpdateContentContactPayloadMutationInput {
   lastName: String
   title: String
   status: Int
+}
+
+input UpdateContentContactImagesMutationInput {
+  id: Int!
+  payload: UpdateContentContactImagesPayloadMutationInput = {}
+}
+
+input UpdateContentContactImagesPayloadMutationInput {
+  primaryImage: ObjectID
+  images: [ObjectID!]
 }
 
 `;

--- a/services/graphql-server/src/graphql/definitions/platform/content/types/contact.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/types/contact.js
@@ -95,8 +95,8 @@ input UpdateContentContactImagesMutationInput {
 }
 
 input UpdateContentContactImagesPayloadMutationInput {
-  primaryImage: ObjectID
-  images: [ObjectID!]
+  primaryImageId: ObjectID
+  imageIds: [ObjectID!]
 }
 
 `;

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -1232,10 +1232,10 @@ module.exports = {
     updateContentCompanyPublicContacts: async (_, { input }, { base4rest, basedb }, info) => {
       validateRest(base4rest);
       const type = 'platform/content/contact';
-      const { id, payload: { ids } } = input;
+      const { id, payload: { contactIds } } = input;
       const body = new Base4RestPayload({ type: 'platform/content/company' });
       body.set('id', id);
-      body.setLinks('publicContacts', ids.map(i => ({ id: i, type })));
+      body.setLinks('publicContacts', contactIds.map(i => ({ id: i, type })));
       await base4rest.updateOne({ model: 'platform/content/company', id, body });
       const projection = buildProjection({ info, type: 'ContentCompany' });
       return basedb.findOne('platform.Content', { _id: id }, { projection });

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -1216,10 +1216,10 @@ module.exports = {
       const contact = 'platform/content/contact';
       const image = 'platform/asset/image';
       const { id, payload } = input;
-      const { images, primaryImage } = payload;
+      const { imageIds, primaryImageId } = payload;
       const body = new Base4RestPayload({ type: contact });
-      if (primaryImage) body.setLink('primaryImage', { id: primaryImage, type: image });
-      if (images) body.setLinks('images', images.map(imgId => ({ id: imgId, type: image })));
+      if (primaryImageId) body.setLink('primaryImage', { id: primaryImageId, type: image });
+      if (imageIds) body.setLinks('images', imageIds.map(imgId => ({ id: imgId, type: image })));
       body.set('id', id);
       await base4rest.updateOne({ model: contact, id, body });
       const projection = buildProjection({ info, type: 'ContentContact' });

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -1177,5 +1177,20 @@ module.exports = {
       const projection = buildProjection({ info, type: 'ContentCompany' });
       return basedb.findOne('platform.Content', { _id: id }, { projection });
     },
+
+    /**
+     *
+     */
+    createContentContact: async (_, { input }, { base4rest, basedb }, info) => {
+      validateRest(base4rest);
+      const type = 'platform/content/contact';
+      const { payload } = input;
+      const keys = Object.keys(payload);
+      const body = new Base4RestPayload({ type });
+      keys.forEach(k => body.set(k, payload[k]));
+      const { data } = await base4rest.insertOne({ model: type, body });
+      const projection = buildProjection({ info, type: 'ContentContact' });
+      return basedb.findOne('platform.Content', { _id: data.id }, { projection });
+    },
   },
 };

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -1192,5 +1192,20 @@ module.exports = {
       const projection = buildProjection({ info, type: 'ContentContact' });
       return basedb.findOne('platform.Content', { _id: data.id }, { projection });
     },
+
+    /**
+     *
+     */
+    updateContentContact: async (_, { input }, { base4rest, basedb }, info) => {
+      validateRest(base4rest);
+      const type = 'platform/content/contact';
+      const { id, payload } = input;
+      const body = new Base4RestPayload({ type });
+      Object.keys(payload).forEach(k => body.set(k, payload[k]));
+      body.set('id', id);
+      await base4rest.updateOne({ model: type, id, body });
+      const projection = buildProjection({ info, type: 'ContentContact' });
+      return basedb.findOne('platform.Content', { _id: id }, { projection });
+    },
   },
 };

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -1207,5 +1207,23 @@ module.exports = {
       const projection = buildProjection({ info, type: 'ContentContact' });
       return basedb.findOne('platform.Content', { _id: id }, { projection });
     },
+
+    /**
+     *
+     */
+    updateContentContactImages: async (_, { input }, { base4rest, basedb }, info) => {
+      validateRest(base4rest);
+      const contact = 'platform/content/contact';
+      const image = 'platform/asset/image';
+      const { id, payload } = input;
+      const { images, primaryImage } = payload;
+      const body = new Base4RestPayload({ type: contact });
+      if (primaryImage) body.setLink('primaryImage', { id: primaryImage, type: image });
+      if (images) body.setLinks('images', images.map(imgId => ({ id: imgId, type: image })));
+      body.set('id', id);
+      await base4rest.updateOne({ model: contact, id, body });
+      const projection = buildProjection({ info, type: 'ContentContact' });
+      return basedb.findOne('platform.Content', { _id: id }, { projection });
+    },
   },
 };

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -1225,5 +1225,20 @@ module.exports = {
       const projection = buildProjection({ info, type: 'ContentContact' });
       return basedb.findOne('platform.Content', { _id: id }, { projection });
     },
+
+    /**
+     *
+     */
+    updateContentCompanyPublicContacts: async (_, { input }, { base4rest, basedb }, info) => {
+      validateRest(base4rest);
+      const type = 'platform/content/contact';
+      const { id, payload: { ids } } = input;
+      const body = new Base4RestPayload({ type: 'platform/content/company' });
+      body.set('id', id);
+      body.setLinks('publicContacts', ids.map(i => ({ id: i, type })));
+      await base4rest.updateOne({ model: 'platform/content/company', id, body });
+      const projection = buildProjection({ info, type: 'ContentCompany' });
+      return basedb.findOne('platform.Content', { _id: id }, { projection });
+    },
   },
 };


### PR DESCRIPTION
Adds the following mutations:
- createContentContact
- updateContentContact
- updateContentContactImages
- updateContentCompanyPublicContacts

```graphql
# Write your query or mutation here
mutation CreateContentContact($createContact: CreateContentContactMutationInput!){
  createContentContact(input: $createContact) {
    id
    status
    name
    firstName
    lastName
    title
    primaryImage {
      src
    }
  }
}

# Write your query or mutation here
mutation UpdateContentContact($updateContact: UpdateContentContactMutationInput!){
  updateContentContact(input:$updateContact) {
    id
    status
    name
    firstName
    lastName
    title
    primaryImage {
      src
    }
  }
}

mutation UpdateContentContactImages($updateImages: UpdateContentContactImagesMutationInput!) {
  updateContentContactImages(input: $updateImages) {
    id
    primaryImage {
      id
      src
    }
    images {
      edges {
        node {
          id
          src
        }
      }
    }
  }
}

mutation UpdateContentCompanyPublicContacts($updateContacts: UpdateContentCompanyPublicContactsMutationInput!) {
  updateContentCompanyPublicContacts(input: $updateContacts) {
    id
    publicContacts {
      edges {
        node {
          id
          name
        }
      }
    }
  }
}
```
```json
{
  "createContact": {
    "payload": {
      "firstName": "Jean-Luc",
      "lastName": "Picard",
      "title":"Captain"
    }
  },
  "updateContact": {
    "id": 21118184,
    "payload": {
      "title": "Admiral (retired)",
      "status": 1
    }
  },
  "updateImages": {
    "id": 21118184,
    "payload": {
      "primaryImage": "5df406929f818c2c008b456c",
      "images": ["5df406929f818c2c008b456c"]
    }
  },
  "updateContacts": {
    "id": 21117626,
    "payload": {
      "ids": [21118184, 21118076]
    }
  }
}
```