### PR TITLE
Add support for custom print URL

### DIFF
--- a/packages/marko-web-social-sharing/browser/share-button.vue
+++ b/packages/marko-web-social-sharing/browser/share-button.vue
@@ -53,6 +53,15 @@ export default {
       type: Boolean,
       default: false,
     },
+    /**
+     * A custom print landing page URL.
+     * If set, the print action will redirect the user as opposed
+     * to prompting the print dialog.
+     */
+    printUrl: {
+      type: String,
+      default: null,
+    },
   },
 
   data: () => ({
@@ -114,7 +123,12 @@ export default {
       if (this.type === 'direct') {
         window.open(url, '_self');
       } else if (this.type === 'print') {
-        window.print();
+        const { printUrl } = this;
+        if (printUrl) {
+          window.open(printUrl, '_self');
+        } else {
+          window.print();
+        }
       } else {
         this.openPopup(url);
       }

--- a/packages/marko-web-social-sharing/browser/social-sharing.vue
+++ b/packages/marko-web-social-sharing/browser/social-sharing.vue
@@ -8,6 +8,7 @@
       :title="title"
       :description="description"
       :media="media"
+      :print-url="printUrl"
       :show-action="showAction"
       @open="emitEvent('open', ...arguments)"
       @change="emitEvent('change', ...arguments)"
@@ -49,6 +50,15 @@ export default {
     providers: {
       type: Array,
       default: () => [],
+    },
+    /**
+     * A custom print landing page URL.
+     * If set, the print action will redirect the user as opposed
+     * to prompting the print dialog.
+     */
+    printUrl: {
+      type: String,
+      default: null,
     },
   },
 

--- a/packages/marko-web-social-sharing/components/marko.json
+++ b/packages/marko-web-social-sharing/components/marko.json
@@ -7,6 +7,8 @@
     "@title": "string",
     "@description": "string",
     "@media": "string",
+    "@print-url": "string",
+    "@print-path": "string",
     "@show-action": "boolean"
   }
 }

--- a/packages/marko-web-social-sharing/components/social-sharing.marko
+++ b/packages/marko-web-social-sharing/components/social-sharing.marko
@@ -5,8 +5,16 @@ $ const { req, requestOrigin } = out.global;
 $ const path = input.path || req.path;
 $ const url = input.url || `${out.global.requestOrigin}/${cleanPath(path)}`;
 
+$ let printUrl;
+$ if (input.printUrl) {
+  printUrl = input.printUrl;
+} else if (input.printPath) {
+  printUrl = `${out.global.requestOrigin}/${cleanPath(input.printPath)}`;
+}
+
 $ const props = {
   url,
+  printUrl,
   providers: input.providers,
   title: input.title,
   description: input.description,


### PR DESCRIPTION
If a `printUrl` (or `printPath` on the server-side) is provided to the social share component, the Print button (if enabled) will redirect the user to that location.

If not specified, the default print prompt will still display.