### PR TITLE
Use updated or start date as published date

### DIFF
--- a/packages/marko-web-native-x/utils/convert-ad-to-content.js
+++ b/packages/marko-web-native-x/utils/convert-ad-to-content.js
@@ -1,5 +1,9 @@
+const { get } = require('@base-cms/object-path');
+
 module.exports = (ad = {}, { sectionName = 'Sponsored' } = {}) => {
   const { campaign, creative, image } = ad;
+  const startDate = get(campaign, 'criteria.start');
+  const { updatedAt } = campaign;
   return {
     id: campaign.id,
     name: creative.title,
@@ -7,7 +11,7 @@ module.exports = (ad = {}, { sectionName = 'Sponsored' } = {}) => {
     typeTitled: 'Text Ad',
     type: 'text-ad',
     teaser: creative.teaser,
-    published: campaign.createdAt,
+    published: updatedAt > startDate ? updatedAt : startDate,
     canonicalPath: ad.href, // @deprecated. Use siteContext.path instead
     siteContext: {
       path: ad.href,


### PR DESCRIPTION
The published date will use the campaign’s updated date when newer than the start date. Otherwise the start date will be used.

The campaign created date is no longer used, as it could reflect a much older date.