### PR TITLE
Only look up users that have a password

### DIFF
--- a/services/graphql-server/src/user/user-service.js
+++ b/services/graphql-server/src/user/user-service.js
@@ -15,6 +15,7 @@ const UserService = class UserService {
       accountNonLocked: true,
       credentialsNonExpired: true,
       enabled: true,
+      password: { $exists: true },
     };
     const user = await this.basedb.findOne('platform.User', criteria);
     if (!user) throw new AuthenticationError('The provided user credentials are invalid.');

--- a/services/graphql-server/src/user/user-service.js
+++ b/services/graphql-server/src/user/user-service.js
@@ -15,11 +15,10 @@ const UserService = class UserService {
       accountNonLocked: true,
       credentialsNonExpired: true,
       enabled: true,
-      password: { $exists: true },
     };
     const user = await this.basedb.findOne('platform.User', criteria);
-    if (!user) throw new AuthenticationError('The provided user credentials are invalid.');
-    const hash = user.password.replace(/^\$2y\$/, '$2a$');
+    if (!user || !user.password) throw new AuthenticationError('The provided user credentials are invalid.');
+    const hash = `${user.password}`.replace(/^\$2y\$/, '$2a$');
     const valid = await bcrypt.compare(plaintext, hash);
     if (!valid) throw new AuthenticationError('The provided user credentials are invalid.');
     return this.tokenService.create(user._id);


### PR DESCRIPTION
When attempting to use the `login` mutation for a user without a set password, the user is presented with a `Cannot read property 'replace' of undefined` error.

With this change, the `login` mutation will correctly result in an authentication error that the provided credentials are invalid.