### PR TITLE
Send canonical path and query string in context

### DIFF
--- a/packages/marko-web-gtm/context/content.js
+++ b/packages/marko-web-gtm/context/content.js
@@ -1,7 +1,6 @@
 const { getAsObject, getAsArray, get } = require('@base-cms/object-path');
 const { asObject } = require('@base-cms/utils');
-
-const { MARKO_WEB_GTM_USE_ORIGINAL_URL } = process.env;
+const buildQueryString = require('../utils/build-query-string');
 
 module.exports = ({ obj, req }) => {
   const content = asObject(obj);
@@ -25,7 +24,8 @@ module.exports = ({ obj, req }) => {
   }));
   return {
     page_type: 'content',
-    canonical_path: MARKO_WEB_GTM_USE_ORIGINAL_URL ? req.originalUrl : get(content, 'siteContext.path'),
+    canonical_path: get(content, 'siteContext.path'),
+    query_string: buildQueryString({ req }),
     content: {
       id: content.id,
       type: content.type,

--- a/packages/marko-web-gtm/context/default.js
+++ b/packages/marko-web-gtm/context/default.js
@@ -1,6 +1,11 @@
 const { asObject } = require('@base-cms/utils');
+const buildQueryString = require('../utils/build-query-string');
 
 module.exports = ({ type, obj, req }) => {
   const o = asObject(obj);
-  return { page_type: type, canonical_path: o.canonicalPath || req.path };
+  return {
+    page_type: type,
+    canonical_path: o.canonicalPath || req.path,
+    query_string: buildQueryString({ req }),
+  };
 };

--- a/packages/marko-web-gtm/context/dynamic-page.js
+++ b/packages/marko-web-gtm/context/dynamic-page.js
@@ -1,13 +1,13 @@
 const { get } = require('@base-cms/object-path');
 const { asObject } = require('@base-cms/utils');
-
-const { MARKO_WEB_GTM_USE_ORIGINAL_URL } = process.env;
+const buildQueryString = require('../utils/build-query-string');
 
 module.exports = ({ obj, req }) => {
   const page = asObject(obj);
   return {
     page_type: 'dynamic-page',
-    canonical_path: MARKO_WEB_GTM_USE_ORIGINAL_URL ? req.originalUrl : get(page, 'siteContext.path'),
+    canonical_path: get(page, 'siteContext.path'),
+    query_string: buildQueryString({ req }),
     page: {
       id: page.id,
       name: page.name,

--- a/packages/marko-web-gtm/context/magazine-issue.js
+++ b/packages/marko-web-gtm/context/magazine-issue.js
@@ -1,14 +1,14 @@
 const { getAsObject } = require('@base-cms/object-path');
 const { asObject } = require('@base-cms/utils');
-
-const { MARKO_WEB_GTM_USE_ORIGINAL_URL } = process.env;
+const buildQueryString = require('../utils/build-query-string');
 
 module.exports = ({ obj, req }) => {
   const issue = asObject(obj);
   const publication = getAsObject(issue, 'publication');
   return {
     page_type: 'magazine-issue',
-    canonical_path: MARKO_WEB_GTM_USE_ORIGINAL_URL ? req.originalUrl : issue.canonicalPath,
+    canonical_path: issue.canonicalPath,
+    query_string: buildQueryString({ req }),
     issue: {
       id: issue.id,
       name: issue.name,

--- a/packages/marko-web-gtm/context/magazine-publication.js
+++ b/packages/marko-web-gtm/context/magazine-publication.js
@@ -1,12 +1,12 @@
 const { asObject } = require('@base-cms/utils');
-
-const { MARKO_WEB_GTM_USE_ORIGINAL_URL } = process.env;
+const buildQueryString = require('../utils/build-query-string');
 
 module.exports = ({ obj, req }) => {
   const publication = asObject(obj);
   return {
     page_type: 'magazine-publication',
-    canonical_path: MARKO_WEB_GTM_USE_ORIGINAL_URL ? req.originalUrl : publication.canonicalPath,
+    canonical_path: publication.canonicalPath,
+    query_string: buildQueryString({ req }),
     publication: {
       id: publication.id,
       name: publication.name,

--- a/packages/marko-web-gtm/context/website-section.js
+++ b/packages/marko-web-gtm/context/website-section.js
@@ -1,7 +1,6 @@
 const { getAsArray } = require('@base-cms/object-path');
 const { asObject } = require('@base-cms/utils');
-
-const { MARKO_WEB_GTM_USE_ORIGINAL_URL } = process.env;
+const buildQueryString = require('../utils/build-query-string');
 
 module.exports = ({ obj, req }) => {
   const section = asObject(obj);
@@ -12,7 +11,8 @@ module.exports = ({ obj, req }) => {
   }));
   return {
     page_type: 'website-section',
-    canonical_path: MARKO_WEB_GTM_USE_ORIGINAL_URL ? req.originalUrl : section.canonicalPath,
+    canonical_path: section.canonicalPath,
+    query_string: buildQueryString({ req }),
     section: {
       id: section.id,
       name: section.name,

--- a/packages/marko-web-gtm/utils/build-query-string.js
+++ b/packages/marko-web-gtm/utils/build-query-string.js
@@ -1,0 +1,3 @@
+const { URLSearchParams } = require('url');
+
+module.exports = ({ req }) => (new URLSearchParams(req.query)).toString();


### PR DESCRIPTION
Adds ability to properly handle canonical paths with query strings. To implement in GTM, it is recommended to add a `Page Query String` variable and then handle in a `Page Location` var.

For example:
```js
function() {
  // Page Location Variable Definition
  var pageNum = {{Page Number}};
  var canonicalPath = {{Canonical Path}};
  var queryString = {{Page Query String}};
  var path = {{Page Path}};
  var location = window.location.protocol + '//' + {{Page Hostname}} + (canonicalPath || path);
  if (pageNum > 1) {
    location = location.replace(/\/+$/, '');
    return location + '/page-' + pageNum;
  }
  if (queryString) return location + '?' + queryString;
  return location;
}
```