### PR TITLE
Add `WebsiteSection.coverImage` field

### DIFF
--- a/services/graphql-server/src/graphql/definitions/website/section.js
+++ b/services/graphql-server/src/graphql/definitions/website/section.js
@@ -74,6 +74,7 @@ type WebsiteSection {
   parent(input: WebsiteSectionParentInput = {}): WebsiteSection @projection @refOne(loader: "websiteSection")
   children(input: WebsiteSectionChildrenInput = {}): WebsiteSectionConnection! @projection(localField: "_id") @refMany(model: "website.Section", localField: "_id", foreignField: "parent.$id")
   logo: AssetImage @projection @refOne(loader: "platformAsset", criteria: "assetImage")
+  coverImage: AssetImage @projection @refOne(loader: "platformAsset", criteria: "assetImage")
 
   # fields from trait.platform::Content\SeoFields
 


### PR DESCRIPTION
Include `labels` and `coverImage` fields on the GraphQL definition for `Website\Section`.

Ref cygnusb2b/base-platform#4332

![image](https://user-images.githubusercontent.com/1778222/74866381-69f1db80-5318-11ea-8402-4043c61b62ac.png)
