### PR TITLE
Add support for lazy loading

### DIFF
--- a/packages/marko-web-gam/components/enable.marko
+++ b/packages/marko-web-gam/components/enable.marko
@@ -1,5 +1,6 @@
 import { getAsObject } from "@base-cms/object-path";
 import buildTargeting from "../utils/build-targeting";
+import buildLazyLoad from "../utils/build-lazy-load";
 
 $ const { req } = out.global;
 
@@ -14,6 +15,10 @@ $ const options = {
 $ const calls = [];
 $ if (options.enableSingleRequest) calls.push("googletag.pubads().enableSingleRequest();");
 $ if (options.collapseEmptyDivs) calls.push("googletag.pubads().collapseEmptyDivs();");
+
+<!-- Lazy loading -->
+$ const lazyload = buildLazyLoad(getAsObject(input, "lazyLoad"));
+$ if (lazyload) calls.push(lazyload);
 
 <!-- Build global targeting calls -->
 $ const keyValues = getAsObject(input, "keyValues");

--- a/packages/marko-web-gam/components/marko.json
+++ b/packages/marko-web-gam/components/marko.json
@@ -19,6 +19,12 @@
   },
   "<marko-web-gam-enable>": {
     "template": "./enable.marko",
+    "<lazy-load>": {
+      "@enabled": "boolean",
+      "@fetch-margin-percent": "number",
+      "@render-margin-percent": "number",
+      "@mobile-scaling": "number"
+    },
     "@options": "object",
     "@key-values": "object",
     "@include-path": {

--- a/packages/marko-web-gam/utils/build-lazy-load.js
+++ b/packages/marko-web-gam/utils/build-lazy-load.js
@@ -1,0 +1,15 @@
+/**
+ * @see https://developers.google.com/doubleclick-gpt/samples/lazy-loading
+ * @see https://developers.google.com/doubleclick-gpt/reference#googletag.PubAdsService_enableLazyLoad
+ */
+module.exports = ({
+  enabled = false,
+  fetchMarginPercent = 0,
+  renderMarginPercent = 0,
+  mobileScaling = 1,
+} = {}) => {
+  if (!enabled) return '';
+  const opts = { fetchMarginPercent, renderMarginPercent, mobileScaling };
+  const optStr = Object.keys(opts).map(prop => `${prop}: ${opts[prop]}`).join(', ');
+  return `googletag.pubads().enableLazyLoad({ ${optStr} });`;
+};


### PR DESCRIPTION
Lazy loading is disabled by default and can be enabled/configured as follows:

```marko
<marko-web-gam-enable>
  <!-- other props here -->
  <@lazy-load enabled=true fetch-margin-percent=100 render-margin-percent=50 mobile-scaling=2 />
</marko-web-gam-enable>
```

The `fetch-margin-percent` and `render-margin-percent` determine when an ad should be fetched and rendered (respectively). See the following for more info:

https://developers.google.com/doubleclick-gpt/samples/lazy-loading
https://developers.google.com/doubleclick-gpt/reference#googletag.PubAdsService_enableLazyLoad