### PR TITLE
Identityx email consent

### DIFF
--- a/packages/marko-web-identity-x/api/fragments/active-user.js
+++ b/packages/marko-web-identity-x/api/fragments/active-user.js
@@ -13,6 +13,7 @@ fragment ActiveUserFragment on AppUser {
   countryCode
   regionCode
   postalCode
+  receiveEmail
 }
 
 `;

--- a/packages/marko-web-identity-x/api/queries/get-active-context.js
+++ b/packages/marko-web-identity-x/api/queries/get-active-context.js
@@ -12,6 +12,7 @@ query GetActiveAppContext {
         id
         name
         consentPolicy
+        emailConsentRequest
       }
     }
     user {

--- a/packages/marko-web-identity-x/browser/authenticate.vue
+++ b/packages/marko-web-identity-x/browser/authenticate.vue
@@ -12,6 +12,7 @@
       :required-server-fields="requiredServerFields"
       :required-client-fields="requiredClientFields"
       :consent-policy="consentPolicy"
+      :email-consent-request="emailConsentRequest"
       @submit="redirect"
     />
   </div>
@@ -68,6 +69,10 @@ export default {
       default: () => [],
     },
     consentPolicy: {
+      type: String,
+      default: null,
+    },
+    emailConsentRequest: {
       type: String,
       default: null,
     },

--- a/packages/marko-web-identity-x/browser/form/fields/receive-email.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/receive-email.vue
@@ -1,0 +1,51 @@
+<template>
+  <form-group>
+    <div class="custom-control custom-checkbox">
+      <input
+        :id="id"
+        v-model="receiveEmail"
+        :disabled="disabled"
+        type="checkbox"
+        class="custom-control-input"
+      >
+      <label :for="id" class="custom-control-label">
+        {{ emailConsentRequest }}
+      </label>
+    </div>
+  </form-group>
+</template>
+
+<script>
+import FormGroup from '../common/form-group.vue';
+
+export default {
+  components: { FormGroup },
+  props: {
+    emailConsentRequest: {
+      type: String,
+      required: true,
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    value: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data: () => ({
+    id: 'sign-on-receive-email',
+  }),
+  computed: {
+    receiveEmail: {
+      get() {
+        return this.value;
+      },
+      set(receiveEmail) {
+        this.$emit('input', receiveEmail);
+      },
+    },
+  },
+};
+</script>

--- a/packages/marko-web-identity-x/browser/form/fields/region.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/region.vue
@@ -10,7 +10,7 @@
       :disabled="disabled"
       :required="required"
       class="custom-select"
-      autocomplete="region"
+      autocomplete="address-level1"
     >
       <option disabled value="">
         Select state/region...

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -58,6 +58,15 @@
           </div>
         </div>
 
+        <div v-if="emailConsentRequest" class="row mt-3">
+          <div class="col-md-6">
+            <receive-email
+              v-model="user.receiveEmail"
+              :email-consent-request="emailConsentRequest"
+            />
+          </div>
+        </div>
+
         <small
           v-if="consentPolicy"
           class="text-muted mb-3"
@@ -96,6 +105,7 @@ import OrganizationTitle from './form/fields/organization-title.vue';
 import Country from './form/fields/country.vue';
 import Region from './form/fields/region.vue';
 import PostalCode from './form/fields/postal-code.vue';
+import ReceiveEmail from './form/fields/receive-email.vue';
 import Login from './login.vue';
 
 import FeatureError from './errors/feature';
@@ -110,6 +120,7 @@ export default {
     Country,
     Region,
     PostalCode,
+    ReceiveEmail,
     Login,
   },
 
@@ -146,6 +157,10 @@ export default {
       default: null,
     },
     appContextId: {
+      type: String,
+      default: null,
+    },
+    emailConsentRequest: {
       type: String,
       default: null,
     },

--- a/packages/marko-web-identity-x/components/form-authenticate.marko
+++ b/packages/marko-web-identity-x/components/form-authenticate.marko
@@ -13,6 +13,7 @@ $ const isEnabled = Boolean(req.identityX);
       requiredClientFields: identityX.config.getRequiredClientFields(),
       endpoints: identityX.config.getEndpoints(),
       consentPolicy: get(application, "organization.consentPolicy"),
+      emailConsentRequest: get(application, "organization.emailConsentRequest"),
     };
     <marko-web-browser-component name="IdentityXAuthenticate" props=props />
   </marko-web-identity-x-context>

--- a/packages/marko-web-identity-x/components/form-profile.marko
+++ b/packages/marko-web-identity-x/components/form-profile.marko
@@ -13,6 +13,7 @@ $ const { identityX } = req;
       reloadPageOnSubmit: input.reloadPageOnSubmit,
       endpoints: identityX.config.getEndpoints(),
       consentPolicy: get(application, "organization.consentPolicy"),
+      emailConsentRequest: get(application, "organization.emailConsentRequest"),
       appContextId: identityX.config.get("appContextId"),
     };
     <if(isEnabled)>

--- a/packages/marko-web-identity-x/routes/profile.js
+++ b/packages/marko-web-identity-x/routes/profile.js
@@ -22,6 +22,7 @@ module.exports = asyncRoute(async (req, res) => {
     countryCode,
     regionCode,
     postalCode,
+    receiveEmail,
   } = body;
   const input = {
     givenName,
@@ -31,6 +32,7 @@ module.exports = asyncRoute(async (req, res) => {
     countryCode,
     regionCode,
     postalCode,
+    receiveEmail,
   };
   const { data } = await identityX.client.mutate({ mutation, variables: { input } });
   res.json({ ok: true, user: data.updateOwnAppUser });


### PR DESCRIPTION
Add email consent language and checkbox to user profile form. This will only display if the consent language is added to the organization.

Requires base-cms/id-me#61 to merged and deployed.

![image](https://user-images.githubusercontent.com/3289485/78704700-de390c00-78d1-11ea-8611-8b734acf9e41.png)


