### PR TITLE
Ensure listener (optionally) displays ad on all elements

### DIFF
--- a/packages/marko-web-reveal-ad/browser/listener.vue
+++ b/packages/marko-web-reveal-ad/browser/listener.vue
@@ -109,7 +109,6 @@ export default {
       if (['adImagePath', 'adTitle', 'backgroundImagePath', 'adClickUrl'].every(k => payload[k])) {
         const elements = this.selectAllTargets
           ? document.querySelectorAll(this.target) : [document.querySelector(this.target)];
-        document.querySelectorAll(this.target);
         this.payload = { ...this.defaults, ...payload };
         this.displayBackground();
         for (let i = 0; i < elements.length; i += 1) {

--- a/packages/marko-web-reveal-ad/browser/listener.vue
+++ b/packages/marko-web-reveal-ad/browser/listener.vue
@@ -102,11 +102,13 @@ export default {
     },
     listener(event) {
       const payload = parseJson(event.data);
-      const element = document.querySelector(this.target);
-      if (['adImagePath', 'adTitle', 'backgroundImagePath', 'adClickUrl'].every(k => payload[k]) && element) {
+      if (['adImagePath', 'adTitle', 'backgroundImagePath', 'adClickUrl'].every(k => payload[k])) {
+        const elements = document.querySelectorAll(this.target);
         this.payload = { ...this.defaults, ...payload };
         this.displayBackground();
-        this.displayAd(element);
+        for (let i = 0; i < elements.length; i += 1) {
+          this.displayAd(elements[i]);
+        }
         this.observeMutations();
         window.removeEventListener('message', this.listener);
       }

--- a/packages/marko-web-reveal-ad/browser/listener.vue
+++ b/packages/marko-web-reveal-ad/browser/listener.vue
@@ -30,6 +30,10 @@ export default {
       type: Object,
       default: () => ({ backgroundColor: 'transparent' }),
     },
+    selectAllTargets: {
+      type: Boolean,
+      default: false,
+    },
   },
   data: () => ({
     observed: 0,
@@ -103,7 +107,9 @@ export default {
     listener(event) {
       const payload = parseJson(event.data);
       if (['adImagePath', 'adTitle', 'backgroundImagePath', 'adClickUrl'].every(k => payload[k])) {
-        const elements = document.querySelectorAll(this.target);
+        const elements = this.selectAllTargets
+          ? document.querySelectorAll(this.target) : [document.querySelector(this.target)];
+        document.querySelectorAll(this.target);
         this.payload = { ...this.defaults, ...payload };
         this.displayBackground();
         for (let i = 0; i < elements.length; i += 1) {

--- a/packages/marko-web-reveal-ad/components/listener.marko
+++ b/packages/marko-web-reveal-ad/components/listener.marko
@@ -1,6 +1,7 @@
 $ const props = {
   target: input.target,
   defaults: input.defaults,
+  selectAllTargets: input.selectAllTargets,
 };
 
 <marko-web-browser-component name="RevealAdListener" props=props />

--- a/packages/marko-web-reveal-ad/components/marko.json
+++ b/packages/marko-web-reveal-ad/components/marko.json
@@ -2,6 +2,7 @@
   "<marko-web-reveal-ad-listener>": {
     "template": "./listener.marko",
     "@target": "string",
-    "@defaults": "object"
+    "@defaults": "object",
+    "@select-all-targets": "boolean"
   }
 }


### PR DESCRIPTION
The component now uses `querySelectorAll` and loads the ad to all elements it finds rather than just the first one. This will only by applied if the `select-all-targets` prop is set to `true`.