### PR TITLE
Create micro JSON server with terminus wrapper

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -522,13 +522,14 @@ services:
   google-data-api:
     << : *node
     working_dir: /base-cms/services/google-data-api
-    entrypoint: ["node_modules/.bin/micro-dev"]
-    command: ["--port", "80", "--silent", "--ignore=newrelic"]
+    command: ["/base-cms/node_modules/.bin/gulp"]
     environment:
       <<: *env
       <<: *env-newrelic
       GOOGLE_DATA_MONGO_DSN: ${GOOGLE_DATA_MONGO_DSN-mongodb://mongodb}
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}
+      PORT: 80
+      EXPOSED_PORT: 10014
     depends_on:
       - mongodb
     ports:

--- a/packages/micro/package.json
+++ b/packages/micro/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@base-cms/object-path": "^1.9.0",
+    "@godaddy/terminus": "^4.2.0",
     "node-fetch": "^2.6.0"
   },
   "publishConfig": {

--- a/packages/micro/src/service/index.js
+++ b/packages/micro/src/service/index.js
@@ -1,9 +1,11 @@
 const json = require('./json-service');
+const jsonServer = require('./json-server');
 const createParamError = require('./param-error');
 const createRequiredParamError = require('./required-param-error');
 
 module.exports = {
   json,
+  jsonServer,
   createParamError,
   createRequiredParamError,
 };

--- a/packages/micro/src/service/json-server.js
+++ b/packages/micro/src/service/json-server.js
@@ -1,0 +1,129 @@
+const micro = require('micro');
+const { get } = require('@base-cms/object-path');
+const { createTerminus } = require('@godaddy/terminus');
+const isFn = require('../utils/is-function');
+
+const createParamError = require('./param-error');
+const jsonErrors = require('./json-errors');
+
+const { env } = process;
+const { json, createError } = micro;
+
+const wait = ms => new Promise(resolve => setTimeout(resolve, parseInt(ms, 10)));
+
+/**
+ * Starts a micro json service server.
+ *
+ * @param {object}   args
+ * @param {object}   args.actions The service actions to load.
+ * @param {function} [args.context] A function to generate context. Will be passed to all actions.
+ * @param {boolean}  [args.enableLogging=true] Whether to enable server log messages.
+ * @param {string[]} [args.signals]
+ * @param {string}   [args.healthCheckPath=/_health]
+ * @param {number}   [args.port=80]
+ * @param {number}   [args.exposedPort=80]
+ * @param {function} [args.onError]
+ * @param {function} [args.onStart]
+ * @param {function} [args.onSignal]
+ * @param {function} [args.beforeShutdown]
+ * @param {function} [args.onShutdown]
+ * @param {function} [args.onHealthCheck]
+ */
+module.exports = async ({
+  actions = {},
+  context,
+  enableLogging = true,
+  signals = ['SIGTERM', 'SIGINT', 'SIGHUP', 'SIGQUIT'],
+  healthCheckPath = '/_health',
+  port = 80,
+  exposedPort = 80,
+  onError,
+  onStart,
+  onSignal,
+  beforeShutdown,
+  onShutdown,
+  onHealthCheck,
+}) => {
+  // Create logger.
+  const log = (message) => {
+    const { log: emit } = console;
+    if (enableLogging) emit(`> ${message}`);
+  };
+
+  // Create error handler.
+  const errorHandler = isFn(onError) ? onError : () => {};
+
+  // Await required services here...
+  if (isFn(onStart)) await onStart();
+
+  const server = micro(jsonErrors(async (req, res) => {
+    const input = await json(req);
+    const { action: path, params, meta } = input;
+    if (!path) throw createError(400, 'No action provided.');
+
+    const fn = get(actions, path);
+    if (!isFn(fn)) throw createParamError('action', path, Object.keys(actions));
+
+    const contextData = isFn(context) ? await context({ req, res, input }) : context;
+
+    const data = await fn(params || {}, {
+      req,
+      res,
+      meta: meta || {},
+      context: contextData || {},
+    });
+    return { data };
+  }, errorHandler));
+
+  createTerminus(server, {
+    timeout: parseInt(env.TERMINUS_TIMEOUT || 1000, 10),
+    signals,
+    healthChecks: {
+      [healthCheckPath]: async () => {
+        if (isFn(onHealthCheck)) return onHealthCheck();
+        return { ping: 'pong' };
+      },
+    },
+    onSignal: async () => {
+      // Stop required services here...
+      log('Signal received, running cleanup hook...');
+      try {
+        if (isFn(onSignal)) await onSignal();
+      } catch (e) {
+        errorHandler(e);
+        log('CLEANUP ERRORS DETECTED!');
+      } finally {
+        log('Cleanup complete.');
+      }
+    },
+    beforeShutdown: async () => {
+      log('Running before shutdown hook...');
+      try {
+        if (isFn(beforeShutdown)) await beforeShutdown();
+        const { TERMINUS_SHUTDOWN_DELAY } = env;
+        if (TERMINUS_SHUTDOWN_DELAY) {
+          log(`Delaying shutdown by ${TERMINUS_SHUTDOWN_DELAY}ms...`);
+          await wait(TERMINUS_SHUTDOWN_DELAY);
+        }
+      } catch (e) {
+        errorHandler(e);
+        log('BEFORE SHUTDOWN ERRORS DETECTED!');
+      } finally {
+        log('Before shutdown complete.');
+      }
+    },
+    onShutdown: async () => {
+      log('Running shutdown hook...');
+      try {
+        if (isFn(onShutdown)) await onShutdown();
+      } catch (e) {
+        errorHandler(e);
+        log('SHUTDOWN ERRORS DETECTED!');
+      } finally {
+        log('Shutdown complete.');
+      }
+    },
+  });
+
+  server.listen(port, () => log(`Ready on http://0.0.0.0:${exposedPort}`));
+};

--- a/packages/micro/src/utils/is-function.js
+++ b/packages/micro/src/utils/is-function.js
@@ -1,0 +1,1 @@
+module.exports = v => v && typeof v === 'function';

--- a/services/google-data-api/Dockerfile
+++ b/services/google-data-api/Dockerfile
@@ -6,4 +6,4 @@ WORKDIR /base-cms
 RUN yarn --production
 
 WORKDIR /base-cms/services/google-data-api
-ENTRYPOINT [ "./node_modules/.bin/micro", "-l", "tcp://0.0.0.0:80" ]
+ENTRYPOINT [ "node", "src/index.js" ]

--- a/services/google-data-api/gulpfile.js
+++ b/services/google-data-api/gulpfile.js
@@ -1,0 +1,9 @@
+const gulpfile = require('../../gulpfile');
+
+gulpfile({
+  entry: 'src/index.js',
+  lintPaths: ['src/**/*.js'],
+  watchPaths: [
+    'src/**/*.js',
+  ],
+});

--- a/services/google-data-api/src/env.js
+++ b/services/google-data-api/src/env.js
@@ -1,11 +1,21 @@
 const envalid = require('@base-cms/env');
 
-const { bool, cleanEnv, validators } = envalid;
+const {
+  bool,
+  cleanEnv,
+  validators,
+  num,
+  port,
+} = envalid;
 const { nonemptystr } = validators;
 
 module.exports = cleanEnv(process.env, {
+  PORT: port({ desc: 'The internal port to run on.', default: 80 }),
+  EXPOSED_PORT: port({ desc: 'The external port to run on.', default: 80 }),
   GOOGLE_DATA_MONGO_DSN: nonemptystr({ desc: 'The Base MongoDB connection URL.' }),
   GOOGLE_API_KEY: nonemptystr({ desc: 'The Google Data API key.' }),
   NEW_RELIC_ENABLED: bool({ desc: 'Whether New Relic is enabled.', default: true, devDefault: false }),
   NEW_RELIC_LICENSE_KEY: nonemptystr({ desc: 'The license key for New Relic.', devDefault: '(unset)' }),
+  TERMINUS_TIMEOUT: num({ desc: 'Number of milliseconds before forceful exiting', default: 1000 }),
+  TERMINUS_SHUTDOWN_DELAY: num({ desc: 'Number of milliseconds before the HTTP server starts its shutdown', default: 10000 }),
 });


### PR DESCRIPTION
Leaves the `service.json` method as-is, and adds a `service.jsonServer` that boots the micro server programmatically and wraps it with terminus.

The google data API service was updated to use this. Example usage:

```js
require('./newrelic');
const { service } = require('@base-cms/micro');
const newrelic = require('./newrelic');
const { PORT, EXPOSED_PORT } = require('./env');
const pkg = require('../package.json');
const { connect, ping } = require('./mongodb');
const actions = require('./actions');

const { log } = console;

process.on('unhandledRejection', (e) => {
  newrelic.noticeError(e);
  throw e;
});

service.jsonServer({
  actions,
  onStart: async () => {
    log(`> Booting ${pkg.name} v${pkg.version}...`);
    log('> Connecting to MongoDB...');
    const connection = await connect();
    await connection.db('google-data-api').createIndex('responses', { expires: 1 }, { background: true, expireAfterSeconds: 0 });
  },
  onHealthCheck: ping,
  onError: newrelic.noticeError,
  port: PORT,
  exposedPort: EXPOSED_PORT,
}).catch(e => setImmediate(() => {
  newrelic.noticeError(e);
  throw e;
}));
```