### PR TITLE
Add custom context support to website section pages

### DIFF
--- a/packages/marko-web/middleware/with-website-section.js
+++ b/packages/marko-web/middleware/with-website-section.js
@@ -8,6 +8,7 @@ module.exports = ({
   queryFragment,
   aliasResolver,
   redirectOnPathMismatch = true,
+  context: contextFn,
 } = {}) => asyncRoute(async (req, res) => {
   const alias = isFn(aliasResolver) ? await aliasResolver(req, res) : req.params.alias;
   const { apollo } = req;
@@ -27,5 +28,15 @@ module.exports = ({
     variables: { input: { alias: cleanedAlias } },
     resultField: 'websiteSectionAlias',
   });
-  return res.marko(template, { ...section, pageNode });
+
+  let context = {};
+  if (typeof contextFn === 'function') {
+    context = await contextFn({
+      req,
+      res,
+      section,
+      pageNode,
+    });
+  }
+  return res.marko(template, { ...section, pageNode, context });
 });


### PR DESCRIPTION
If the `context` callback passed to the middleware, it will be called with the current request, response, website section, and page node. This allows consuming websites to return custom context values (in the form of an object) that will be passed to the template as `data.context`.