### PR TITLE
Add `sectionIds` parameter to leaders component

### DIFF
--- a/packages/leaders-program/src/components/leaders.vue
+++ b/packages/leaders-program/src/components/leaders.vue
@@ -41,6 +41,7 @@ import LeadersHeader from './header.vue';
 
 import allQuery from '../graphql/queries/all-sections';
 import fromTaxonomyQuery from '../graphql/queries/sections-from-taxonomy';
+import fromIdsQuery from '../graphql/queries/sections-from-ids';
 import contentQuery from '../graphql/queries/content';
 import getEdgeNodes from '../utils/get-edge-nodes';
 
@@ -59,6 +60,10 @@ export default {
     contentId: {
       type: Number,
       default: null,
+    },
+    sectionIds: {
+      type: Array,
+      default: () => ([]),
     },
     open: {
       type: String,
@@ -216,6 +221,14 @@ export default {
     },
 
     async loadSections() {
+      const { sectionIds } = this;
+      if (sectionIds && sectionIds.length) {
+        const variables = { sectionIds };
+        const r = await this.$apollo.query({ query: fromIdsQuery, variables });
+        const sections = getEdgeNodes(r, 'data.websiteSections')
+          .filter(s => s.hierarchy.some(({ alias }) => alias === this.sectionAlias));
+        if (sections.length) return sections;
+      }
       const fromContent = await this.loadContentSections();
       if (fromContent.length) {
         this.loadType = 'contextual';

--- a/packages/leaders-program/src/graphql/queries/sections-from-ids.js
+++ b/packages/leaders-program/src/graphql/queries/sections-from-ids.js
@@ -1,0 +1,24 @@
+import gql from 'graphql-tag';
+
+export default gql`
+
+query LeadersSectionsFromIds($sectionIds: [Int!]!) {
+  websiteSections(input: {
+    includeIds: $sectionIds,
+    pagination: { limit: 0 },
+    sort: { field: name, order: asc },
+  }) {
+    edges {
+      node {
+        id
+        name
+        hierarchy {
+          id
+          alias
+        }
+      }
+    }
+  }
+}
+
+`;


### PR DESCRIPTION
Allows sectionIds to be specified. For use when displaying a contextual block without section related taxonomy --  will likely be the content primary section or all ids the content is scheduled to (endeavor leaders program)