### PR TITLE
Add class to body when reveal ad is present

### DIFF
--- a/packages/marko-web-reveal-ad/browser/listener.vue
+++ b/packages/marko-web-reveal-ad/browser/listener.vue
@@ -54,6 +54,7 @@ export default {
       const backgroundImage = `url("${backgroundImagePath}")`;
       const revealBackground = $('<a>', { href: adClickUrl, target, rel }).addClass('reveal-ad-background').css({ backgroundImage });
       $('body').css({ backgroundColor }).prepend(revealBackground);
+      $('body').addClass('with-reveal-ad');
     },
     displayAd(element) {
       if (!element) return;


### PR DESCRIPTION
Allows websites to target other elements of the page when the reveal ad is active.