### PR TITLE
Support storing IP address with inquiry submission

### DIFF
--- a/services/graphql-server/src/graphql/definitions/website/inquiry-submission.js
+++ b/services/graphql-server/src/graphql/definitions/website/inquiry-submission.js
@@ -24,6 +24,7 @@ type InquirySubmissionAddresses {
 input CreateInquirySubmissionMutationInput {
   contentId: Int!
   addresses: InquirySubmissionAddressesInput!
+  ipAddress: String
   payload: JSON!
 }
 

--- a/services/graphql-server/src/graphql/resolvers/website/inquiry-submission.js
+++ b/services/graphql-server/src/graphql/resolvers/website/inquiry-submission.js
@@ -8,12 +8,14 @@ module.exports = {
      */
     createInquirySubmission: async (_, { input }, { basedb }) => {
       const { payload, addresses, contentId } = input;
+      const { ipAddress } = input;
       const clean = Object.keys(payload)
         .reduce((obj, key) => (payload[key] ? { ...obj, [key]: payload[key] } : obj), {});
       const document = {
         payload: clean,
         created: new Date(),
         contentId,
+        ipAddress,
         addresses,
       };
       await basedb.insertOne('website.InquirySubmission', document);


### PR DESCRIPTION
The field is optional for backwards compatibility, and will be supplied by the front-end when storing the submission (the request IP as detected by the backend would be the internal docker IP, not the client IP)