### PR TITLE
Ensure magazine active issues query uses status

### DIFF
--- a/services/graphql-server/src/graphql/definitions/magazine/issue.js
+++ b/services/graphql-server/src/graphql/definitions/magazine/issue.js
@@ -85,6 +85,7 @@ input MagazineLatestIssueQueryInput {
 }
 
 input MagazineActiveIssuesQueryInput {
+  status: ModelStatus = active
   publicationId: ObjectID!
   excludeIssueIds: [Int!] = []
   sort: MagazineIssueSortInput = { field: mailDate, order: desc }


### PR DESCRIPTION
Otherwise, by default, deleted issues are displayed.