### PR TITLE
Add runtime options to embedded media

### DIFF
--- a/packages/marko-web/components/element/content/body.marko
+++ b/packages/marko-web/components/element/content/body.marko
@@ -1,11 +1,12 @@
-import { get } from "@base-cms/object-path";
+import { get, getAsObject } from "@base-cms/object-path";
 import extractRender from "../extract-render";
 
 $ const { parseEmbeddedMedia, res } = out.global;
 
 $ const body = get(input.obj, "body");
 $ const v = body == null ? "" : `${body}`.trim();
-$ const obj = { body: parseEmbeddedMedia(v, res) };
+$ const embedOptions = getAsObject(input, "embedOptions")
+$ const obj = { body: parseEmbeddedMedia(v, res, embedOptions) };
 
 <marko-web-obj-text
   type="content"

--- a/packages/marko-web/components/element/content/marko.json
+++ b/packages/marko-web/components/element/content/marko.json
@@ -11,6 +11,7 @@
   },
   "<marko-web-content-body>": {
     "template": "./body.marko",
+    "<embed-options>": {},
     "@block-name": "string",
     "@obj": "object",
     "@tag": "string",

--- a/packages/marko-web/express/embedded-media.js
+++ b/packages/marko-web/express/embedded-media.js
@@ -11,13 +11,13 @@ module.exports = (app, { image, oembed, invalid } = {}) => {
   };
 
   // eslint-disable-next-line no-param-reassign
-  app.locals.parseEmbeddedMedia = (body, res) => {
+  app.locals.parseEmbeddedMedia = (body, res, options) => {
     const $global = buildMarkoGlobal(res);
 
     const replacements = extractEmbeddedTags(body).map((tag) => {
       const type = ['image', 'oembed'].includes(tag.type) && tag.isValid() ? tag.type : 'invalid';
       const pattern = tag.getRegExp();
-      const replacement = handlers[type](tag, $global);
+      const replacement = handlers[type](tag, $global, options);
       return { pattern, replacement };
     });
 

--- a/packages/marko-web/utils/embedded-media/image.js
+++ b/packages/marko-web/utils/embedded-media/image.js
@@ -4,8 +4,8 @@ const stringifyAttrs = attrs => Object.keys(attrs).reduce((arr, key) => {
   return arr;
 }, []).join(' ');
 
-module.exports = (tag, { config }) => {
-  const lazyload = config.lazyloadImages();
+module.exports = (tag, { config } = {}, { lazyloadImages } = {}) => {
+  const lazyload = lazyloadImages == null ? config.lazyloadImages() : lazyloadImages;
   const src = tag.get('src');
   const alt = tag.get('alt');
   const caption = tag.get('caption');


### PR DESCRIPTION
Affords the ability to disable lazy loading of images at request/run time in content bodies.