### PR TITLE
Add Upcoming & Archive to AllPublishedContentQuery

### DIFF
--- a/packages/web-common/src/block-loaders/all-published-content.js
+++ b/packages/web-common/src/block-loaders/all-published-content.js
@@ -6,6 +6,10 @@ const date = v => (v instanceof Date ? v.valueOf() : v);
  * @param {ApolloClient} apolloClient The Apollo GraphQL client that will perform the query.
  * @param {object} params
  * @param {date} params.since The date to consider content published by
+ * * This addes logic to only return content with starr/end date in the future
+ * @param {boolean} params.upcoming
+ * This addes logic to only return content with starr/end date in the past
+ * @param {boolean} params.archived
  * @param {date} params.beginningAfter The date to include content by
  * @param {date} params.beginningBefore The date to include content by
  * @param {date} params.endingAfter The date to include content by
@@ -28,6 +32,8 @@ module.exports = async (apolloClient, {
   after,
 
   since,
+  upcoming,
+  archived,
   beginningAfter,
   beginningBefore,
   endingAfter,
@@ -62,6 +68,8 @@ module.exports = async (apolloClient, {
     beginning: { after: date(beginningAfter), before: date(beginningBefore) },
     ending: { after: date(endingAfter), before: date(endingBefore) },
   };
+  if (archived) input.archived = archived;
+  if (upcoming) input.upcoming = upcoming;
   if (field || order) input.sort = { field, order };
   const query = buildQuery({ queryFragment, queryName });
   const variables = { input };

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -276,6 +276,8 @@ input ContentSitemapNewsUrlsQueryInput {
 input AllPublishedContentQueryInput {
   siteId: ObjectID
   after: Date
+  upcoming: Boolean
+  archived: Boolean
   since: Date
   sectionId: Int
   # @deprecated. Use \`AllPublishedContentQueryInput.includeContentTypes\` instead.
@@ -324,6 +326,8 @@ input AllCompanyContentQueryInput {
 input ContentBeginningInput {
   before: Date
   after: Date
+  upcoming: Boolean
+  archived: Boolean
 }
 
 input ContentEndingInput {

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -609,6 +609,8 @@ module.exports = {
       const {
         since,
         after,
+        upcoming,
+        archived,
         sectionId,
         contentTypes: deprecatedContentTypes,
         includeContentTypes,
@@ -628,6 +630,8 @@ module.exports = {
       const query = getPublishedCriteria({
         since,
         after,
+        upcoming,
+        archived,
         contentTypes,
         excludeContentIds,
         excludeContentTypes,
@@ -640,6 +644,26 @@ module.exports = {
       if (beginning.after) query.$and.push({ startDate: { $gte: beginning.after } });
       if (ending.before) query.$and.push({ endDate: { $lte: ending.before } });
       if (ending.after) query.$and.push({ endDate: { $gte: ending.after } });
+
+      if (upcoming) {
+        const date = new Date();
+        query.$and.push({
+          $or: [
+            { startDate: { $gt: date } },
+            { endDate: { $gt: date } },
+          ],
+        });
+      }
+
+      if (archived) {
+        const date = new Date();
+        query.$and.push({
+          $or: [
+            { startDate: { $lt: date } },
+            { endDate: { $exists: true, $lt: date } },
+          ],
+        });
+      }
 
       if (requiresImage) {
         query.primaryImage = { $exists: true };
@@ -672,6 +696,8 @@ module.exports = {
       const {
         since,
         after,
+        upcoming,
+        archived,
         includeContentTypes: contentTypes,
         excludeContentTypes,
       } = input;
@@ -679,6 +705,8 @@ module.exports = {
       const $match = getPublishedCriteria({
         since,
         after,
+        upcoming,
+        archived,
         contentTypes,
         excludeContentTypes,
       });


### PR DESCRIPTION
 - Upcoming: return anything with a startDate or endDate in the future
 - Archive: is anything with a startDate and if endDate is set and in the past

**ARCHIVED:**
```gql
query{
  allPublishedContent(
    input:{
      includeContentTypes:Webinar,
      archived: true
      sort: {
        field:startDate,
        order:asc
      },
      pagination: {
        limit: 10
      }
    }
	)
	{
    	edges {
        node {
          name
          ... on ContentWebinar {
            starts
          }
        }
      }
  	}
}
```

**Upcoming:**
```gql
query{
  allPublishedContent(
    input:{
      includeContentTypes:Webinar,
      upcoming: true
      sort: {
        field:startDate,
        order: asc
      },
      pagination: {
        limit: 10
      }
    }
	)
	{
    	edges {
        node {
          name
          ... on ContentWebinar {
            starts
          }
        }
      }
  	}
}
```