### PR TITLE
Published content query builder

### DIFF
--- a/packages/marko-web/middleware/with-content.js
+++ b/packages/marko-web/middleware/with-content.js
@@ -13,10 +13,11 @@ module.exports = ({
   const id = isFn(idResolver) ? await idResolver(req, res) : req.params.id;
   const { apollo } = req;
 
-  const additionalInput = { since: new Date() };
+  const additionalInput = {};
   if (req.cookies['preview-mode'] || req.query['preview-mode']) {
-    delete additionalInput.since;
     additionalInput.status = 'any';
+  } else {
+    additionalInput.since = new Date();
   }
   const content = await loader(apollo, { id, additionalInput });
   const { redirectTo } = content;

--- a/packages/marko-web/middleware/with-content.js
+++ b/packages/marko-web/middleware/with-content.js
@@ -13,8 +13,11 @@ module.exports = ({
   const id = isFn(idResolver) ? await idResolver(req, res) : req.params.id;
   const { apollo } = req;
 
-  const additionalInput = {};
-  if (req.cookies['preview-mode'] || req.query['preview-mode']) additionalInput.status = 'any';
+  const additionalInput = { since: new Date() };
+  if (req.cookies['preview-mode'] || req.query['preview-mode']) {
+    delete additionalInput.since;
+    additionalInput.status = 'any';
+  }
   const content = await loader(apollo, { id, additionalInput });
   const { redirectTo } = content;
   const path = get(content, 'siteContext.path');

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -9,6 +9,7 @@ extend type Query {
     model: "platform.Content",
     using: { id: "_id" },
     criteria: "content",
+    queryBuilder: "publishedContent",
     withSite: false, # allow content to always load, regardless of site context.
   )
   contentHash(input: ContentHashQueryInput = {}): Content @findOne(
@@ -231,6 +232,7 @@ input ContentQueryInput {
   siteId: ObjectID
   status: ModelStatus = active
   id: Int!
+  since: Date
 }
 
 input ContentHashQueryInput {

--- a/services/graphql-server/src/graphql/query-builders/index.js
+++ b/services/graphql-server/src/graphql/query-builders/index.js
@@ -1,5 +1,6 @@
 const magazineActiveIssues = require('./magazine-active-issues');
 const magazineLatestIssue = require('./magazine-latest-issue');
+const publishedContent = require('./published-content');
 const taxonomies = require('./taxonomies');
 const websiteSections = require('./website-sections');
 
@@ -17,6 +18,7 @@ const websiteSections = require('./website-sections');
 const builders = {
   magazineActiveIssues,
   magazineLatestIssue,
+  publishedContent,
   taxonomies,
   websiteSections,
 };

--- a/services/graphql-server/src/graphql/query-builders/published-content.js
+++ b/services/graphql-server/src/graphql/query-builders/published-content.js
@@ -1,0 +1,12 @@
+const { getPublishedContentCriteria } = require('@base-cms/utils');
+
+module.exports = ({ query }, { input }) => {
+  const { since } = input;
+
+  if (since) {
+    const criteria = getPublishedContentCriteria({ since });
+    return { query: { ...query, ...criteria } };
+  }
+
+  return { query };
+};


### PR DESCRIPTION
Adds `since` parameter to the content query to support only returning published content (independant of status). This is primarily for use on the websites to prevent returning content that has expired (or is not yet published).

Once released, consuming applications will need to update the `marko-web` package to take advantage of the new query middleware.