### PR TITLE
Add content alias redirect support

### DIFF
--- a/packages/marko-web/express/error-handlers.js
+++ b/packages/marko-web/express/error-handlers.js
@@ -2,6 +2,7 @@ const { STATUS_CODES } = require('http');
 const createError = require('http-errors');
 const errorTemplate = require('../components/document/components/error');
 const getRedirect = require('./get-redirect');
+const findContentAlias = require('./find-content-alias');
 
 const { isArray } = Array;
 
@@ -30,6 +31,24 @@ const render = (res, { statusCode, err, template }) => {
   return renderError(res, { statusCode, err, template });
 };
 
+const redirectOrError = ({
+  req,
+  res,
+  err,
+  redirectHandler,
+  statusCode,
+  template,
+}) => {
+  getRedirect(req, redirectHandler).then((redirect) => {
+    if (redirect) {
+      const { code, to } = redirect;
+      res.redirect(code, to);
+    } else {
+      render(res, { statusCode, err, template });
+    }
+  }).catch(() => render(res, { statusCode, err, template }));
+};
+
 module.exports = (app, { template, redirectHandler }) => {
   // Force Express to throw an error on 404s.
   app.use((req, res, next) => { // eslint-disable-line no-unused-vars
@@ -40,14 +59,27 @@ module.exports = (app, { template, redirectHandler }) => {
   // @todo handle logging
   app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
     const statusCode = err.status || err.statusCode || 500;
+    const opts = {
+      req,
+      res,
+      err,
+      redirectHandler,
+      statusCode,
+      template,
+    };
 
-    getRedirect(req, redirectHandler).then((redirect) => {
-      if (redirect) {
-        const { code, to } = redirect;
-        res.redirect(code, to);
-      } else {
-        render(res, { statusCode, err, template });
-      }
-    }).catch(() => render(res, { statusCode, err, template }));
+    // Attempt to load aliased content (when applicable).
+    if (statusCode === 404) {
+      findContentAlias({ req }).then((redirectTo) => {
+        if (redirectTo) {
+          res.set('x-redirected-from', req.path);
+          res.redirect(301, redirectTo);
+        } else {
+          redirectOrError(opts);
+        }
+      }).catch(() => redirectOrError(opts));
+    } else {
+      redirectOrError(opts);
+    }
   });
 };

--- a/packages/marko-web/express/find-content-alias.js
+++ b/packages/marko-web/express/find-content-alias.js
@@ -1,0 +1,30 @@
+const gql = require('graphql-tag');
+const { get } = require('@base-cms/object-path');
+const buildContentInput = require('../utils/build-content-input');
+
+const query = gql`
+
+query WebsiteContentPageAlias($input: ContentAliasQueryInput!) {
+  contentAlias(input: $input) {
+    id
+    siteContext {
+      path
+    }
+  }
+}
+
+`;
+
+module.exports = async ({ req }) => {
+  const { apollo, path } = req;
+  if (!path) return null;
+  const alias = path.replace(/\/+$/, '').replace(/^\/+/, '');
+  if (!alias) return null;
+
+  const input = buildContentInput({ req });
+  input.alias = alias;
+  const variables = { input };
+  const { data } = await apollo.query({ query, variables });
+  if (!data || !data.contentAlias) return null;
+  return get(data, 'contentAlias.siteContext.path');
+};

--- a/packages/marko-web/middleware/with-content.js
+++ b/packages/marko-web/middleware/with-content.js
@@ -3,6 +3,7 @@ const { asyncRoute, isFunction: isFn } = require('@base-cms/utils');
 const { content: loader } = require('@base-cms/web-common/page-loaders');
 const { blockContent: queryFactory } = require('@base-cms/web-common/query-factories');
 const PageNode = require('./page-node');
+const buildContentInput = require('../utils/build-content-input');
 
 module.exports = ({
   template,
@@ -13,12 +14,7 @@ module.exports = ({
   const id = isFn(idResolver) ? await idResolver(req, res) : req.params.id;
   const { apollo } = req;
 
-  const additionalInput = {};
-  if (req.cookies['preview-mode'] || req.query['preview-mode']) {
-    additionalInput.status = 'any';
-  } else {
-    additionalInput.since = Date.now();
-  }
+  const additionalInput = buildContentInput({ req });
   const content = await loader(apollo, { id, additionalInput });
   const { redirectTo } = content;
   const path = get(content, 'siteContext.path');

--- a/packages/marko-web/utils/build-content-input.js
+++ b/packages/marko-web/utils/build-content-input.js
@@ -1,0 +1,9 @@
+module.exports = ({ req }) => {
+  const input = {};
+  if (req.cookies['preview-mode'] || req.query['preview-mode']) {
+    input.status = 'any';
+  } else {
+    input.since = Date.now();
+  }
+  return input;
+};

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -12,6 +12,14 @@ extend type Query {
     queryBuilder: "publishedContent",
     withSite: false, # allow content to always load, regardless of site context.
   )
+  # load content from custom alias
+  contentAlias(input: ContentAliasQueryInput = {}): Content @findOne(
+    model: "platform.Content",
+    using: { alias: "mutations.Website.alias" },
+    criteria: "content",
+    queryBuilder: "publishedContent",
+    withSite: false, # allow content to always load, regardless of site context.
+  )
   contentHash(input: ContentHashQueryInput = {}): Content @findOne(
     model: "platform.Content",
     using: { hash: "hash" },
@@ -233,6 +241,13 @@ input ContentQueryInput {
   siteId: ObjectID
   status: ModelStatus = active
   id: Int!
+  since: Date
+}
+
+input ContentAliasQueryInput {
+  siteId: ObjectID
+  status: ModelStatus = active
+  alias: String!
   since: Date
 }
 


### PR DESCRIPTION
If the website could not find a match for a route, it will now attempt to look up a content object using the current request path. If a content alias exists that matches the path, the user will be redirect to the _canonical_ URL for that content object. If no qualifying content was found (no alias, bad status, or expired) the standard "redirect-or-error" logic will continue.