### PR TITLE
Check correct image wrapper width variable

### DIFF
--- a/packages/marko-web/components/node/image-wrapper.marko
+++ b/packages/marko-web/components/node/image-wrapper.marko
@@ -6,7 +6,7 @@ $ const hasImage = Boolean(input.src);
 $ const { width, height } = imageValues(input);
 
 $ const style = [];
-$ if (input.width) {
+$ if (width) {
   style.push(`width: ${input.width}px;`);
   // Add min-width for IE11
   style.push(`min-width: ${input.width}px;`);


### PR DESCRIPTION
Was using `input.width` and not the calculated `width` value. As such, fluid images were getting widths applied, breaking fluidity.