### PR TITLE
Add `after` input option to `allPublishedContent` and `publishedContentCounts` queries

### DIFF
--- a/packages/utils/src/get-published-content-criteria.js
+++ b/packages/utils/src/get-published-content-criteria.js
@@ -7,6 +7,7 @@ module.exports = ({
   contentTypes = [],
   excludeContentTypes = [],
   since,
+  after,
 } = {}) => {
   const date = since || new Date();
   const types = isArray(contentTypes) && contentTypes.length
@@ -30,6 +31,7 @@ module.exports = ({
       },
     ],
   };
+  if (after) query.$and.push({ published: { $gte: after } });
   if (isArray(excludeContentIds) && excludeContentIds.length) {
     query._id = { $nin: excludeContentIds };
   }

--- a/packages/utils/src/get-published-content-criteria.js
+++ b/packages/utils/src/get-published-content-criteria.js
@@ -21,7 +21,10 @@ module.exports = ({
   const query = {
     status: 1,
     type,
-    published: { $lte: date },
+    published: {
+      $lte: date,
+      ...(after && { $gte: after }),
+    },
     $and: [
       {
         $or: [
@@ -31,7 +34,6 @@ module.exports = ({
       },
     ],
   };
-  if (after) query.$and.push({ published: { $gte: after } });
   if (isArray(excludeContentIds) && excludeContentIds.length) {
     query._id = { $nin: excludeContentIds };
   }

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -292,6 +292,7 @@ input AllPublishedContentQueryInput {
 
 input PublishedContentCountsQueryInput {
   siteId: ObjectID
+  after: Date
   since: Date
   excludeContentTypes: [ContentType!] = []
   includeContentTypes: [ContentType!] = []

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -275,6 +275,7 @@ input ContentSitemapNewsUrlsQueryInput {
 
 input AllPublishedContentQueryInput {
   siteId: ObjectID
+  after: Date
   since: Date
   sectionId: Int
   # @deprecated. Use \`AllPublishedContentQueryInput.includeContentTypes\` instead.

--- a/services/graphql-server/src/graphql/query-builders/published-content.js
+++ b/services/graphql-server/src/graphql/query-builders/published-content.js
@@ -1,10 +1,20 @@
 const { getPublishedContentCriteria } = require('@base-cms/utils');
 
 module.exports = ({ query }, { input }) => {
-  const { since } = input;
+  const { since, after } = input;
+
+  if (since && after) {
+    const criteria = getPublishedContentCriteria({ since, after });
+    return { query: { ...query, ...criteria } };
+  }
 
   if (since) {
     const criteria = getPublishedContentCriteria({ since });
+    return { query: { ...query, ...criteria } };
+  }
+
+  if (after) {
+    const criteria = getPublishedContentCriteria({ after });
     return { query: { ...query, ...criteria } };
   }
 

--- a/services/graphql-server/src/graphql/query-builders/published-content.js
+++ b/services/graphql-server/src/graphql/query-builders/published-content.js
@@ -3,18 +3,8 @@ const { getPublishedContentCriteria } = require('@base-cms/utils');
 module.exports = ({ query }, { input }) => {
   const { since, after } = input;
 
-  if (since && after) {
+  if (since || after) {
     const criteria = getPublishedContentCriteria({ since, after });
-    return { query: { ...query, ...criteria } };
-  }
-
-  if (since) {
-    const criteria = getPublishedContentCriteria({ since });
-    return { query: { ...query, ...criteria } };
-  }
-
-  if (after) {
-    const criteria = getPublishedContentCriteria({ after });
     return { query: { ...query, ...criteria } };
   }
 

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -624,7 +624,12 @@ module.exports = {
       // @deprecated Prefer includeContentTypes over contentTypes.
       const contentTypes = includeContentTypes.length
         ? includeContentTypes : deprecatedContentTypes;
-      const query = getPublishedCriteria({ since, after, contentTypes, excludeContentTypes });
+      const query = getPublishedCriteria({ 
+        since,
+        after,
+        contentTypes,
+        excludeContentTypes,
+      });
 
       const siteId = input.siteId || site.id();
       if (siteId) query['mutations.Website.primarySite'] = siteId;

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -608,6 +608,7 @@ module.exports = {
     allPublishedContent: async (_, { input }, { basedb, site }, info) => {
       const {
         since,
+        after,
         sectionId,
         contentTypes: deprecatedContentTypes,
         includeContentTypes,
@@ -623,7 +624,7 @@ module.exports = {
       // @deprecated Prefer includeContentTypes over contentTypes.
       const contentTypes = includeContentTypes.length
         ? includeContentTypes : deprecatedContentTypes;
-      const query = getPublishedCriteria({ since, contentTypes, excludeContentTypes });
+      const query = getPublishedCriteria({ since, after, contentTypes, excludeContentTypes });
 
       const siteId = input.siteId || site.id();
       if (siteId) query['mutations.Website.primarySite'] = siteId;
@@ -663,12 +664,14 @@ module.exports = {
     publishedContentCounts: async (_, { input }, { basedb, site }) => {
       const {
         since,
+        after,
         includeContentTypes: contentTypes,
         excludeContentTypes,
       } = input;
 
       const $match = getPublishedCriteria({
         since,
+        after,
         contentTypes,
         excludeContentTypes,
       });

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -624,7 +624,7 @@ module.exports = {
       // @deprecated Prefer includeContentTypes over contentTypes.
       const contentTypes = includeContentTypes.length
         ? includeContentTypes : deprecatedContentTypes;
-      const query = getPublishedCriteria({ 
+      const query = getPublishedCriteria({
         since,
         after,
         contentTypes,


### PR DESCRIPTION
Add after param to all published content to be able to get all content after or between two dates

The following will only return content created on Feb 15 2018

```gql
query {
  allPublishedContent(input: {
    # includeContentTypes: Company,
    after: 1518705594000,
    since: 1518739200000,
    }){
    edges {
      node {
        name
        publishedDate
      }
    }
  }
}
```
