### PR TITLE
Add `withSite` and `siteId` support to `all-company-content` query

### DIFF
--- a/packages/web-common/src/block-loaders/all-company-content.js
+++ b/packages/web-common/src/block-loaders/all-company-content.js
@@ -10,6 +10,8 @@ const date = v => (v instanceof Date ? v.valueOf() : v);
  * @param {number} params.companyId The company (content) ID.
  * @param {string[]} [params.includeContentTypes] An array of content types to include.
  * @param {boolean} [params.requiresImage] Whether the content must have an image.
+ * @param {boolean} [params.withSite] Whether to limit results to the current site context
+ * @param {string} [params.siteId] A website site identifier to limit results by primarySite
  * @param {string} [params.sortField] The field to use for sorting results
  * @param {string} [params.sortOrder] The direction to sort results
  * @param {number} [params.limit] The number of results to return.
@@ -32,6 +34,8 @@ module.exports = async (apolloClient, {
   includeContentTypes,
   excludeContentTypes,
   requiresImage,
+  withSite,
+  siteId,
 
   queryFragment,
   queryName,
@@ -43,6 +47,8 @@ module.exports = async (apolloClient, {
     excludeContentTypes,
     pagination,
     requiresImage,
+    withSite,
+    siteId,
     since: date(since),
   };
   if (field || order) input.sort = { field, order };

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -321,6 +321,7 @@ input AllCompanyContentQueryInput {
   requiresImage: Boolean = false
   sort: ContentSortInput = { field: published, order: desc }
   pagination: PaginationInput = {}
+  withSite: Boolean = true
 }
 
 input ContentBeginningInput {

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -816,6 +816,7 @@ module.exports = {
         requiresImage,
         sort,
         pagination,
+        withSite,
       } = input;
 
       const query = getPublishedCriteria({
@@ -824,7 +825,7 @@ module.exports = {
         excludeContentTypes,
       });
       const siteId = input.siteId || site.id();
-      if (siteId) query['mutations.Website.primarySite'] = siteId;
+      if (withSite && siteId) query['mutations.Website.primarySite'] = siteId;
 
       query.$or = [
         { company: companyId },


### PR DESCRIPTION
Allows company query to control site context by either limiting the query results to the current site context (withSite) or by specifing a particular primarySite (siteId).