### PR TITLE
Ensure redirect and query params input are merged

### DIFF
--- a/services/graphql-server/src/graphql/resolvers/website/site.js
+++ b/services/graphql-server/src/graphql/resolvers/website/site.js
@@ -1,5 +1,6 @@
-const querystring = require('querystring');
+const { URL, URLSearchParams } = require('url');
 const { UserInputError } = require('apollo-server-express');
+const { asObject } = require('@base-cms/utils');
 const defaults = require('../../defaults');
 
 const cleanRedirect = async (redirect, from, basedb) => {
@@ -66,11 +67,20 @@ module.exports = {
       const siteId = input.siteId || site.id();
       if (!siteId) throw new UserInputError('A siteId must be provided via input or context.');
 
-      const query = querystring.stringify(params);
+      const queryParams = new URLSearchParams(asObject(params));
       const redirect = await basedb.findOne('website.Redirects', { siteId, from });
       const cleaned = await cleanRedirect(redirect, from, basedb);
+
       // Preserve query string params (if applicable);
-      if (cleaned && cleaned.to && query) cleaned.to = `${cleaned.to}?${query}`;
+      if (cleaned && cleaned.to && `${queryParams}`) {
+        // Determine if the `to` value has query params.
+        // If so, merge with the incoming params.
+        // If the same param is present in both, the `to` value wins.
+        // Must put a "fake" host in front of the path to properly parse.
+        const toUrl = new URL(`http://localhost${cleaned.to}`);
+        toUrl.searchParams.forEach((value, key) => queryParams.set(key, value));
+        cleaned.to = `${toUrl.pathname}?${queryParams}`;
+      }
       return cleaned;
     },
   },

--- a/services/graphql-server/src/graphql/resolvers/website/site.js
+++ b/services/graphql-server/src/graphql/resolvers/website/site.js
@@ -77,9 +77,12 @@ module.exports = {
         // If so, merge with the incoming params.
         // If the same param is present in both, the `to` value wins.
         // Must put a "fake" host in front of the path to properly parse.
-        const toUrl = new URL(`http://localhost${cleaned.to}`);
+        const isExternal = /^http/.test(cleaned.to);
+        const to = isExternal ? cleaned.to : `http://localhost${cleaned.to}`;
+        const toUrl = new URL(to);
         toUrl.searchParams.forEach((value, key) => queryParams.set(key, value));
-        cleaned.to = `${toUrl.pathname}?${queryParams}`;
+        const origin = isExternal ? toUrl.origin : '';
+        cleaned.to = `${origin}${toUrl.pathname}?${queryParams}`;
       }
       return cleaned;
     },


### PR DESCRIPTION
Fixes an issue where, if the `redirect.to` value contained a query string, and the incoming `input.params` were present, two query string values were being appended.

For example, if the `to` value was `/foo?x=y` and the incoming input params were `{ a: 'b' }`, the final `to` value became `/foo?x=y?a=b`. This subsequently caused bad requests when the `to` value was accessed.

The above example will now return as `/foo?x=y&a=b`.

If there is a conflicting query param key, the value of the redirect wins. For example:
With a `to` value of `/foo?x=y` and an input of `{ x: 'z' }`, the final result would be `/foo?x=y` _not_ `/foo?x=z`.