### PR TITLE
Extract imported images via file loader

### DIFF
--- a/packages/web-cli/package.json
+++ b/packages/web-cli/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-vue": "^5.2.3",
     "fancy-log": "^1.3.3",
     "figlet": "^1.2.4",
+    "file-loader": "^5.0.2",
     "graphql": "^14.5.4",
     "graphql-tag": "^2.10.1",
     "gulp": "^4.0.2",

--- a/packages/web-cli/src/gulp/js.js
+++ b/packages/web-cli/src/gulp/js.js
@@ -53,6 +53,7 @@ const readRcFile = (cwd) => {
 // @todo Add default polyfills to entry point
 module.exports = cwd => (cb) => {
   const { exclude, targets, debug } = readRcFile(cwd);
+  const imagePattern = /\.(png|svg|jpg|gif|webp)$/;
   const { ifProduction, ifNotProduction } = getIfUtils(process.env.NODE_ENV || 'development');
   pump([
     src('browser/index.js', { cwd }),
@@ -112,12 +113,21 @@ module.exports = cwd => (cb) => {
               require.resolve('css-loader'),
             ],
           },
+          {
+            test: imagePattern,
+            loader: require.resolve('file-loader'),
+            options: {
+              name: '[name].[ext]',
+              outputPath: '../assets',
+            },
+          },
         ],
       },
       plugins: [
         new VueLoaderPlugin(),
         new ManifestPlugin({
           publicPath: '',
+          filter: ({ name }) => !imagePattern.test(name),
         }),
       ],
     }, wp),

--- a/yarn.lock
+++ b/yarn.lock
@@ -7200,6 +7200,14 @@ file-loader@^4.2.0:
     loader-utils "^1.2.3"
     schema-utils "^2.0.0"
 
+file-loader@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-5.0.2.tgz#7f3d8b4ac85a5e8df61338cfec95d7405f971caa"
+  integrity sha512-QMiQ+WBkGLejKe81HU8SZ9PovsU/5uaLo0JdTCEXOYv7i7jfAjHZi1tcwp9tSASJPOmmHZtbdCervFmXMH/Dcg==
+  dependencies:
+    loader-utils "^1.2.3"
+    schema-utils "^2.5.0"
+
 filesize@^3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.6.1.tgz#090bb3ee01b6f801a8a8be99d31710b3422bb317"


### PR DESCRIPTION
Currently, this will only handle images that are directly imported into frontend JS files or via CSS files that are directly imported. All extracted images are placed in the site's `dist/assets` folder.