### PR TITLE
Add screen change events

### DIFF
--- a/packages/marko-web-gtm/browser/track-bus-event.vue
+++ b/packages/marko-web-gtm/browser/track-bus-event.vue
@@ -33,15 +33,27 @@ export default {
      */
     eventName: {
       type: String,
-      required: true,
+      default: null,
+    },
+
+    /**
+     * Whether to clear the data layer after firing the event,
+     */
+    clearData: {
+      type: Boolean,
+      default: false,
     },
   },
   created() {
-    const { on, eventName } = this;
-    if (on && eventName) {
-      this.EventBus.$on(on, (...args) => {
+    const { on } = this;
+    if (on) {
+      const eventName = this.eventName || on;
+      this.EventBus.$on(on, (data) => {
         const dataLayer = window[this.layerName];
-        if (dataLayer) dataLayer.push({ eventArgs: args, event: eventName });
+        if (dataLayer) {
+          dataLayer.push({ [eventName]: data, event: eventName });
+          if (this.clearData) dataLayer.push({ [eventName]: undefined, event: undefined });
+        }
       });
     }
   },

--- a/packages/marko-web-gtm/components/marko.json
+++ b/packages/marko-web-gtm/components/marko.json
@@ -47,6 +47,7 @@
     "template": "./track-bus-event.marko",
     "@on": "string",
     "@event-name": "string",
-    "@layer-name": "string"
+    "@layer-name": "string",
+    "@clear-data": "boolean"
   }
 }

--- a/packages/marko-web/browser/components/index.js
+++ b/packages/marko-web/browser/components/index.js
@@ -1,5 +1,6 @@
 import LoadMoreTrigger from './load-more-trigger.vue';
 import TriggerInViewEvent from './trigger-in-view-event.vue';
+import TriggerScreenChangeEvent from './trigger-screen-change-event.vue';
 
 const OEmbed = () => import(/* webpackChunkName: "oembed" */ './oembed.vue');
 const FormDotComGatedDownload = () => import(/* webpackChunkName: "form-dot-com" */ './gated-download/form-dot-com.vue');
@@ -8,6 +9,7 @@ const WufooGatedDownload = () => import(/* webpackChunkName: "wufoo-gated-downlo
 export default (Browser) => {
   Browser.register('LoadMoreTrigger', LoadMoreTrigger);
   Browser.register('TriggerInViewEvent', TriggerInViewEvent);
+  Browser.register('TriggerScreenChangeEvent', TriggerScreenChangeEvent);
   Browser.register('OEmbed', OEmbed);
   Browser.register('FormDotComGatedDownload', FormDotComGatedDownload);
   Browser.register('WufooGatedDownload', WufooGatedDownload);

--- a/packages/marko-web/browser/components/trigger-screen-change-event.vue
+++ b/packages/marko-web/browser/components/trigger-screen-change-event.vue
@@ -1,0 +1,94 @@
+<template>
+  <div :id="elementId" style="display: none;" />
+</template>
+
+<script>
+import EventBus from '../event-bus';
+import elementId from './element-id';
+import $ from '../jquery';
+
+export default {
+  props: {
+    multiplier: {
+      type: Number,
+      default: 1.35,
+    },
+    screenHeight: {
+      type: Number,
+      default: 1000,
+    },
+    scrollTimeoutMs: {
+      type: Number,
+      default: 250,
+    },
+    eventName: {
+      type: String,
+      default: 'screen_change',
+    },
+  },
+
+  data: () => ({
+    activeScreen: 1,
+    didScroll: true,
+  }),
+
+  computed: {
+    elementId() {
+      return elementId(`${this.eventName}-event`);
+    },
+    maxHeight() {
+      const { screenHeight } = this;
+      if (!screenHeight) return window.innerHeight;
+      return screenHeight;
+    },
+  },
+
+  watch: {
+    activeScreen(current, old) {
+      const direction = current < old ? 'Up' : 'Down';
+      this.trigger(direction);
+    },
+  },
+
+  mounted() {
+    $(window).on('scroll', () => {
+      this.didScroll = true;
+    });
+    setInterval(this.handleScroll, this.scrollTimeoutMs);
+  },
+
+  beforeDestroy() {
+    clearInterval(this.handleScroll);
+  },
+
+  methods: {
+    getScrollY() {
+      return window.pageYOffset || window.scrollY;
+    },
+
+    handleScroll() {
+      if (this.didScroll) {
+        this.setActiveScreen();
+        this.didScroll = false;
+      }
+    },
+
+    setActiveScreen() {
+      const screenHeight = this.maxHeight * this.multiplier;
+      this.activeScreen = Math.floor(this.getScrollY() / screenHeight) + 1;
+    },
+
+    trigger(direction) {
+      EventBus.$emit(this.eventName, {
+        direction,
+        activeScreen: this.activeScreen,
+        scrollY: this.getScrollY(),
+        maxHeight: this.maxHeight,
+        multiplier: this.multiplier,
+        innerHeight: window.innerHeight,
+        innerWidth: window.innerWidth,
+      });
+    },
+  },
+};
+</script>

--- a/services/example-website-lfw/config/site.js
+++ b/services/example-website-lfw/config/site.js
@@ -23,7 +23,7 @@ module.exports = {
     { provider: 'facebook', href: 'https://www.facebook.com/pages/Laser-Focus-World/126899915297', target: '_blank' },
   ],
   gtm: {
-    containerId: 'GTM-M7H8VJG',
+    containerId: 'GTM-MFCT2LV',
   },
   wufoo: {
     userName: 'cygnuscorporate',

--- a/services/example-website-lfw/server/components/document.marko
+++ b/services/example-website-lfw/server/components/document.marko
@@ -16,6 +16,8 @@ $ const { site } = out.global;
     <marko-web-gam-enable />
   </@head>
   <@above-container>
+    <marko-web-browser-component name="TriggerScreenChangeEvent" />
+    <marko-web-gtm-track-bus-event on="screen_change" />
     <marko-web-reveal-ad-listener />
     <marko-web-gtm-track-load-more />
     <default-theme-site-header />


### PR DESCRIPTION
Create generic `screen_change` event in `marko-web` that is sent along the Vue event bus. Then, using the `<marko-web-gtm-track-bus-event>` component, send the change event and data to GTM.