### PR TITLE
Use timestamp instead of date for `since` value

### DIFF
--- a/packages/marko-web/middleware/with-content.js
+++ b/packages/marko-web/middleware/with-content.js
@@ -17,7 +17,7 @@ module.exports = ({
   if (req.cookies['preview-mode'] || req.query['preview-mode']) {
     additionalInput.status = 'any';
   } else {
-    additionalInput.since = new Date();
+    additionalInput.since = Date.now();
   }
   const content = await loader(apollo, { id, additionalInput });
   const { redirectTo } = content;


### PR DESCRIPTION
This fixes an issue where valid, active content was 404ing. The underlying GraphQL query expects the date value to be a millisecond timestamp, not a stringified date object.