### PR TITLE
Adjust page grid sizes to prevent scroll bar overlapping ad

### DIFF
--- a/packages/marko-web-theme-default/skins/lazarus/components/_page-grid.scss
+++ b/packages/marko-web-theme-default/skins/lazarus/components/_page-grid.scss
@@ -17,8 +17,8 @@
       }
     }
 
-    flex: 0 0 320px;
-    max-width: 320px;
+    flex: 0 0 330px;
+    max-width: 330px;
     overflow: scroll;
     opacity: 1;
     transition-duration: 375ms;
@@ -42,7 +42,7 @@
 
   &__right-col {
     @include make-col-ready();
-    max-width: 880px;
+    max-width: 870px;
   }
 
   &__top-row {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171625870

Current:
![Screen Shot 2020-03-04 at 2 54 30 PM](https://user-images.githubusercontent.com/6343242/75922270-4eaec200-5e28-11ea-8fe4-cb85e4ccb675.png)

New:
![Screen Shot 2020-03-04 at 2 53 00 PM](https://user-images.githubusercontent.com/6343242/75922274-50788580-5e28-11ea-9554-a0da57945db2.png)
