### PR TITLE
Update oEmbed browser component to handle scripts

### DIFF
--- a/packages/marko-web/browser/components/oembed.vue
+++ b/packages/marko-web/browser/components/oembed.vue
@@ -40,7 +40,8 @@ export default {
   }),
   computed: {
     id() {
-      return `${this.attrs.id}-${Date.now()}`;
+      const clean = `${this.attrs.id}`.replace(/[\W|-]/ig, '');
+      return `${clean}-${Date.now()}`;
     },
     html() {
       if (this.embed) return this.embed;

--- a/packages/marko-web/browser/components/oembed.vue
+++ b/packages/marko-web/browser/components/oembed.vue
@@ -37,6 +37,7 @@ export default {
     embed: null,
     oembedType: null,
     provider: null,
+    observer: null,
   }),
   computed: {
     id() {
@@ -52,6 +53,35 @@ export default {
   },
   mounted() {
     document.addEventListener('lazybeforeunveil', this.lazyload.bind(this));
+    if (window.MutationObserver) {
+      // inline script tags aren't added to the DOM, so the twitter widget never loads
+      // This would be widespread -- if the payload returns a script tag, ensure that it is
+      // appended to the head rather than written as part of the `embed` code here.
+      this.observer = new MutationObserver((mutationList) => {
+        for (let i = 0; i < mutationList.length; i += 1) {
+          const mutation = mutationList[i];
+          if (mutation.type === 'childList') {
+            for (let x = 0; x < mutation.addedNodes.length; x += 1) {
+              const added = mutation.addedNodes[x];
+              if (added.tagName && added.tagName === 'SCRIPT') {
+                const script = document.createElement('script');
+                for (let n = 0; n < added.attributes.length; n += 1) {
+                  const { name, value } = added.attributes[n];
+                  script.setAttribute(name, value);
+                }
+                document.querySelector('head').appendChild(script);
+              }
+            }
+          }
+        }
+      });
+      const node = document.getElementById(this.id);
+      this.observer.observe(node, { childList: true, subtree: true });
+    }
+  },
+  beforeDestroy() {
+    document.removeEventListener('lazybeforeunveil', this.lazyload);
+    if (this.observer) this.observer.disconnect();
   },
   methods: {
     lazyload({ target }) {


### PR DESCRIPTION
[CS-3080 - Embedding a tweet into BASE article](https://southcomm.atlassian.net/browse/CS-3080)

Currently, the twitter oEmbed widgets do not work as they rely on a Javascript payload. These embeds work on Icarus sites due to the global head injection of the twitter widget payload. This PR addresses this issue by pushing incoming script tags (if any) to the head of the document, allowing them to be executed and load as expected.

- Update oEmbed element ID to match [MDN recommendations](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id)
- Add MutationObserver to the oEmbed element that will listen for inserted script tags
- If script tags are found, it will duplicate their attributes and insert them into the document `<head>`, causing them to be executed.
- _Note:_ Simply doing `document.querySelector('head').appendChild(added)` does not work with script elements, as they have already been cached (or something) and re-appending them doesn't cause them to be executed (same results with `Node.cloneNode()`) -- hence the iteration over the script attributes.

This change has no BC breaks and should result in patch version.