### PR TITLE
Add webpack config callback support; expose full version of jQuery

### DIFF
--- a/packages/marko-web/browser/jquery-full.js
+++ b/packages/marko-web/browser/jquery-full.js
@@ -1,0 +1,3 @@
+import $ from 'jquery/dist/jquery.min';
+
+export default $;

--- a/packages/web-cli/src/gulp/js.js
+++ b/packages/web-cli/src/gulp/js.js
@@ -48,89 +48,113 @@ const readRcFile = (cwd) => {
   return { exclude, targets, debug };
 };
 
+/**
+ * Loads a configuration callback in the current working
+ * directory that receives the base webpack config.
+ *
+ * This function can modify the webpack config in any way.
+ *
+ * @param {string} cwd
+ * @returns {function|null}
+ */
+const loadConfigCallback = (cwd) => {
+  const fileName = 'webpack.base-cms.js';
+  const fileLoc = join(cwd, fileName);
+  const fileExists = existsSync(fileLoc);
+  if (!fileExists) return null;
+  // eslint-disable-next-line import/no-dynamic-require
+  const fn = require(fileLoc);
+  return typeof fn === 'function' ? fn : null;
+};
+
 // @todo Determine how to combine CSS with the main CSS build
 // @todo Add sass to Vue components
 // @todo Add default polyfills to entry point
 module.exports = cwd => (cb) => {
   const { exclude, targets, debug } = readRcFile(cwd);
+  const configCallback = loadConfigCallback(cwd);
   const imagePattern = /\.(png|svg|jpg|gif|webp)$/;
   const { ifProduction, ifNotProduction } = getIfUtils(process.env.NODE_ENV || 'development');
-  pump([
-    src('browser/index.js', { cwd }),
-    webpack({
-      mode: ifProduction('production', 'development'),
-      cache: ifNotProduction(),
-      devtool: 'source-map',
-      output: {
-        library: 'CMSBrowserComponents',
-        libraryExport: 'default',
-        libraryTarget: 'umd',
-        filename: 'index.[contenthash:8].js',
-        chunkFilename: '[name].[contenthash:8].js',
-        publicPath: '/dist/js/',
-      },
-      module: {
-        rules: [
-          {
-            test: /\.vue$/,
-            loader: require.resolve('vue-loader'),
-          },
-          {
-            test: /\.js$/,
-            loader: require.resolve('babel-loader'),
-            exclude,
-            options: {
-              presets: [
-                [
-                  require.resolve('@babel/preset-env'),
-                  {
-                    modules: false,
-                    useBuiltIns: false,
-                    targets,
-                    loose: false,
-                    debug,
-                  },
-                ],
+
+  let baseConfig = {
+    mode: ifProduction('production', 'development'),
+    cache: ifNotProduction(),
+    devtool: 'source-map',
+    output: {
+      library: 'CMSBrowserComponents',
+      libraryExport: 'default',
+      libraryTarget: 'umd',
+      filename: 'index.[contenthash:8].js',
+      chunkFilename: '[name].[contenthash:8].js',
+      publicPath: '/dist/js/',
+    },
+    module: {
+      rules: [
+        {
+          test: /\.vue$/,
+          loader: require.resolve('vue-loader'),
+        },
+        {
+          test: /\.js$/,
+          loader: require.resolve('babel-loader'),
+          exclude,
+          options: {
+            presets: [
+              [
+                require.resolve('@babel/preset-env'),
+                {
+                  modules: false,
+                  useBuiltIns: false,
+                  targets,
+                  loose: false,
+                  debug,
+                },
               ],
-              plugins: [
-                [
-                  require.resolve('@babel/plugin-transform-runtime'),
-                  {
-                    regenerator: true,
-                    corejs: false,
-                    helpers: true,
-                    useESModules: false,
-                    absoluteRuntime,
-                  },
-                ],
+            ],
+            plugins: [
+              [
+                require.resolve('@babel/plugin-transform-runtime'),
+                {
+                  regenerator: true,
+                  corejs: false,
+                  helpers: true,
+                  useESModules: false,
+                  absoluteRuntime,
+                },
               ],
-            },
-          },
-          {
-            test: /\.css$/,
-            use: [
-              require.resolve('vue-style-loader'),
-              require.resolve('css-loader'),
             ],
           },
-          {
-            test: imagePattern,
-            loader: require.resolve('file-loader'),
-            options: {
-              name: '[name].[ext]',
-              outputPath: '../assets',
-            },
+        },
+        {
+          test: /\.css$/,
+          use: [
+            require.resolve('vue-style-loader'),
+            require.resolve('css-loader'),
+          ],
+        },
+        {
+          test: imagePattern,
+          loader: require.resolve('file-loader'),
+          options: {
+            name: '[name].[ext]',
+            outputPath: '../assets',
           },
-        ],
-      },
-      plugins: [
-        new VueLoaderPlugin(),
-        new ManifestPlugin({
-          publicPath: '',
-          filter: ({ name }) => !imagePattern.test(name),
-        }),
+        },
       ],
-    }, wp),
+    },
+    plugins: [
+      new VueLoaderPlugin(),
+      new ManifestPlugin({
+        publicPath: '',
+        filter: ({ name }) => !imagePattern.test(name),
+      }),
+    ],
+  };
+  if (configCallback) baseConfig = configCallback({ baseConfig, ifProduction, ifNotProduction });
+
+  pump([
+    src('browser/index.js', { cwd }),
+    webpack(baseConfig, wp),
     dest('dist/js', { cwd }),
   ], e => completeTask(e, cb));
 };


### PR DESCRIPTION
If a `webpack.base-cms.js` file exists in the working directory of the site (and is a function) it will be called with the base Webpack configuration. This allows consuming projects to modify the standard configuration in any way.

For example, if the `cwd` is `/some-project/some-site`, then creating the file below would instruct Webpack to ignore AMD modules. This is simply an example - any config values can be modified.
```js
// File: /some-project/some-site/webpack.base-cms.js
module.exports = ({ baseConfig }) => {
  baseConfig.module.rules.push({ parser: { amd: false } });
  return baseConfig;
};
```

In addition, an optional `jquery-full.js` export was added for consumers who wish to import the full version of jQuery into their components. This isn't used or required by any core components. For example, to use inside a Vue component:
```vue
<script>
import $ from '@base-cms/marko-web/browser/jquery-full';

export default {
  mounted() {
    $(document).ready(() => {
      // Do something
    });
  },
};
</script>
```
While it is generally discouraged to use jQuery (and especially the full library) there may be edge cases that require it.