### PR TITLE
Add env var to force using the request url

### DIFF
--- a/packages/marko-web-gtm/context/content.js
+++ b/packages/marko-web-gtm/context/content.js
@@ -1,7 +1,9 @@
 const { getAsObject, getAsArray, get } = require('@base-cms/object-path');
 const { asObject } = require('@base-cms/utils');
 
-module.exports = ({ obj }) => {
+const { MARKO_WEB_GTM_USE_ORIGINAL_URL } = process.env;
+
+module.exports = ({ obj, req }) => {
   const content = asObject(obj);
   const company = getAsObject(content, 'company');
   const createdBy = getAsObject(content, 'createdBy');
@@ -23,7 +25,7 @@ module.exports = ({ obj }) => {
   }));
   return {
     page_type: 'content',
-    canonical_path: get(content, 'siteContext.path'),
+    canonical_path: MARKO_WEB_GTM_USE_ORIGINAL_URL ? req.originalUrl : get(content, 'siteContext.path'),
     content: {
       id: content.id,
       type: content.type,

--- a/packages/marko-web-gtm/context/dynamic-page.js
+++ b/packages/marko-web-gtm/context/dynamic-page.js
@@ -1,11 +1,13 @@
 const { get } = require('@base-cms/object-path');
 const { asObject } = require('@base-cms/utils');
 
-module.exports = ({ obj }) => {
+const { MARKO_WEB_GTM_USE_ORIGINAL_URL } = process.env;
+
+module.exports = ({ obj, req }) => {
   const page = asObject(obj);
   return {
     page_type: 'dynamic-page',
-    canonical_path: get(page, 'siteContext.path'),
+    canonical_path: MARKO_WEB_GTM_USE_ORIGINAL_URL ? req.originalUrl : get(page, 'siteContext.path'),
     page: {
       id: page.id,
       name: page.name,

--- a/packages/marko-web-gtm/context/magazine-issue.js
+++ b/packages/marko-web-gtm/context/magazine-issue.js
@@ -1,12 +1,14 @@
 const { getAsObject } = require('@base-cms/object-path');
 const { asObject } = require('@base-cms/utils');
 
-module.exports = ({ obj }) => {
+const { MARKO_WEB_GTM_USE_ORIGINAL_URL } = process.env;
+
+module.exports = ({ obj, req }) => {
   const issue = asObject(obj);
   const publication = getAsObject(issue, 'publication');
   return {
     page_type: 'magazine-issue',
-    canonical_path: issue.canonicalPath,
+    canonical_path: MARKO_WEB_GTM_USE_ORIGINAL_URL ? req.originalUrl : issue.canonicalPath,
     issue: {
       id: issue.id,
       name: issue.name,

--- a/packages/marko-web-gtm/context/magazine-publication.js
+++ b/packages/marko-web-gtm/context/magazine-publication.js
@@ -1,10 +1,12 @@
 const { asObject } = require('@base-cms/utils');
 
-module.exports = ({ obj }) => {
+const { MARKO_WEB_GTM_USE_ORIGINAL_URL } = process.env;
+
+module.exports = ({ obj, req }) => {
   const publication = asObject(obj);
   return {
     page_type: 'magazine-publication',
-    canonical_path: publication.canonicalPath,
+    canonical_path: MARKO_WEB_GTM_USE_ORIGINAL_URL ? req.originalUrl : publication.canonicalPath,
     publication: {
       id: publication.id,
       name: publication.name,

--- a/packages/marko-web-gtm/context/website-section.js
+++ b/packages/marko-web-gtm/context/website-section.js
@@ -1,7 +1,9 @@
 const { getAsArray } = require('@base-cms/object-path');
 const { asObject } = require('@base-cms/utils');
 
-module.exports = ({ obj }) => {
+const { MARKO_WEB_GTM_USE_ORIGINAL_URL } = process.env;
+
+module.exports = ({ obj, req }) => {
   const section = asObject(obj);
   const hierarchy = getAsArray(section, 'hierarchy').map(s => ({
     id: s.id,
@@ -10,7 +12,7 @@ module.exports = ({ obj }) => {
   }));
   return {
     page_type: 'website-section',
-    canonical_path: section.canonicalPath,
+    canonical_path: MARKO_WEB_GTM_USE_ORIGINAL_URL ? req.originalUrl : section.canonicalPath,
     section: {
       id: section.id,
       name: section.name,


### PR DESCRIPTION
Instead of the canonical path.

UTM (campaign) parameters are not being properly handled by GTM/GA without this option.