### PR TITLE
Service boot enhancements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ x-env-defaults: &env
   YARN_CACHE_FOLDER: /.yarn-cache
   NODE_ENV: development
   TERMINUS_TIMEOUT: 1000
-  TERMINUS_BEFORE_SHUTDOWN_TIMEOUT: 0
+  TERMINUS_SHUTDOWN_DELAY: 0
 
 x-env-newrelic: &env-newrelic
   NEW_RELIC_ENABLED: ${NEW_RELIC_ENABLED-0}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3.7'
 x-env-defaults: &env
   YARN_CACHE_FOLDER: /.yarn-cache
   NODE_ENV: development
+  TERMINUS_TIMEOUT: 1000
+  TERMINUS_BEFORE_SHUTDOWN_TIMEOUT: 0
 
 x-env-newrelic: &env-newrelic
   NEW_RELIC_ENABLED: ${NEW_RELIC_ENABLED-0}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,10 +22,11 @@ module.exports = ({
   const serve = async () => {
     if (node) node.kill();
     node = await spawn('node', [entry], { stdio: 'inherit' });
-    node.on('close', (code) => {
-      if (code === 8) {
-        log('Error detected, waiting for changes...');
-      }
+    node.on('close', (code, signal) => {
+      const exited = [];
+      if (code) exited.push(`code ${(code)}`);
+      if (signal) exited.push(`signal ${(signal)}`);
+      log(`Process ${('exited')} with ${exited.join(' ')}`);
     });
   };
 

--- a/services/graphql-server/src/env.js
+++ b/services/graphql-server/src/env.js
@@ -6,6 +6,7 @@ const {
   bool,
   port,
   str,
+  num,
 } = envalid;
 const { nonemptystr } = custom;
 
@@ -22,4 +23,6 @@ module.exports = cleanEnv(process.env, {
   GOOGLE_DATA_API_URI: nonemptystr({ desc: 'The Google Data API URI', default: 'http://google-data-api' }),
   TOKEN_SECRET: nonemptystr({ desc: 'The token signing secret.' }),
   TOKEN_NAMESPACE: nonemptystr({ desc: 'The UUIDv4 namespace' }),
+  TERMINUS_TIMEOUT: num({ desc: 'Number of milliseconds before forceful exiting', default: 30000 }),
+  TERMINUS_BEFORE_SHUTDOWN_TIMEOUT: num({ desc: 'Number of milliseconds before the HTTP server starts its shutdown', default: 5000 }),
 });

--- a/services/graphql-server/src/env.js
+++ b/services/graphql-server/src/env.js
@@ -24,5 +24,5 @@ module.exports = cleanEnv(process.env, {
   TOKEN_SECRET: nonemptystr({ desc: 'The token signing secret.' }),
   TOKEN_NAMESPACE: nonemptystr({ desc: 'The UUIDv4 namespace' }),
   TERMINUS_TIMEOUT: num({ desc: 'Number of milliseconds before forceful exiting', default: 30000 }),
-  TERMINUS_BEFORE_SHUTDOWN_TIMEOUT: num({ desc: 'Number of milliseconds before the HTTP server starts its shutdown', default: 5000 }),
+  TERMINUS_SHUTDOWN_DELAY: num({ desc: 'Number of milliseconds before the HTTP server starts its shutdown', default: 5000 }),
 });

--- a/services/graphql-server/src/index.js
+++ b/services/graphql-server/src/index.js
@@ -19,7 +19,10 @@ const run = async () => {
     healthChecks: { '/_health': () => services.ping() },
     onSignal: () => {
       log('> Cleaning up...');
-      return services.stop().catch(e => log('> CLEANUP ERRORS:', e));
+      return services.stop().catch((e) => {
+        newrelic.noticeError(e);
+        log('> CLEANUP ERRORS:', e);
+      });
     },
     onShutdown: () => log('> Cleanup finished. Shutting down.'),
   });

--- a/services/graphql-server/src/index.js
+++ b/services/graphql-server/src/index.js
@@ -6,7 +6,7 @@ const {
   PORT,
   EXPOSED_PORT,
   TERMINUS_TIMEOUT: timeout,
-  TERMINUS_BEFORE_SHUTDOWN_TIMEOUT: beforeShutdownTimeout,
+  TERMINUS_SHUTDOWN_DELAY: beforeShutdownTimeout,
 } = require('./env');
 const app = require('./app');
 const pkg = require('../package.json');

--- a/services/graphql-server/src/index.js
+++ b/services/graphql-server/src/index.js
@@ -2,7 +2,12 @@ require('./newrelic');
 const http = require('http');
 const { createTerminus } = require('@godaddy/terminus');
 const newrelic = require('./newrelic');
-const { PORT, EXPOSED_PORT } = require('./env');
+const {
+  PORT,
+  EXPOSED_PORT,
+  TERMINUS_TIMEOUT: timeout,
+  TERMINUS_BEFORE_SHUTDOWN_TIMEOUT: beforeShutdownTimeout,
+} = require('./env');
 const app = require('./app');
 const pkg = require('../package.json');
 const services = require('./services');
@@ -14,7 +19,7 @@ const run = async () => {
   await services.start();
 
   createTerminus(server, {
-    timeout: 1000,
+    timeout,
     signals: ['SIGTERM', 'SIGINT', 'SIGHUP', 'SIGQUIT'],
     healthChecks: { '/_health': () => services.ping() },
     onSignal: () => {
@@ -23,6 +28,11 @@ const run = async () => {
         newrelic.noticeError(e);
         log('> CLEANUP ERRORS:', e);
       });
+    },
+    beforeShutdown: () => {
+      log(`> Delaying shutdown by ${beforeShutdownTimeout}ms...`);
+      return new Promise(resolve => setTimeout(resolve, beforeShutdownTimeout))
+        .then(() => log('> Shutdown delay complete.'));
     },
     onShutdown: () => log('> Cleanup finished. Shutting down.'),
   });

--- a/services/graphql-server/src/index.js
+++ b/services/graphql-server/src/index.js
@@ -1,3 +1,4 @@
+require('./newrelic');
 const http = require('http');
 const { createTerminus } = require('@godaddy/terminus');
 const newrelic = require('./newrelic');

--- a/services/oembed/src/env.js
+++ b/services/oembed/src/env.js
@@ -4,6 +4,7 @@ const {
   custom,
   cleanEnv,
   bool,
+  num,
 } = envalid;
 const { nonemptystr } = custom;
 
@@ -11,4 +12,6 @@ module.exports = cleanEnv(process.env, {
   EMBEDLY_API_KEY: nonemptystr({ desc: 'The Embed.ly API key..' }),
   NEW_RELIC_ENABLED: bool({ desc: 'Whether New Relic is enabled.', default: true, devDefault: false }),
   NEW_RELIC_LICENSE_KEY: nonemptystr({ desc: 'The license key for New Relic.', devDefault: '(unset)' }),
+  TERMINUS_TIMEOUT: num({ desc: 'Number of milliseconds before forceful exiting', default: 30000 }),
+  TERMINUS_SHUTDOWN_DELAY: num({ desc: 'Number of milliseconds before the HTTP server starts its shutdown', default: 5000 }),
 });

--- a/services/oembed/src/index.js
+++ b/services/oembed/src/index.js
@@ -2,6 +2,10 @@ require('./newrelic');
 const http = require('http');
 const { createTerminus } = require('@godaddy/terminus');
 const newrelic = require('./newrelic');
+const {
+  TERMINUS_TIMEOUT: timeout,
+  TERMINUS_SHUTDOWN_DELAY: beforeShutdownTimeout,
+} = require('./env');
 const app = require('./app');
 const pkg = require('../package.json');
 
@@ -11,11 +15,16 @@ const server = http.createServer(app);
 
 const run = async () => {
   createTerminus(server, {
-    timeout: 1000,
+    timeout,
     signals: ['SIGTERM', 'SIGINT', 'SIGHUP', 'SIGQUIT'],
     healthChecks: { '/_health': () => Promise.resolve(`${pkg.name} pinged successfully.`) },
     onSignal: () => {
       log('> Cleaning up...');
+    },
+    beforeShutdown: () => {
+      log(`> Delaying shutdown by ${beforeShutdownTimeout}ms...`);
+      return new Promise(resolve => setTimeout(resolve, beforeShutdownTimeout))
+        .then(() => log('> Shutdown delay complete.'));
     },
     onShutdown: () => log('> Cleanup finished. Shutting down.'),
   });

--- a/services/oembed/src/index.js
+++ b/services/oembed/src/index.js
@@ -1,3 +1,4 @@
+require('./newrelic');
 const http = require('http');
 const { createTerminus } = require('@godaddy/terminus');
 const newrelic = require('./newrelic');

--- a/services/rss/src/env.js
+++ b/services/rss/src/env.js
@@ -5,6 +5,7 @@ const {
   cleanEnv,
   bool,
   port,
+  num,
 } = envalid;
 const { nonemptystr } = validators;
 
@@ -14,4 +15,6 @@ module.exports = cleanEnv(process.env, {
   EXPOSED_PORT: port({ desc: 'The external port to run on.', default: 80 }),
   NEW_RELIC_ENABLED: bool({ desc: 'Whether New Relic is enabled.', default: true, devDefault: false }),
   NEW_RELIC_LICENSE_KEY: nonemptystr({ desc: 'The license key for New Relic.', devDefault: '(unset)' }),
+  TERMINUS_TIMEOUT: num({ desc: 'Number of milliseconds before forceful exiting', default: 30000 }),
+  TERMINUS_SHUTDOWN_DELAY: num({ desc: 'Number of milliseconds before the HTTP server starts its shutdown', default: 5000 }),
 });

--- a/services/rss/src/index.js
+++ b/services/rss/src/index.js
@@ -1,3 +1,4 @@
+require('./newrelic');
 const http = require('http');
 const { createTerminus } = require('@godaddy/terminus');
 const newrelic = require('./newrelic');

--- a/services/rss/src/index.js
+++ b/services/rss/src/index.js
@@ -2,7 +2,13 @@ require('./newrelic');
 const http = require('http');
 const { createTerminus } = require('@godaddy/terminus');
 const newrelic = require('./newrelic');
-const { GRAPHQL_URI, PORT, EXPOSED_PORT } = require('./env');
+const {
+  GRAPHQL_URI,
+  PORT,
+  EXPOSED_PORT,
+  TERMINUS_TIMEOUT: timeout,
+  TERMINUS_SHUTDOWN_DELAY: beforeShutdownTimeout,
+} = require('./env');
 const app = require('./app');
 const pkg = require('../package.json');
 const { log } = require('./output');
@@ -11,11 +17,16 @@ const server = http.createServer(app);
 
 const run = async () => {
   createTerminus(server, {
-    timeout: 1000,
+    timeout,
     signals: ['SIGTERM', 'SIGINT', 'SIGHUP', 'SIGQUIT'],
     healthChecks: { '/_health': () => Promise.resolve(`${pkg.name} pinged successfully.`) },
     onSignal: () => {
       log('> Cleaning up...');
+    },
+    beforeShutdown: () => {
+      log(`> Delaying shutdown by ${beforeShutdownTimeout}ms...`);
+      return new Promise(resolve => setTimeout(resolve, beforeShutdownTimeout))
+        .then(() => log('> Shutdown delay complete.'));
     },
     onShutdown: () => log('> Cleanup finished. Shutting down.'),
   });

--- a/services/sitemaps/src/env.js
+++ b/services/sitemaps/src/env.js
@@ -16,4 +16,6 @@ module.exports = cleanEnv(process.env, {
   PAGE_SIZE: num({ desc: 'The number of urls per page', default: 5000 }),
   NEW_RELIC_ENABLED: bool({ desc: 'Whether New Relic is enabled.', default: true, devDefault: false }),
   NEW_RELIC_LICENSE_KEY: nonemptystr({ desc: 'The license key for New Relic.', devDefault: '(unset)' }),
+  TERMINUS_TIMEOUT: num({ desc: 'Number of milliseconds before forceful exiting', default: 30000 }),
+  TERMINUS_SHUTDOWN_DELAY: num({ desc: 'Number of milliseconds before the HTTP server starts its shutdown', default: 5000 }),
 });

--- a/services/sitemaps/src/index.js
+++ b/services/sitemaps/src/index.js
@@ -1,3 +1,4 @@
+require('./newrelic');
 const http = require('http');
 const { createTerminus } = require('@godaddy/terminus');
 const newrelic = require('./newrelic');

--- a/services/sitemaps/src/index.js
+++ b/services/sitemaps/src/index.js
@@ -2,7 +2,13 @@ require('./newrelic');
 const http = require('http');
 const { createTerminus } = require('@godaddy/terminus');
 const newrelic = require('./newrelic');
-const { GRAPHQL_URI, PORT, EXPOSED_PORT } = require('./env');
+const {
+  GRAPHQL_URI,
+  PORT,
+  EXPOSED_PORT,
+  TERMINUS_TIMEOUT: timeout,
+  TERMINUS_SHUTDOWN_DELAY: beforeShutdownTimeout,
+} = require('./env');
 const app = require('./app');
 const pkg = require('../package.json');
 const { log } = require('./output');
@@ -11,11 +17,16 @@ const server = http.createServer(app);
 
 const run = async () => {
   createTerminus(server, {
-    timeout: 1000,
+    timeout,
     signals: ['SIGTERM', 'SIGINT', 'SIGHUP', 'SIGQUIT'],
     healthChecks: { '/_health': () => Promise.resolve(`${pkg.name} pinged successfully.`) },
     onSignal: () => {
       log('> Cleaning up...');
+    },
+    beforeShutdown: () => {
+      log(`> Delaying shutdown by ${beforeShutdownTimeout}ms...`);
+      return new Promise(resolve => setTimeout(resolve, beforeShutdownTimeout))
+        .then(() => log('> Shutdown delay complete.'));
     },
     onShutdown: () => log('> Cleanup finished. Shutting down.'),
   });


### PR DESCRIPTION
- ensure new relic is required first
- log shutdown errors to new relic
- add `TERMINUS_TIMEOUT` env var with a default of 30000ms (1000ms on dev)
- add `TERMINUS_SHUTDOWN_DELAY` and implement in the `beforeShutdown` hook (default 5000ms; 0ms on dev)
- check that mongodb is writeable when pinged
- log when a signal or code is received within the gulp dev server