### PR TITLE
Add default `bg` value of white for logo images

### DIFF
--- a/packages/image/src/build-imgix-url.js
+++ b/packages/image/src/build-imgix-url.js
@@ -160,6 +160,7 @@ module.exports = (src, selected, defaults, isLogo) => {
   if (isLogo) {
     options.fit = 'fill';
     options.fillColor = options.fillColor || 'fff';
+    options.bg = options.bg || 'fff';
     options.pad = options.pad || '5';
   }
   try {


### PR DESCRIPTION
Ensures logos with an alpha channel usethe same color as the fill.