### PR TITLE
Update leaders view-more link to be external

### DIFF
--- a/packages/leaders-program/src/components/card/blocks/view-more.vue
+++ b/packages/leaders-program/src/components/card/blocks/view-more.vue
@@ -1,5 +1,5 @@
 <template>
-  <common-link :href="href" @click="emitClick">
+  <common-link :href="href" :target="target" @click="emitClick">
     {{ value }} &raquo;
   </common-link>
 </template>
@@ -14,6 +14,10 @@ export default {
     href: {
       type: String,
       required: true,
+    },
+    target: {
+      type: String,
+      default: '_self',
     },
     label: {
       type: String,

--- a/packages/leaders-program/src/components/card/index.vue
+++ b/packages/leaders-program/src/components/card/index.vue
@@ -55,7 +55,12 @@
           Featured Videos
         </template>
         <template #header-right>
-          <view-more label="videos" :href="profileHref" @click="handleProfileClick" />
+          <view-more
+            label="videos"
+            :href="youtubeHref"
+            target="_blank"
+            @click="handleVideoClick"
+          />
         </template>
         <template #default="{ item }">
           <video-card
@@ -63,7 +68,7 @@
             :title="item.title"
             :href="item.url"
             :image-src="item.thumbnail"
-            @click="handeVideoClick"
+            @click="handleVideoClick"
           />
         </template>
       </content-deck>
@@ -111,6 +116,9 @@ export default {
     },
     profileHref() {
       return get(this.company, 'siteContext.path');
+    },
+    youtubeHref() {
+      return get(this.company, 'youtube.url');
     },
     executive() {
       return getEdgeNodes(this.company, 'publicContacts')[0];
@@ -164,7 +172,7 @@ export default {
         label: 'Company Website',
       }, data, event);
     },
-    handeVideoClick(data, event) {
+    handleVideoClick(data, event) {
       this.emitAction({
         type: 'click',
         label: 'YouTube Video',

--- a/packages/leaders-program/src/graphql/queries/content-for-section.js
+++ b/packages/leaders-program/src/graphql/queries/content-for-section.js
@@ -93,6 +93,7 @@ query ContentForLeadersSection($sectionId: Int!) {
           youtube {
             username
             channelId
+            url
           }
           videos: youtubeVideos(input: { pagination: { limit: 3 } }) {
             edges {


### PR DESCRIPTION
- Update "View More" videos link to be an external link to Youtube URL
- Support passing `target` attr to `view-more` component
- Fix `handeVideoClick` typo