### PR TITLE
Add isArray check for relatedSectionIds in query builder

### DIFF
--- a/services/graphql-server/src/graphql/query-builders/website-sections.js
+++ b/services/graphql-server/src/graphql/query-builders/website-sections.js
@@ -1,3 +1,5 @@
+const { isArray } = Array;
+
 module.exports = ({ query }, { input }) => {
   const q = { ...query };
 
@@ -13,7 +15,9 @@ module.exports = ({ query }, { input }) => {
 
   if (rootOnly) q['parent.$id'] = { $exists: false };
   if (taxonomyIds.length) q['relatedTaxonomy.$id'] = { $in: taxonomyIds };
-  if (relatedSectionIds.length) q.relatedSections = { $in: relatedSectionIds };
+  if (isArray(relatedSectionIds) && relatedSectionIds.length) {
+    q.relatedSections = { $in: relatedSectionIds };
+  }
   if (includeIds.length || excludeIds.length) {
     q._id = {
       ...(includeIds.length && { $in: includeIds }),


### PR DESCRIPTION
Resolves issue introduced in https://github.com/base-cms/base-cms/commit/9bf5b82f2478a9d4954b75ed6213726ae01f631c which allowed querying for website sections by the `relatedSections` field. This was added to the root query builder but assumed that the input would always be the same when invoked either from `WebsiteSectionsQueryInput` or `WebsiteSiteSectionsInput`, which obviously wasn't the case.