### PR TITLE
Add support for customizing inquiry email subject lines

### DIFF
--- a/packages/marko-web-inquiry/routers/submit.js
+++ b/packages/marko-web-inquiry/routers/submit.js
@@ -13,6 +13,8 @@ module.exports = ({ queryFragment, notification, confirmation }) => asyncRoute(a
     sendFrom: from,
     sendTo: to,
     directSend,
+    notificationSubject,
+    confirmationSubject,
   } = site.getAsObject('inquiry');
   const $global = buildMarkoGlobal(res);
   const { apollo, body: payload } = req;
@@ -38,6 +40,7 @@ module.exports = ({ queryFragment, notification, confirmation }) => asyncRoute(a
       template: notification,
       $global,
       content,
+      subject: notificationSubject,
       payload,
       addresses,
     })),
@@ -46,6 +49,7 @@ module.exports = ({ queryFragment, notification, confirmation }) => asyncRoute(a
       template: confirmation,
       $global,
       content,
+      subject: confirmationSubject,
       email: req.body.confirmationEmail,
       from,
       bcc,

--- a/packages/marko-web-inquiry/template-builders/confirmation-builder.js
+++ b/packages/marko-web-inquiry/template-builders/confirmation-builder.js
@@ -14,6 +14,7 @@ module.exports = ({
   template,
   $global,
   content,
+  subject = 'Your inquiry was received.',
   email,
   bcc,
   from,
@@ -23,7 +24,6 @@ module.exports = ({
     from,
     bcc,
   };
-  const subject = 'Your inquiry was received.';
   const input = {
     $global,
     content,

--- a/packages/marko-web-inquiry/template-builders/notification-builder.js
+++ b/packages/marko-web-inquiry/template-builders/notification-builder.js
@@ -15,10 +15,10 @@ module.exports = ({
   template,
   $global,
   content,
+  subject = 'A new inquiry submission was received.',
   payload,
   addresses,
 }) => {
-  const subject = 'A new inquiry submission was received.';
   const input = {
     $global,
     content,


### PR DESCRIPTION
Inquiry submission and confirmation email subject lines can now be customized. 

To use within an implementing website, add the following to the `inquiry` site config:

```js
module.exports = {
  // other config options
  inquiry: {
    notificationSubject: 'Your notification subject line',
    confirmationSubject: 'Your confirmation subject line',
  },
};
```