### PR TITLE
Throw warning when query component is not found

### DIFF
--- a/packages/marko-core/components/queries/index.marko
+++ b/packages/marko-core/components/queries/index.marko
@@ -1,3 +1,4 @@
+import { warn } from "@base-cms/utils";
 import AllAuthorContent from "./all-author-content";
 import AllCompanyContent from "./all-company-content";
 import AllPublishedContent from "./all-published-content";
@@ -36,7 +37,6 @@ $ const map = {
   "website-section": WebsiteSection,
   "website-sections": WebsiteSections,
 };
-$ const name = input.name;
 $ const collapsible = shouldCollapse(input.collapsible);
 
 $ const Component = map[input.name];
@@ -60,3 +60,6 @@ $ const Component = map[input.name];
     </else>
   </>
 </if>
+<else>
+  $ warn(`Unable to execute query: no component was found for '${input.name}'`);
+</else>


### PR DESCRIPTION
Previously, when passing a query `name` without a corresponding component, the query would silently collapse. A warning message will now be emitted in the console on this condition. Example:

```
Warning: Unable to execute query: no component was found for 'website-schedule-content'
    at module.exports (/root/node_modules/@base-cms/utils/src/warn.js:5:11)
    at render (/root/node_modules/@base-cms/marko-core/components/queries/index.marko.js:82:5)
    at renderer (/root/node_modules/marko/src/runtime/components/renderer.js:227:9)
    at wrappedRenderer (/root/node_modules/marko/src/runtime/helpers/load-tag.js:19:9)
    at renderBody (/root/sites/oemoffhighway.com/server/templates/website-section/market-analysis/equipment-market-outlook.marko.js:109:33)
    at dynamicTag (/root/node_modules/marko/src/runtime/helpers/dynamic-tag.js:118:29)
    at /root/node_modules/@base-cms/marko-web/components/element/index.marko.js:30:7
    at dynamicTag (/root/node_modules/marko/src/runtime/helpers/dynamic-tag.js:58:17)
    at render (/root/node_modules/@base-cms/marko-web/components/element/index.marko.js:25:5)
    at renderer (/root/node_modules/marko/src/runtime/components/renderer.js:227:9)
```