### PR TITLE
Return undefined instead of null in error handler

### DIFF
--- a/packages/micro/src/service/json-errors.js
+++ b/packages/micro/src/service/json-errors.js
@@ -24,6 +24,8 @@ module.exports = (fn, onError) => async (req, res) => {
         log('ON ERROR CALLBACK FAILED!', ex);
       }
     }
-    return null;
   }
+  // return `undefined` instead of `null` to prevent micro.run from sending
+  // an additional 204 response.
+  return undefined;
 };


### PR DESCRIPTION
Prevents the `micro.run` function from sending an additional (quasi-hidden) 204 response after the error response. The `run` function specifically looks for a `null` or `!== undefined` value when executing. Otherwise, it ignores sending a response - which is desired in this case, since the error was already sent.