### PR TITLE
Add native Imgix cropping support to image assets

### DIFF
--- a/packages/image/src/build-imgix-url.js
+++ b/packages/image/src/build-imgix-url.js
@@ -54,6 +54,7 @@ const params = [
   'bg', // Background Color
   'fill-color', // Fill Color
   'fill-mode', // Fill Mode
+  'fill', // Fill
 
   // Focal Point Crop
   'fp-debug', // Focal Point Debug

--- a/packages/image/src/crop-rectangle.js
+++ b/packages/image/src/crop-rectangle.js
@@ -24,6 +24,13 @@ class CropRectangle {
   }
 }
 
+/**
+ * Generates a crop rectangle for the given image width, height
+ * and crop dimensions.
+ *
+ * Uses the same scaling logic as Base Platform to properly calculate
+ * the crop area.
+ */
 module.exports = ({ width, height, cropDimensions }) => {
   if (!cropDimensions) {
     return new CropRectangle({

--- a/packages/image/src/crop-rectangle.js
+++ b/packages/image/src/crop-rectangle.js
@@ -1,0 +1,54 @@
+class CropRectangle {
+  constructor({
+    x,
+    y,
+    width,
+    height,
+  } = {}) {
+    this.x = x;
+    this.y = y;
+    this.width = width;
+    this.height = height;
+  }
+
+  isCropped() {
+    return !this.notCropped();
+  }
+
+  notCropped() {
+    return this.x === 0 && this.y === 0;
+  }
+
+  toString() {
+    return ['x', 'y', 'width', 'height'].map(key => this[key]).join(',');
+  }
+}
+
+module.exports = ({ width, height, cropDimensions }) => {
+  if (!cropDimensions) {
+    return new CropRectangle({
+      x: 0,
+      y: 0,
+      width,
+      height,
+    });
+  }
+  // @see Cygnus\ApplicationBundle\Apps\Management\Controller::cropImageAction
+  const scale = width / 640;
+  const {
+    x1,
+    x2,
+    y1,
+    y2,
+  } = ['x1', 'x2', 'y1', 'y2'].reduce((o, key) => {
+    const v = Math.round(cropDimensions[key] * scale);
+    return { ...o, [key]: v };
+  }, {});
+
+  return new CropRectangle({
+    x: x1,
+    y: y1,
+    width: x2 - x1,
+    height: y2 - y1,
+  });
+};

--- a/packages/image/src/index.js
+++ b/packages/image/src/index.js
@@ -2,10 +2,12 @@ const buildImgixUrl = require('./build-imgix-url');
 const createAltFor = require('./create-alt-for');
 const createCaptionFor = require('./create-caption-for');
 const createSrcFor = require('./create-src-for');
+const cropRectangle = require('./crop-rectangle');
 
 module.exports = {
   buildImgixUrl,
   createAltFor,
   createCaptionFor,
   createSrcFor,
+  cropRectangle,
 };

--- a/services/graphql-server/package.json
+++ b/services/graphql-server/package.json
@@ -46,6 +46,7 @@
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.26",
     "newrelic": "^5.11.0",
+    "node-fetch": "^2.6.0",
     "object-hash": "^1.3.1",
     "sift": "^7.0.1",
     "uuid": "^3.3.3"

--- a/services/graphql-server/src/graphql/definitions/platform/asset.js
+++ b/services/graphql-server/src/graphql/definitions/platform/asset.js
@@ -11,6 +11,13 @@ extend type Mutation {
   createAssetImageFromUrl(input: CreateAssetImageFromUrlMutationInput!): AssetImage! @requiresAuth
 }
 
+enum AssetImageDisplay {
+  left
+  right
+  center
+  none
+}
+
 type AssetImage {
   # from platform.model::Asset
   id: ObjectID! @projection(localField: "_id") @value(localField: "_id")
@@ -27,6 +34,8 @@ type AssetImage {
   cropDimensions: AssetImageCrop @projection
   isLogo: Boolean @projection
   body: String @projection
+
+  primaryImageDisplay: AssetImageDisplay! @projection
 
   # from platform.model::Asset\Image mutations
   approvedWebsite: Boolean @projection(localField: "mutations.Website.approved") @value(localField: "mutations.Website.approved")

--- a/services/graphql-server/src/graphql/definitions/platform/asset.js
+++ b/services/graphql-server/src/graphql/definitions/platform/asset.js
@@ -33,8 +33,9 @@ type AssetImage {
   approvedMagazine: Boolean @projection(localField: "mutations.Magazine.approved") @value(localField: "mutations.Magazine.approved")
 
   # GraphQL specific fields
-  src(input: AssetImageSrcInput = {}): String! @projection(localField: "fileName", needs: ["filePath", "cropDimensions", "isLogo"])
+  src(input: AssetImageSrcInput = {}): String! @projection(localField: "fileName", needs: ["filePath", "cropDimensions", "isLogo", "source.width", "source.height"])
   alt: String! @projection(localField: "name", needs: ["caption", "fileName"])
+  cropRectangle: AssetImageCropRectangle! @projection(localField: "cropDimensions", needs: ["source.width", "source.height", "fileName", "filePath"])
 }
 
 type AssetImageConnection @projectUsing(type: "AssetImage") {
@@ -54,6 +55,13 @@ type AssetImageSource {
   width: Int
   height: Int
   processed: Boolean
+}
+
+type AssetImageCropRectangle {
+  x: Int!
+  y: Int!
+  width: Int!
+  height: Int!
 }
 
 type AssetImageCrop {
@@ -99,6 +107,7 @@ input AssetImageSortInput {
 
 input AssetImageSrcInput {
   options: JSON
+  useCropRectangle: Boolean = false
 }
 
 `;

--- a/services/graphql-server/src/graphql/resolvers/platform/asset.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/asset.js
@@ -38,6 +38,7 @@ module.exports = {
       const { cropDimensions } = image;
       return cropRectangle({ width, height, cropDimensions });
     },
+    primaryImageDisplay: image => image.primaryImageDisplay || 'center',
   },
 
   /**

--- a/services/graphql-server/src/graphql/resolvers/platform/asset.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/asset.js
@@ -19,7 +19,11 @@ module.exports = {
     src: async (image, { input = {} }, { site, basedb }) => {
       // Use site image host otherwise fallback to global default.
       const host = site.get('imageHost', defaults.imageHost);
+
+      // when not using a crop rectangle, return the image src the same way as before
       if (!input.useCropRectangle) return createSrcFor(host, image, input.options, { w: 320, auto: 'format' });
+
+      // otherwise, process the image width/height and create the crop rectangle
       const { width, height } = await getImageDimensions({ image, host, basedb });
       const rect = cropRectangle({
         width,
@@ -27,6 +31,8 @@ module.exports = {
         cropDimensions: image.cropDimensions,
       });
       const { fileName, filePath } = image;
+
+      // when a crop is detected, set the `rect` imgix property
       const opts = rect.isCropped() ? { ...input.options, rect } : input.options;
       return createSrcFor(host, { fileName, filePath }, opts, {});
     },

--- a/services/graphql-server/src/graphql/utils/get-image-dimensions.js
+++ b/services/graphql-server/src/graphql/utils/get-image-dimensions.js
@@ -1,0 +1,25 @@
+const fetch = require('node-fetch');
+
+/**
+ * Retrieves width/height information from Imgix and sets to
+ * the Asset/Image model. Will only do this when the width or height
+ * are missing from the model.
+ */
+module.exports = async ({
+  image,
+  host,
+  basedb,
+}) => {
+  const { source, filePath, fileName } = image;
+  if (source && source.width && source.height) {
+    return { width: source.width, height: source.height };
+  }
+
+  const url = `https://${host}/${filePath}/${fileName}?fm=json`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(res.statusText);
+  const { PixelWidth: width, PixelHeight: height } = await res.json();
+  const $set = { 'source.width': width, 'source.height': height };
+  await basedb.updateOne('platform.Asset', { _id: image._id }, { $set });
+  return { width, height };
+};


### PR DESCRIPTION
Allows image `src` values to (optionally) use image crop dimensions to generate a "pre-cropped" version using the Imgix `rect` parameter. This allows for images to exclusively use Imgix as opposed to using the pre-generated cropped versions from Base.

**This feature is off by default and will not affect any implementing websites.** To opt-in to this feature, set the `useCropRectangle` input value for the `ImageAsset.src` to `true`.

The crop dimensions are calculated in the same manner as Base Platform.

Because the crop rectangle requires the source image width and height, if those values are missing the resolver will load the width and height using Imgix's `fm=json` data API.