### PR TITLE
Support loading leadership sections by related section ids

### DIFF
--- a/packages/leaders-program/src/components/leaders.vue
+++ b/packages/leaders-program/src/components/leaders.vue
@@ -139,6 +139,10 @@ export default {
       type: Number,
       default: 3,
     },
+    useContentPrimarySection: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   data: () => ({
@@ -253,11 +257,14 @@ export default {
       const variables = { contentId: this.contentId };
       const r1 = await this.$apollo.query({ query: contentQuery, variables });
       const taxonomyIds = getEdgeNodes(r1, 'data.content.taxonomy').map(t => t.id);
+      const sectionIds = [];
       this.taxonomyIds = taxonomyIds;
-      const primarySection = getAsObject(r1, 'data.content.primarySection');
-      const relatedSectionIds = primarySection.id ? [primarySection.id] : [];
-      if (!taxonomyIds.length && !relatedSectionIds.length) return [];
-      const v2 = { taxonomyIds, relatedSectionIds };
+      if (this.useContentPrimarySection) {
+        const primarySection = getAsObject(r1, 'data.content.primarySection');
+        if (primarySection.id) sectionIds.push(primarySection.id);
+      }
+      if (!taxonomyIds.length && !sectionIds.length) return [];
+      const v2 = { taxonomyIds, relatedSectionIds: sectionIds };
       const r2 = await this.$apollo.query({ query: fromContentQuery, variables: v2 });
       const sections = getEdgeNodes(r2, 'data.websiteSections');
       return sections

--- a/packages/leaders-program/src/graphql/queries/content.js
+++ b/packages/leaders-program/src/graphql/queries/content.js
@@ -12,6 +12,9 @@ query LeadersContentTaxonomyIds($contentId: Int!) {
         }
       }
     }
+    primarySection {
+      id
+    }
   }
 }
 

--- a/packages/leaders-program/src/graphql/queries/sections-from-content.js
+++ b/packages/leaders-program/src/graphql/queries/sections-from-content.js
@@ -2,8 +2,9 @@ import gql from 'graphql-tag';
 
 export default gql`
 
-query LeadersSectionsFromTaxonomy($taxonomyIds: [Int!]!) {
+query LeadersSectionsFromContent($taxonomyIds: [Int!]!, $relatedSectionIds: [Int!]!) {
   websiteSections(input: {
+    relatedSectionIds: $relatedSectionIds,
     taxonomyIds: $taxonomyIds,
     pagination: { limit: 0 },
     sort: { field: name, order: asc },

--- a/services/example-website-lfw/server/components/blocks/leaders/contextual.marko
+++ b/services/example-website-lfw/server/components/blocks/leaders/contextual.marko
@@ -13,6 +13,7 @@ $ const { contentId } = input;
     promotionLimit: site.get("leaders.promotionLimit", 4),
     videoLimit: site.get("leaders.videoLimit", 3),
     viewAllHref: '/leaders',
+    useContentPrimarySection: true,
     mediaQueries: [
       { prop: "displayCallout", value: true, query: "(min-width: 701px)" },
       { prop: "displayCallout", value: false, query: "(min-width: 992px)" },

--- a/services/graphql-server/src/graphql/definitions/website/section.js
+++ b/services/graphql-server/src/graphql/definitions/website/section.js
@@ -158,6 +158,7 @@ input WebsiteSectionsQueryInput {
   excludeIds: [Int!] = []
   rootOnly: Boolean = false
   taxonomyIds: [Int!] = []
+  relatedSectionIds: [Int!] = []
   status: ModelStatus = active
   sort: WebsiteSectionSortInput = {}
   pagination: PaginationInput = {}

--- a/services/graphql-server/src/graphql/query-builders/website-sections.js
+++ b/services/graphql-server/src/graphql/query-builders/website-sections.js
@@ -6,12 +6,14 @@ module.exports = ({ query }, { input }) => {
     excludeIds,
     rootOnly,
     taxonomyIds,
+    relatedSectionIds,
     excludeAliases,
     includeAliases,
   } = input;
 
   if (rootOnly) q['parent.$id'] = { $exists: false };
   if (taxonomyIds.length) q['relatedTaxonomy.$id'] = { $in: taxonomyIds };
+  if (relatedSectionIds.length) q.relatedSections = { $in: relatedSectionIds };
   if (includeIds.length || excludeIds.length) {
     q._id = {
       ...(includeIds.length && { $in: includeIds }),


### PR DESCRIPTION
Current, no taxonomy relationships
![image](https://user-images.githubusercontent.com/1778222/81208279-6a535780-8f94-11ea-8f65-d1f49a24f799.png)

With section relationship support
![image](https://user-images.githubusercontent.com/1778222/81208323-7a6b3700-8f94-11ea-9816-aeb6ad49bef5.png)
