### PR TITLE
Properly check for option name length

### DIFF
--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -488,7 +488,7 @@ module.exports = {
           basedb,
           siteId,
           ids: optionId,
-          names: optionName || ['Standard'],
+          names: optionName.length ? optionName : ['Standard'],
         }),
       ]);
 
@@ -985,7 +985,7 @@ module.exports = {
           basedb,
           siteId,
           ids: optionId,
-          names: optionName || ['Standard'],
+          names: optionName.length ? optionName : ['Standard'],
         }),
       ]);
 


### PR DESCRIPTION
Otherwise, the query will not properly fallback to `Standard` option when the input array is empty.