### PR TITLE
Increate site footer z-index

### DIFF
--- a/packages/marko-web-theme-default/scss/components/_site-footer.scss
+++ b/packages/marko-web-theme-default/scss/components/_site-footer.scss
@@ -1,6 +1,7 @@
 .site-footer {
-  z-index: 1;
-  margin-top: auto;
+  position: relative;
+  z-index: 1500;
+  margin-top: 20px;
   font-family: $theme-site-footer-font-family;
   font-size: $theme-site-footer-font-size;
   font-weight: $theme-site-footer-font-weight;


### PR DESCRIPTION
Correction for reskin ad overlaying footer background
https://www.pivotaltracker.com/story/show/172730503

Current:
<img width="1440" alt="Screen Shot 2020-05-08 at 10 08 07 AM" src="https://user-images.githubusercontent.com/6343242/81413810-11123200-9114-11ea-95af-24e410b9b406.png">
<img width="1440" alt="Screen Shot 2020-05-08 at 10 05 26 AM" src="https://user-images.githubusercontent.com/6343242/81413818-14a5b900-9114-11ea-9eb2-66dbc7e0d0bc.png">

New:
<img width="1438" alt="Screen Shot 2020-05-08 at 9 43 26 AM" src="https://user-images.githubusercontent.com/6343242/81413829-196a6d00-9114-11ea-93b9-2bc3e7fac4fa.png">
<img width="1440" alt="Screen Shot 2020-05-08 at 10 10 19 AM" src="https://user-images.githubusercontent.com/6343242/81413862-2a1ae300-9114-11ea-966f-5c2bc15a24f4.png">
