### PR TITLE
Update reveal ad component

### DIFF
--- a/packages/marko-web-reveal-ad/browser/listener.vue
+++ b/packages/marko-web-reveal-ad/browser/listener.vue
@@ -56,6 +56,7 @@ export default {
       $('body').css({ backgroundColor }).prepend(revealBackground);
     },
     displayAd(element) {
+      if (!element) return;
       const {
         adClickUrl,
         adImagePath,
@@ -74,11 +75,12 @@ export default {
       $(element).before(adContainer);
     },
     shouldDisplay() {
-      const { displayFrequency, observed } = this;
-      this.observed = observed + 1;
+      const { displayFrequency } = this;
+      this.observed += 1;
       return this.observed % displayFrequency > 0;
     },
     observeMutations() {
+      if (!window.MutationObserver) return;
       this.observer = new MutationObserver((mutationList) => {
         for (let i = 0; i < mutationList.length; i += 1) {
           const mutation = mutationList[i];
@@ -94,7 +96,7 @@ export default {
       });
       const node = document.querySelector(this.target);
       if (node && node.parentNode) {
-        this.observer.observe(node.parentNode, { childList: true });
+        this.observer.observe(node.parentNode, { childList: true, subtree: true });
       }
     },
     listener(event) {

--- a/packages/marko-web-reveal-ad/browser/listener.vue
+++ b/packages/marko-web-reveal-ad/browser/listener.vue
@@ -13,51 +13,95 @@ const parseJson = (str) => {
   }
 };
 
+const target = '_blank';
+const rel = 'noopener noreferrer';
+
 export default {
   props: {
-    target: {
+    containerClass: {
       type: String,
-      default: '.document-container .page',
+      default: 'document-container',
+    },
+    targetClass: {
+      type: String,
+      default: 'page',
+    },
+    displayFrequency: {
+      type: Number,
+      default: 2,
     },
     defaults: {
       type: Object,
       default: () => ({ backgroundColor: 'transparent' }),
     },
   },
+  data: () => ({
+    observed: 0,
+    observer: null,
+    payload: {},
+  }),
   created() {
     window.addEventListener('message', this.listener);
   },
   beforeDestroy() {
     window.removeEventListener('message', this.listener);
+    if (this.observer) this.observer.disconnect();
   },
   methods: {
-    display(payload) {
-      const options = { ...this.defaults, ...payload };
-      const { adClickUrl: href, backgroundColor, backgroundImagePath } = options;
-      const { adImagePath: src, adTitle: alt } = options;
+    displayBackground() {
+      const { adClickUrl: href, backgroundColor, backgroundImagePath } = this.payload;
+
       const backgroundImage = `url("${backgroundImagePath}")`;
-
-      const title = alt;
-      const target = '_blank';
-      const rel = 'noopener noreferrer';
-
       const adContainer = $('<div>').addClass('reveal-ad');
-      if (options.boxShadow) adContainer.addClass(`reveal-ad--${options.boxShadow}-shadow`);
-      adContainer.html($('<a>', {
-        href,
-        title,
-        target,
-        rel,
-      }).append($('<img>', { src, alt })));
+      if (this.payload.boxShadow) adContainer.addClass(`reveal-ad--${this.payload.boxShadow}-shadow`);
 
       const revealBackground = $('<a>', { href, target, rel }).addClass('reveal-ad-background').css({ backgroundImage });
       $('body').css({ backgroundColor }).prepend(revealBackground);
-      $(this.target).before(adContainer);
+    },
+    displayAd(element) {
+      const { adClickUrl: href, adImagePath: src, adTitle: alt } = this.payload;
+
+      const adContainer = $('<div>').addClass('reveal-ad');
+      if (this.payload.boxShadow) adContainer.addClass(`reveal-ad--${this.payload.boxShadow}-shadow`);
+      adContainer.html($('<a>', {
+        href,
+        title: alt,
+        target,
+        rel,
+      }).append($('<img>', { src, alt })));
+      $(element).before(adContainer);
+    },
+    shouldDisplay() {
+      const { displayFrequency, observed } = this;
+      this.observed = observed + 1;
+      return this.observed % displayFrequency > 0;
+    },
+    observeMutations() {
+      this.observer = new MutationObserver((list) => {
+        // Use traditional 'for loops' for IE 11
+        // eslint-disable-next-line no-restricted-syntax, prefer-const
+        for (let mutation of list) {
+          if (mutation.type === 'childList') {
+            // eslint-disable-next-line no-restricted-syntax, prefer-const
+            for (let added of mutation.addedNodes) {
+              if (added.classList && added.classList.contains(this.targetClass)) {
+                if (this.shouldDisplay()) this.displayAd(added);
+              }
+            }
+          }
+        }
+      });
+      const node = document.getElementsByClassName(this.containerClass)[0];
+      this.observer.observe(node, { childList: true });
     },
     listener(event) {
       const payload = parseJson(event.data);
+      const element = $(`.${this.containerClass} .${this.targetClass}`);
       if (['adImagePath', 'adTitle', 'backgroundImagePath', 'adClickUrl'].every(k => payload[k])) {
-        this.display(payload);
+        this.payload = { ...this.defaults, ...payload };
+        this.displayBackground();
+        this.displayAd(element);
+        this.observeMutations();
         window.removeEventListener('message', this.listener);
       }
     },


### PR DESCRIPTION
- Adds `displayFrequency` parameter to set the frequency at which the secondary ads should be shown
- Removes `target` parameter in favor of explicit `containerClass` and `targetClass` params to indicate the observed element and the class designating a target area.
- Utilizes a `MutationObserver` to detect changes to the container, and handle display logic

![screencapture-0-0-0-0-11162-2020-01-21-14_22_43](https://user-images.githubusercontent.com/1778222/72840587-2ee98300-3c5a-11ea-92cd-d876bf6a864a.jpg)
