### PR TITLE
Allow section to be optional on scheduled content

### DIFF
--- a/packages/web-common/src/block-loaders/website-scheduled-content.js
+++ b/packages/web-common/src/block-loaders/website-scheduled-content.js
@@ -3,9 +3,8 @@ const buildQuery = require('../gql/query-factories/block-website-scheduled-conte
 /**
  * @param {ApolloClient} apolloClient The Apollo GraphQL client that will perform the query.
  * @param {object} params
- * @param {number} params.sectionId The section ID.
- * @param {number} params.sectionAlias The section alias.
- *                                     A `sectionId` or `sectionAlias` is required.
+ * @param {number} [params.sectionId] The section ID.
+ * @param {number} [params.sectionAlias] The section alias.
  * @param {number} [params.limit] The number of results to return.
  * @param {string} [params.after] The cursor to start returning results from.
  * @param {object} [params.sort] The sort parameters (field and order) to apply to the query.

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -161,7 +161,7 @@ type ContentConnection @projectUsing(type: "Content") {
 type WebsiteScheduledContentConnection @projectUsing(type: "Content") {
   totalCount: Int!
   edges: [ContentEdge]!
-  section: WebsiteSection! @refOne(localField: "sectionId", loader: "websiteSection")
+  section: WebsiteSection @refOne(localField: "sectionId", loader: "websiteSection")
   pageInfo: PageInfo!
 }
 


### PR DESCRIPTION
If a section ID or alias is not provided, return content that’s scheduled to _any_ section (i.e. `{sectionId: { $exists: true } }`)