### PR TITLE
Ensure that non-scalar targeting values are kept

### DIFF
--- a/packages/marko-web-gam/package.json
+++ b/packages/marko-web-gam/package.json
@@ -10,7 +10,7 @@
     "lint:js": "eslint --ext .js --ext .vue --max-warnings 5 ./",
     "lint:css": "stylelint ./**/*.scss --max-warnings 5",
     "compile": "basecms-marko-compile compile --dir ./ --silent true",
-    "test": "yarn run lint && ../../node_modules/.bin/mocha --reporter spec"
+    "test": "yarn compile && yarn lint && mocha --reporter spec"
   },
   "dependencies": {
     "@base-cms/object-path": "^1.25.0",

--- a/packages/marko-web-gam/package.json
+++ b/packages/marko-web-gam/package.json
@@ -10,7 +10,7 @@
     "lint:js": "eslint --ext .js --ext .vue --max-warnings 5 ./",
     "lint:css": "stylelint ./**/*.scss --max-warnings 5",
     "compile": "basecms-marko-compile compile --dir ./ --silent true",
-    "test": "yarn compile && yarn lint"
+    "test": "yarn run lint && ../../node_modules/.bin/mocha --reporter spec"
   },
   "dependencies": {
     "@base-cms/object-path": "^1.25.0",
@@ -20,6 +20,10 @@
   "peerDependencies": {
     "@base-cms/marko-core": "^1.0.0",
     "@base-cms/marko-web": "^1.0.0"
+  },
+  "devDependencies": {
+    "chai": "^4.2.0",
+    "mocha": "^6.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/marko-web-gam/test/mocha.opts
+++ b/packages/marko-web-gam/test/mocha.opts
@@ -1,0 +1,3 @@
+--recursive
+--async-only
+--timeout 2000

--- a/packages/marko-web-gam/test/utils/build-targeting.spec.js
+++ b/packages/marko-web-gam/test/utils/build-targeting.spec.js
@@ -1,0 +1,45 @@
+const { describe, it } = require('mocha');
+const { expect } = require('chai');
+const builder = require('../../utils/build-targeting');
+
+describe('utils/build-targeting', () => {
+  describe('character cleaning', () => {
+    it('should strip invalid characters from keys', async () => {
+      const out = await builder({ 'key"\'=!+#*~;^()[]<>,.&123': 'good value' });
+      expect(out).to.equal('setTargeting(\'key123\', \'good value\')');
+    });
+    it('should strip invalid characters from string values', async () => {
+      const out = await builder({ key123: 'good"\'=!+#*~;^()[]<>,.& value' });
+      expect(out).to.equal('setTargeting(\'key123\', \'good value\')');
+    });
+    it('should strip invalid characters from array values', async () => {
+      const out = await builder({
+        key123: [
+          'good"\'=!+#*~;^()[]<>,.& value',
+          'another value',
+          'aonther #*~;^() value',
+        ],
+      });
+      expect(out).to.equal(`setTargeting('key123', '${JSON.stringify([
+        'good value',
+        'another value',
+        'aonther  value',
+      ])}')`);
+    });
+  });
+
+  // describe('a prefix of "BRUNDON"', () => {
+  //   const obj = { _id: 1234 };
+  //   const canonicalRules = requestParser({ headers: { 'x-canonical-magazine-issue-prefix':
+  // 'BRUNDON' } });
+  //   const context = { canonicalRules };
+  //   it('should return "/" when passed invalid input', async () => {
+  //     const out = await issue({}, context);
+  //     expect(out).to.equal('/');
+  //   });
+  //   it('should return "/BRUNDON/1234"', async () => {
+  //     const out = await issue(obj, context);
+  //     expect(out).to.equal('/BRUNDON/1234');
+  //   });
+  // });
+});

--- a/packages/marko-web-gam/test/utils/build-targeting.spec.js
+++ b/packages/marko-web-gam/test/utils/build-targeting.spec.js
@@ -20,11 +20,16 @@ describe('utils/build-targeting', () => {
           'aonther #*~;^() value',
         ],
       });
-      expect(out).to.equal(`setTargeting('key123', '${JSON.stringify([
+      expect(out).to.equal(`setTargeting('key123', ${JSON.stringify([
         'good value',
         'another value',
         'aonther  value',
-      ])}')`);
+      ])})`);
+    });
+    it('should return a valid array', async () => {
+      const test = ['array', 'of', 'values'];
+      const out = await builder({ key123: test });
+      expect(out).to.equal(`setTargeting('key123', ${JSON.stringify(test)})`);
     });
   });
 

--- a/packages/marko-web-gam/test/utils/build-targeting.spec.js
+++ b/packages/marko-web-gam/test/utils/build-targeting.spec.js
@@ -32,19 +32,4 @@ describe('utils/build-targeting', () => {
       expect(out).to.equal(`setTargeting('key123', ${JSON.stringify(test)})`);
     });
   });
-
-  // describe('a prefix of "BRUNDON"', () => {
-  //   const obj = { _id: 1234 };
-  //   const canonicalRules = requestParser({ headers: { 'x-canonical-magazine-issue-prefix':
-  // 'BRUNDON' } });
-  //   const context = { canonicalRules };
-  //   it('should return "/" when passed invalid input', async () => {
-  //     const out = await issue({}, context);
-  //     expect(out).to.equal('/');
-  //   });
-  //   it('should return "/BRUNDON/1234"', async () => {
-  //     const out = await issue(obj, context);
-  //     expect(out).to.equal('/BRUNDON/1234');
-  //   });
-  // });
 });

--- a/packages/marko-web-gam/utils/build-targeting.js
+++ b/packages/marko-web-gam/utils/build-targeting.js
@@ -12,7 +12,7 @@ module.exports = (targeting) => {
     const value = targeting[key];
     // Clean the key and the values.
     // Per https://support.google.com/admanager/answer/177381
-    const cleaned = isArray(value) ? JSON.stringify(value.map(clean)) : clean(value);
-    return `setTargeting('${clean(key)}', '${cleaned}')`;
+    const cleaned = isArray(value) ? JSON.stringify(value.map(clean)) : `'${clean(value)}'`;
+    return `setTargeting('${clean(key)}', ${cleaned})`;
   }).join('.');
 };

--- a/services/example-website-lfw/server/templates/index.marko
+++ b/services/example-website-lfw/server/templates/index.marko
@@ -12,6 +12,7 @@ $ const { site } = out.global;
       <marko-web-gtm-push data=context />
     </marko-web-gtm-website-section-context>
     <marko-web-resolve-page|{ data: section }| node=pageNode>
+      <marko-web-gam-targeting key-values={ single: 'single', multi: ['array', 'of', 'values'] } />
       $ const aliases = hierarchyAliases(section);
       $ const adSlots = {
           "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/services/example-website-lfw/server/templates/index.marko
+++ b/services/example-website-lfw/server/templates/index.marko
@@ -12,7 +12,6 @@ $ const { site } = out.global;
       <marko-web-gtm-push data=context />
     </marko-web-gtm-website-section-context>
     <marko-web-resolve-page|{ data: section }| node=pageNode>
-      <marko-web-gam-targeting key-values={ single: 'single', multi: ['array', 'of', 'values'] } />
       $ const aliases = hierarchyAliases(section);
       $ const adSlots = {
           "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),


### PR DESCRIPTION
Currently arrays of values to the setTargeting command are being improperly quoted. This PR resolves this issue by only quoting explicit string values.

Current behavior:
```js
googletag.cmd.push(function() {
  googletag.pubads()
    .setTargeting('single', 'some-value')
    .setTargeting('multi', '["array","of","values"]');
});
```
New behavior:
```js
googletag.cmd.push(function() {
  googletag.pubads()
    .setTargeting('single', 'some-value')
    .setTargeting('multi', ["array","of","values"]);
});
```