### PR TITLE
Catch error if onError handler also fails

### DIFF
--- a/packages/micro/src/service/json-errors.js
+++ b/packages/micro/src/service/json-errors.js
@@ -17,7 +17,13 @@ module.exports = (fn, onError) => async (req, res) => {
     } else {
       log('Unknown Error instance.', e);
     }
-    if (typeof onError === 'function') await onError(e);
+    if (typeof onError === 'function') {
+      try {
+        await onError(e);
+      } catch (ex) {
+        log('ON ERROR CALLBACK FAILED!', ex);
+      }
+    }
     return null;
   }
 };


### PR DESCRIPTION
Prevents shutdown of micro service/server if a bad `onError` callback is passed.