### PR TITLE
Add support for custom delivery URIs in config

### DIFF
--- a/packages/marko-newsletters-email-x/config.js
+++ b/packages/marko-newsletters-email-x/config.js
@@ -23,8 +23,8 @@ class EmailXConfiguration {
     const foundAdUnit = getAsObject(this.adUnits, `${alias}.${name}`);
     // Ensure ad unit is duplicated so property re-assignment doesn't "stick."
     return {
-      ...foundAdUnit,
       uri: this.uri,
+      ...foundAdUnit,
     };
   }
 
@@ -36,6 +36,7 @@ class EmailXConfiguration {
    * @param {string} params.id The ad unit id, e.g. `5d4b04769f69b200013ab109`.
    * @param {number} params.width The ad unit width.
    * @param {number} params.height The ad unit height.
+   * @param {string} [params.uri] A custom delivery URI for this adunit
    */
   setAdUnit({
     alias,
@@ -43,6 +44,7 @@ class EmailXConfiguration {
     id,
     width,
     height,
+    uri,
   } = {}) {
     if (!name || !alias || !id) throw new Error('Unable to create EmailX ad unit: the name, alias, and ID are required');
     if (!width || !height) throw new Error('Unable to create EmailX ad unit: the height and width are required');
@@ -53,6 +55,7 @@ class EmailXConfiguration {
       name,
       alias,
     };
+    if (uri) adUnit.uri = uri;
     set(this.adUnits, `${alias}.${name}`, adUnit);
     return this;
   }


### PR DESCRIPTION
Consuming applications can now customize the delivery URI per ad unit. For example:

```js
const EmailXConfiguration = require('@base-cms/marko-newsletters-email-x/config');

const config = new EmailXConfiguration('https://indm.serve.email-x.io');

config
  .setAdUnits('fm-today', [
    {
      name: 'header',
      id: '5ddd5531c044ef4d6c9d4055',
      width: 600,
      height: 100,
      uri: 'https://email-serve.foodmanufacturing.com',
    },
  ]);

module.exports = config;
```