### PR TITLE
Add `withSite` support to AllAuthorContent query

### DIFF
--- a/packages/web-common/src/block-loaders/all-author-content.js
+++ b/packages/web-common/src/block-loaders/all-author-content.js
@@ -10,6 +10,7 @@ const date = v => (v instanceof Date ? v.valueOf() : v);
  * @param {number} params.contactId The author's contact (content) ID.
  * @param {string[]} [params.includeContentTypes] An array of content types to include.
  * @param {boolean} [params.requiresImage] Whether the content must have an image.
+ * @param {boolean} [params.withSite] Whether to limit results to the current site context
  * @param {string[]} [params.authorTypes] The author types to use
  *                                        (e.g author, contributor and/or photographer).
  * @param {string} [params.sortField] The field to use for sorting results
@@ -34,6 +35,7 @@ module.exports = async (apolloClient, {
 
   includeContentTypes,
   requiresImage,
+  withSite,
 
   queryFragment,
   queryName,
@@ -45,6 +47,7 @@ module.exports = async (apolloClient, {
     includeContentTypes,
     pagination,
     requiresImage,
+    withSite,
     since: date(since),
   };
   if (field || order) input.sort = { field, order };

--- a/packages/web-common/src/block-loaders/all-author-content.js
+++ b/packages/web-common/src/block-loaders/all-author-content.js
@@ -11,6 +11,7 @@ const date = v => (v instanceof Date ? v.valueOf() : v);
  * @param {string[]} [params.includeContentTypes] An array of content types to include.
  * @param {boolean} [params.requiresImage] Whether the content must have an image.
  * @param {boolean} [params.withSite] Whether to limit results to the current site context
+ * @param {string} [params.siteId] A website site identifier to limit results by primarySite
  * @param {string[]} [params.authorTypes] The author types to use
  *                                        (e.g author, contributor and/or photographer).
  * @param {string} [params.sortField] The field to use for sorting results
@@ -36,6 +37,7 @@ module.exports = async (apolloClient, {
   includeContentTypes,
   requiresImage,
   withSite,
+  siteId,
 
   queryFragment,
   queryName,
@@ -48,6 +50,7 @@ module.exports = async (apolloClient, {
     pagination,
     requiresImage,
     withSite,
+    siteId,
     since: date(since),
   };
   if (field || order) input.sort = { field, order };

--- a/services/example-website-lfw/server/components/blocks/content-load-more.marko
+++ b/services/example-website-lfw/server/components/blocks/content-load-more.marko
@@ -15,7 +15,7 @@ $ const {
     component-input={ aliases }
     fragment-name="content-list"
     query-name="all-author-content"
-    query-params={ contactId: id }
+    query-params={ contactId: id, withSite: false }
     page-input={ for: "content", id, type }
   />
 </if>

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -308,6 +308,7 @@ input AllAuthorContentQueryInput {
   requiresImage: Boolean = false
   sort: ContentSortInput = { field: published, order: desc }
   pagination: PaginationInput = {}
+  withSite: Boolean = true
 }
 
 input AllCompanyContentQueryInput {

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -774,6 +774,7 @@ module.exports = {
         requiresImage,
         sort,
         pagination,
+        withSite,
       } = input;
 
       if (!authorTypes.length) throw new UserInputError('At least one `authorType` must be provided.');
@@ -781,7 +782,7 @@ module.exports = {
       const query = getPublishedCriteria({ since, contentTypes: includeContentTypes });
 
       const siteId = input.siteId || site.id();
-      if (siteId) query['mutations.Website.primarySite'] = siteId;
+      if (withSite && siteId) query['mutations.Website.primarySite'] = siteId;
 
       query.$or = authorTypes.map((type) => {
         const field = `${type}s`;


### PR DESCRIPTION
- Adds `withSite` parameter to `AllAuthorContentQueryInput` to allow the user to determine whether or not to use the passed `siteId` (via input or via `x-site-id` header).
- Adds support for `withSite` and `siteId` to the author content block loader