### PR TITLE
Add support for querying and updating Brevity\Issue

### DIFF
--- a/packages/db/src/basedb.js
+++ b/packages/db/src/basedb.js
@@ -17,6 +17,7 @@ const { hrtime } = process;
  * @type {string[]}
  */
 const namespaces = [
+  'brevity',
   'configuration',
   'email',
   'magazine',

--- a/services/graphql-server/src/graphql/definitions/brevity/asset.js
+++ b/services/graphql-server/src/graphql/definitions/brevity/asset.js
@@ -1,0 +1,17 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+type BrevityAssetImage {
+  filePath: String @projection
+  fileName: String @projection
+  uri: String @projection
+  src(input: AssetImageSrcInput = {}): String! @projection(localField: "fileName", needs: ["filePath"])
+}
+
+type BrevityAssetVideo {
+  src: String @projection
+  format: String @projection
+}
+
+`;

--- a/services/graphql-server/src/graphql/definitions/brevity/author.js
+++ b/services/graphql-server/src/graphql/definitions/brevity/author.js
@@ -1,0 +1,12 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+type BrevityAuthor {
+  id: ObjectID! @projection(localField: "_id") @value(localField: "_id")
+  firstName: String @projection
+  lastName: String @projection
+  email: String @projection
+}
+
+`;

--- a/services/graphql-server/src/graphql/definitions/brevity/collection.js
+++ b/services/graphql-server/src/graphql/definitions/brevity/collection.js
@@ -27,7 +27,7 @@ type BrevityCollection {
   sequence: Int @projection
 
   # fields directly on brevity.model::Product\Collection
-  accentColor: String
+  accentColor: String @projection
   coverImage: BrevityAssetImage @projection
 
   issues(input: BrevityCollectionIssuesInput = {}): BrevityIssueConnection!

--- a/services/graphql-server/src/graphql/definitions/brevity/collection.js
+++ b/services/graphql-server/src/graphql/definitions/brevity/collection.js
@@ -1,0 +1,75 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+extend type Query {
+  brevityCollection(input: BrevityCollectionQueryInput!): BrevityCollection @findOne(model: "platform.Product", using: { id: "_id" }, criteria: "brevityCollection")
+  brevityCollections(input: BrevityCollectionsQueryInput = {}): BrevityCollectionConnection! @findMany(model: "platform.Product", criteria: "brevityCollection")
+}
+
+enum BrevityCollectionSortField {
+  id
+  name
+  sequence
+}
+
+type BrevityCollection {
+  # fields from platform.model::Product
+  id: ObjectID! @projection(localField: "_id") @value(localField: "_id")
+  name: String! @projection
+  fullName: String @projection
+  description: String @projection
+
+  # fields from platform.trait::StatusEnabled
+  status: Int @projection
+
+  # fields from platform.trait::Sequenceable
+  sequence: Int @projection
+
+  # fields directly on brevity.model::Product\Collection
+  accentColor: String
+  coverImage: BrevityAssetImage @projection
+
+  issues(input: BrevityCollectionIssuesInput = {}): BrevityIssueConnection!
+    @projection(localField: "_id")
+    @refMany(
+      model: "brevity.Issue",
+      refQueryBuilder: "brevityCollectionIssues",
+      localField: "_id",
+      foreignField: "collection.$id"
+    )
+}
+
+type BrevityCollectionConnection @projectUsing(type: "BrevityCollection") {
+  totalCount: Int!
+  edges: [BrevityCollectionEdge]!
+  pageInfo: PageInfo!
+}
+
+type BrevityCollectionEdge {
+  node: BrevityCollection!
+  cursor: String!
+}
+
+input BrevityCollectionQueryInput {
+  id: ObjectID!
+  status: ModelStatus = active
+}
+
+input BrevityCollectionsQueryInput {
+  status: ModelStatus = active
+  sort: BrevityCollectionSortInput = {}
+  pagination: PaginationInput = {}
+}
+
+input BrevityCollectionSortInput {
+  field: BrevityCollectionSortField = id
+  order: SortOrder = desc
+}
+
+input BrevityCollectionIssuesInput {
+  sort: BrevityIssueSortInput = {}
+  pagination: PaginationInput = {}
+}
+
+`;

--- a/services/graphql-server/src/graphql/definitions/brevity/index.js
+++ b/services/graphql-server/src/graphql/definitions/brevity/index.js
@@ -1,0 +1,16 @@
+const gql = require('graphql-tag');
+const asset = require('./asset');
+const author = require('./author');
+const collection = require('./collection');
+const issue = require('./issue');
+const story = require('./story');
+
+module.exports = gql`
+
+${asset}
+${author}
+${collection}
+${issue}
+${story}
+
+`;

--- a/services/graphql-server/src/graphql/definitions/brevity/issue.js
+++ b/services/graphql-server/src/graphql/definitions/brevity/issue.js
@@ -1,0 +1,71 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+extend type Query {
+  brevityIssue(input: BrevityIssueQueryInput!): BrevityIssue @findOne(
+    model: "brevity.Issue"
+    using: { id: "_id" }
+  )
+  brevityIssues(input: BrevityIssuesQueryInput = {}): BrevityIssueConnection! @findMany(
+    model: "brevity.Issue"
+  )
+}
+
+enum BrevityIssueSortField {
+  id
+  name
+}
+
+type BrevityIssue {
+  id: ObjectID! @projection(localField: "_id") @value(localField: "_id")
+  collection(input: BrevityIssueCollectionInput = {}): BrevityCollection @projection @refOne(loader: "platformProduct", criteria: "brevityCollection")
+  stories(input: BrevityIssueStoriesInput = {}): BrevityStoryConnection! @projection @refMany(model: "brevity.Story")
+
+  coverImage: BrevityAssetImage @projection
+  coverVideo: BrevityAssetVideo @projection
+
+  name: String @projection
+  customStyle: String @projection
+  accentColor: String @projection
+  deleted: Boolean! @projection
+  status: String! @projection
+  coverCredit: String @projection
+  textLocation: String @projection
+  description: String @projection
+}
+
+type BrevityIssueConnection @projectUsing(type: "BrevityIssue") {
+  totalCount: Int!
+  edges: [BrevityIssueEdge]!
+  pageInfo: PageInfo!
+}
+
+type BrevityIssueEdge {
+  node: BrevityIssue!
+  cursor: String!
+}
+
+input BrevityIssueQueryInput {
+  id: ObjectID!
+}
+
+input BrevityIssueCollectionInput {
+  status: ModelStatus = active
+}
+
+input BrevityIssueStoriesInput {
+  sort: BrevityStorySortInput = {}
+}
+
+input BrevityIssuesQueryInput {
+  sort: BrevityIssueSortInput = {}
+  pagination: PaginationInput = {}
+}
+
+input BrevityIssueSortInput {
+  field: BrevityIssueSortField = id
+  order: SortOrder = desc
+}
+
+`;

--- a/services/graphql-server/src/graphql/definitions/brevity/issue.js
+++ b/services/graphql-server/src/graphql/definitions/brevity/issue.js
@@ -12,6 +12,10 @@ extend type Query {
   )
 }
 
+extend type Mutation {
+  updateBrevityIssueStories(input: UpdateBrevityIssueStoriesMutationInput!): BrevityIssue! @requiresAuth
+}
+
 enum BrevityIssueSortField {
   id
   name
@@ -56,6 +60,7 @@ input BrevityIssueCollectionInput {
 
 input BrevityIssueStoriesInput {
   sort: BrevityStorySortInput = {}
+  pagination: PaginationInput = {}
 }
 
 input BrevityIssuesQueryInput {
@@ -66,6 +71,15 @@ input BrevityIssuesQueryInput {
 input BrevityIssueSortInput {
   field: BrevityIssueSortField = id
   order: SortOrder = desc
+}
+
+input UpdateBrevityIssueStoriesMutationInput {
+  id: ObjectID!
+  payload: UpdateBrevityIssueStoriesMutationPayloadInput!
+}
+
+input UpdateBrevityIssueStoriesMutationPayloadInput {
+  storyIds: [ObjectID!]!
 }
 
 `;

--- a/services/graphql-server/src/graphql/definitions/brevity/story.js
+++ b/services/graphql-server/src/graphql/definitions/brevity/story.js
@@ -1,0 +1,69 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+extend type Query {
+  brevityStory(input: BrevityStoryQueryInput!): BrevityStory @findOne(
+    model: "brevity.Story"
+    using: { id: "_id" }
+  )
+  brevityStoryies(input: BrevityStoriesQueryInput = {}): BrevityStoryConnection! @findMany(
+    model: "brevity.Story"
+  )
+}
+
+enum BrevityStorySortField {
+  id
+  name
+}
+
+type BrevityStory {
+  id: ObjectID! @projection(localField: "_id") @value(localField: "_id")
+
+  category: String @projection
+  name: String @projection
+  accentColor: String @projection
+  coverCredit: String @projection
+  textLocation: String @projection
+  byline: String @projection
+  body: String @projection
+  teaser: String @projection
+
+  author: BrevityAuthor @projection
+  coverImage: BrevityAssetImage @projection
+  coverVideo: BrevityAssetVideo @projection
+
+  issue(input: BrevityStoryIssueInput = {}): BrevityIssue @projection @refOne(loader: "brevity.Issue")
+}
+
+type BrevityStoryConnection @projectUsing(type: "BrevityStory") {
+  totalCount: Int!
+  edges: [BrevityStoryEdge]!
+  pageInfo: PageInfo!
+}
+
+type BrevityStoryEdge {
+  node: BrevityStory!
+  cursor: String!
+}
+
+input BrevityStoryQueryInput {
+  id: ObjectID!
+  status: ModelStatus = active
+}
+
+input BrevityStoryIssueInput {
+  status: ModelStatus = active
+}
+
+input BrevityStoriesQueryInput {
+  status: ModelStatus = active
+  sort: BrevityStorySortInput = {}
+  pagination: PaginationInput = {}
+}
+input BrevityStorySortInput {
+  field: BrevityStorySortField = id
+  order: SortOrder = desc
+}
+
+`;

--- a/services/graphql-server/src/graphql/definitions/brevity/story.js
+++ b/services/graphql-server/src/graphql/definitions/brevity/story.js
@@ -63,7 +63,7 @@ input BrevityStoriesQueryInput {
 }
 input BrevityStorySortInput {
   field: BrevityStorySortField = id
-  order: SortOrder = desc
+  order: SortOrder = values
 }
 
 `;

--- a/services/graphql-server/src/graphql/definitions/index.js
+++ b/services/graphql-server/src/graphql/definitions/index.js
@@ -1,6 +1,7 @@
 const gql = require('graphql-tag');
 
 const auth = require('./auth');
+const brevity = require('./brevity');
 const configuration = require('./configuration');
 const email = require('./email');
 const magazine = require('./magazine');
@@ -115,6 +116,7 @@ input FormatDate {
   timezone: String
 }
 
+${brevity}
 ${configuration}
 ${email}
 ${magazine}

--- a/services/graphql-server/src/graphql/ref-query-builders/brevity-collection-issues.js
+++ b/services/graphql-server/src/graphql/ref-query-builders/brevity-collection-issues.js
@@ -1,0 +1,5 @@
+module.exports = (doc, currentValues) => {
+  const { _id } = doc;
+  const { query, ...values } = currentValues;
+  return { ...values, query: { ...query, 'collection.$id': _id } };
+};

--- a/services/graphql-server/src/graphql/ref-query-builders/index.js
+++ b/services/graphql-server/src/graphql/ref-query-builders/index.js
@@ -1,3 +1,4 @@
+const brevityCollectionIssues = require('./brevity-collection-issues');
 const websiteSiteSections = require('./website-site-sections');
 
 /**
@@ -13,6 +14,7 @@ const websiteSiteSections = require('./website-site-sections');
  * Each function must return an object containing the new query and sort.
  */
 const builders = {
+  brevityCollectionIssues,
   websiteSiteSections,
 };
 

--- a/services/graphql-server/src/graphql/resolvers/brevity/asset.js
+++ b/services/graphql-server/src/graphql/resolvers/brevity/asset.js
@@ -1,0 +1,15 @@
+const { createSrcFor } = require('@base-cms/image');
+const defaults = require('../../defaults');
+
+module.exports = {
+  /**
+   *
+   */
+  BrevityAssetImage: {
+    src: (image, { input = {} }, { site }) => {
+      // Use site image host otherwise fallback to global default.
+      const imageHost = site.get('imageHost', defaults.imageHost);
+      return createSrcFor(imageHost, image, input.options);
+    },
+  },
+};

--- a/services/graphql-server/src/graphql/resolvers/brevity/index.js
+++ b/services/graphql-server/src/graphql/resolvers/brevity/index.js
@@ -1,0 +1,7 @@
+const deepAssign = require('deep-assign');
+
+const asset = require('./asset');
+
+module.exports = deepAssign(
+  asset,
+);

--- a/services/graphql-server/src/graphql/resolvers/brevity/index.js
+++ b/services/graphql-server/src/graphql/resolvers/brevity/index.js
@@ -1,7 +1,9 @@
 const deepAssign = require('deep-assign');
 
 const asset = require('./asset');
+const issue = require('./issue');
 
 module.exports = deepAssign(
   asset,
+  issue,
 );

--- a/services/graphql-server/src/graphql/resolvers/brevity/issue.js
+++ b/services/graphql-server/src/graphql/resolvers/brevity/issue.js
@@ -1,0 +1,21 @@
+const buildProjection = require('../../utils/build-projection');
+
+module.exports = {
+  /**
+   *
+   */
+  Mutation: {
+    /**
+     *
+     */
+    updateBrevityIssueStories: async (_, { input }, { basedb }, info) => {
+      const { id, payload } = input;
+      const { storyIds } = payload;
+      await basedb.strictFindById('brevity.Issue', id);
+      const stories = storyIds.map($id => ({ $ref: 'Story', $id }));
+      await basedb.updateOne('brevity.Issue', { _id: id }, { $set: { stories } });
+      const projection = buildProjection({ info, type: 'BrevityIssue' });
+      return basedb.findOne('brevity.Issue', { _id: id }, { projection });
+    },
+  },
+};

--- a/services/graphql-server/src/graphql/resolvers/index.js
+++ b/services/graphql-server/src/graphql/resolvers/index.js
@@ -3,6 +3,7 @@ const GraphQLJSON = require('graphql-type-json');
 const { DateType, ObjectIDType } = require('../types');
 
 const configuration = require('./configuration');
+const brevity = require('./brevity');
 const platform = require('./platform');
 const website = require('./website');
 const magazine = require('./magazine');
@@ -12,6 +13,7 @@ const auth = require('./auth');
 
 module.exports = deepAssign(
   auth,
+  brevity,
   configuration,
   googleDataApi,
   platform,

--- a/services/graphql-server/src/graphql/utils/criteria-for.js
+++ b/services/graphql-server/src/graphql/utils/criteria-for.js
@@ -5,6 +5,7 @@ const taxonomyTypes = getDefaultTaxonomyTypes();
 
 const criterion = {
   assetImage: () => ({ type: 'Image' }),
+  brevityCollection: () => ({ type: 'Collection' }),
   configurationThemeIcarus: () => ({ type: 'Icarus' }),
   content: () => ({ type: { $in: contentTypes } }),
   taxonomy: () => ({ type: { $in: taxonomyTypes } }),


### PR DESCRIPTION
Ref [PT #171469762 "Add GraphQL endpoint for reordering Clarity stories"](https://www.pivotaltracker.com/story/show/171469762)

```graphql
# Write your query or mutation here
query QueryBrevityIssue {
  brevityIssue(input: { id: "55d37e7d35ab46bf488b4589" }) {
    id
    name
    description
    status
    stories {
      edges {
        node {
          id
          name
        }
      }
    }
  }
}
mutation UpdateBrevityStoryOrder($input: UpdateBrevityIssueStoriesMutationInput!) {
  updateBrevityIssueStories(input: $input) {
    id
    name
    stories {
      edges {
        node {
          id
          name
        }
      }
    }
  }
}
```

```json
{
  "input": {
    "id": "55d37e7d35ab46bf488b4589",
    "payload": {
      "storyIds": [
        "55d37e9b5fab4681568b4585",
        "55d37ecb5fab46e1578b456b",
        "55d37f065fab468b588b456d",
        "55d37f2835ab46414b8b4597",
        "55d37f3d35ab46344b8b45b3",
        "55db1f6335ab4661538b4567",
        "5aa003135dab469c1be9cbfd"
      ]
    }
  }
}
```