### PR TITLE
Return section with scheduled content queries

### DIFF
--- a/packages/web-common/src/block-loaders/website-optioned-content.js
+++ b/packages/web-common/src/block-loaders/website-optioned-content.js
@@ -51,5 +51,10 @@ module.exports = async (apolloClient, params) => {
   // Merge the content up to the limit and return the scheduled page info.
   const diff = limit - length;
   const nodes = [...optioned.nodes, ...scheduled.nodes.slice(0, diff)];
-  return { nodes, pageInfo: scheduled.pageInfo, optionDepleted: true };
+  return {
+    nodes,
+    pageInfo: scheduled.pageInfo,
+    section: scheduled.section,
+    optionDepleted: true,
+  };
 };

--- a/packages/web-common/src/block-loaders/website-scheduled-content.js
+++ b/packages/web-common/src/block-loaders/website-scheduled-content.js
@@ -18,6 +18,8 @@ const buildQuery = require('../gql/query-factories/block-website-scheduled-conte
  * @param {boolean} [params.sectionBubbling] Whether automatic section bubbling is applied.
  * @param {string} [params.queryFragment] The `graphql-tag` fragment
  *                                        to apply to the `websiteScheduledContent` query.
+ * @param {string} [params.sectionFragment] The `graphql-tag` fragment
+ *                                          to apply to the `websiteScheduledContent` section field.
  */
 module.exports = async (apolloClient, {
   limit,
@@ -39,6 +41,7 @@ module.exports = async (apolloClient, {
 
   queryFragment,
   queryName,
+  sectionFragment,
 } = {}) => {
   const pagination = { limit, skip, after };
   const input = {
@@ -54,14 +57,14 @@ module.exports = async (apolloClient, {
     optionName,
     ...(sort && { sort }),
   };
-  const query = buildQuery({ queryFragment, queryName });
+  const query = buildQuery({ queryFragment, queryName, sectionFragment });
   const variables = { input };
 
   const { data } = await apolloClient.query({ query, variables });
   if (!data || !data.websiteScheduledContent) return { nodes: [], pageInfo: {} };
-  const { pageInfo } = data.websiteScheduledContent;
+  const { pageInfo, section } = data.websiteScheduledContent;
   const nodes = data.websiteScheduledContent.edges
     .map(edge => (edge && edge.node ? edge.node : null))
     .filter(c => c);
-  return { nodes, pageInfo };
+  return { nodes, pageInfo, section };
 };

--- a/packages/web-common/src/gql/query-factories/block-website-scheduled-content.js
+++ b/packages/web-common/src/gql/query-factories/block-website-scheduled-content.js
@@ -9,12 +9,22 @@ const { extractFragmentData } = require('../../utils');
  * @param {string} [params.queryFragment] The `graphql-tag` fragment
  *                                        to apply to `edges.node` on
  *                                        the `websiteScheduledContent` query.
+ * @param {string} [params.sectionFragment] The `graphql-tag` fragment
+ *                                          to apply to the `section`
  */
-module.exports = ({ queryFragment, queryName = '' } = {}) => {
+module.exports = ({ queryFragment, queryName = '', sectionFragment } = {}) => {
   const { spreadFragmentName, processedFragment } = extractFragmentData(queryFragment);
+  const {
+    spreadFragmentName: spreadSectionFragment,
+    processedFragment: processedSectionFragment,
+  } = extractFragmentData(sectionFragment);
   return gql`
     query BlockWebsiteScheduledContent${queryName}($input: WebsiteScheduledContentQueryInput!) {
       websiteScheduledContent(input: $input) {
+        section {
+          id
+          ${spreadSectionFragment}
+        }
         edges {
           node {
             ...BlockWebsiteScheduledContentFragment
@@ -29,5 +39,6 @@ module.exports = ({ queryFragment, queryName = '' } = {}) => {
     }
     ${defaultFragment}
     ${processedFragment}
+    ${processedSectionFragment}
   `;
 };


### PR DESCRIPTION
Automatically includes the queried section data with the `website-schedule-content` and `website-optioned-content` queries.

If a `sectionFragment` is provided, the specified section fields will be returned. If no fragment is provided, only the section ID is returned.