### PR TITLE
Allow Wufoo forms to display without a target

### DIFF
--- a/packages/marko-web-theme-default/components/content/download/index.marko
+++ b/packages/marko-web-theme-default/components/content/download/index.marko
@@ -20,3 +20,6 @@ $ const { surveyId, surveyType } = getAsObject(content, "gating");
     </else>
   </marko-web-block>
 </if>
+<else-if(surveyId && surveyType === "wufoo")>
+  <default-theme-content-download-wufoo ...input.wufoo survey-id=surveyId />
+</else-if>

--- a/packages/marko-web-theme-default/components/content/download/wufoo.marko
+++ b/packages/marko-web-theme-default/components/content/download/wufoo.marko
@@ -10,7 +10,7 @@ $ const props = {
   height: input.height,
 };
 
-<if(userName && surveyId && target)>
+<if(userName && surveyId)>
   <marko-web-element block-name=blockName name="wufoo-form">
     <marko-web-browser-component
       name="WufooGatedDownload"
@@ -19,5 +19,5 @@ $ const props = {
   </marko-web-element>
 </if>
 <else>
-  $ warn('Unable to create Wufoo download form: a username, survey ID, and file target are required.');
+  $ warn('Unable to create Wufoo download form: a username and survey ID are required.');
 </else>

--- a/packages/marko-web/browser/components/gated-download/wufoo.vue
+++ b/packages/marko-web/browser/components/gated-download/wufoo.vue
@@ -41,7 +41,7 @@ export default {
     },
     target: {
       type: String,
-      required: true,
+      default: null,
     },
     height: {
       type: String,
@@ -82,7 +82,7 @@ export default {
         async: true,
         ssl: true,
         addSubmitListener: (e) => {
-          if (e.data === 'wufoo-submit-done') {
+          if (e.data === 'wufoo-submit-done' && this.target) {
             this.canDownload = true;
             window.open(this.target);
           }


### PR DESCRIPTION
Since Wufoo forms can handle their own downloads, allow Wufoo forms to appear even when a content `fileSrc` isn’t present.

If the `fileSrc` is present, handle the Wufoo+download “dance” in the same way.

This wasn’t applied to form.com forms.