### PR TITLE
Filter sensitive info from logged MongoDB urls

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -504,6 +504,8 @@ services:
       AERILON_DSN: ${AERILON_DSN-mongodb://mongodb:27017}
       PICON_DSN: ${PICON_DSN-mongodb://mongodb:27017}
       GEMENON_DSN: ${GEMENON_DSN-mongodb://mongodb:27017}
+      LEONIS_DSN: ${LEONIS_DSN-mongodb://mongodb:27017}
+      TAURON_DSN: ${TAURON_DSN-mongodb://mongodb:27017}
       ENABLE_BASEDB_LOGGING: ${ENABLE_BASEDB_LOGGING-false}
     depends_on:
       - mongodb

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@base-cms/async": "^1.0.0",
+    "@base-cms/object-path": "^1.0.0",
     "@base-cms/utils": "^1.25.0",
     "base64-url": "^2.3.2",
     "deepmerge": "^3.3.0",

--- a/packages/db/src/utils/filter-dsn.js
+++ b/packages/db/src/utils/filter-dsn.js
@@ -1,0 +1,16 @@
+/**
+ * Filters sensitive information (such as passwords) out of a MongoDB connection URI
+ *
+ * @param {Connection} connection The MongoDB connection object.
+ * @return {string} The filtered MongoDB connection URI.
+ */
+const { get } = require('@base-cms/object-path');
+
+const filter = (connection) => {
+  const url = get(connection, 's.url');
+  const pwd = get(connection, 's.options.password');
+  if (pwd) return `${url}`.replace(pwd, '*****');
+  return url;
+};
+
+module.exports = filter;

--- a/packages/db/src/utils/filter-dsn.js
+++ b/packages/db/src/utils/filter-dsn.js
@@ -9,7 +9,8 @@ const { get } = require('@base-cms/object-path');
 const filter = (connection) => {
   const url = get(connection, 's.url');
   const pwd = get(connection, 's.options.password');
-  if (pwd) return `${url}`.replace(pwd, '*****');
+  const usr = get(connection, 's.options.user');
+  if (pwd || usr) return `${url}`.replace(usr, '*****').replace(pwd, '*****');
   return url;
 };
 

--- a/packages/db/src/utils/index.js
+++ b/packages/db/src/utils/index.js
@@ -1,3 +1,4 @@
+const filterDsn = require('./filter-dsn');
 const iterateCursor = require('./iterate-cursor');
 
-module.exports = { iterateCursor };
+module.exports = { filterDsn, iterateCursor };

--- a/services/google-data-api/package.json
+++ b/services/google-data-api/package.json
@@ -12,6 +12,7 @@
     "test": "yarn lint"
   },
   "dependencies": {
+    "@base-cms/db": "^1.0.0",
     "@base-cms/env": "^1.0.0",
     "@base-cms/micro": "^1.25.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/services/google-data-api/src/mongodb.js
+++ b/services/google-data-api/src/mongodb.js
@@ -1,3 +1,4 @@
+const { filterDsn } = require('@base-cms/db/utils');
 const mongodb = require('mongodb');
 
 const { GOOGLE_DATA_MONGO_DSN } = require('./env');
@@ -9,7 +10,8 @@ let connection;
 const connect = async () => {
   if (!connection) {
     connection = await mongodb.connect(GOOGLE_DATA_MONGO_DSN, { useNewUrlParser: true });
-    log(`> MongoDB connected (${GOOGLE_DATA_MONGO_DSN})`);
+    const url = filterDsn(connection);
+    log(`> MongoDB connected (${url})`);
   }
   return connection;
 };

--- a/services/graphql-server/src/services.js
+++ b/services/graphql-server/src/services.js
@@ -1,3 +1,4 @@
+const { filterDsn } = require('@base-cms/db/utils');
 const basedb = require('./basedb')('test');
 const { log } = require('./output');
 const pkg = require('../package.json');
@@ -25,7 +26,7 @@ const ping = (name, promise) => promise.then(() => `${name} pinged successfully.
 
 module.exports = {
   start: () => Promise.all([
-    start('BaseDB', basedb.client.connect(), c => c.s.url),
+    start('BaseDB', basedb.client.connect(), filterDsn),
   ]),
   stop: () => Promise.all([
     stop('BaseDB', basedb.client.close()),

--- a/services/hooks/src/services.js
+++ b/services/hooks/src/services.js
@@ -1,3 +1,4 @@
+const { filterDsn } = require('@base-cms/db/utils');
 const {
   aerilon,
   caprica,
@@ -29,12 +30,12 @@ const ping = (name, promise) => promise.then(() => `${name} pinged successfully.
 
 module.exports = {
   start: () => Promise.all([
-    start('BaseDB Aerilon', aerilon.client.connect(), c => c.s.url),
-    start('BaseDB Caprica', caprica.client.connect(), c => c.s.url),
-    start('BaseDB Picon', picon.client.connect(), c => c.s.url),
-    start('BaseDB Gemenon', gemenon.client.connect(), c => c.s.url),
-    start('BaseDB Leonis', leonis.client.connect(), c => c.s.url),
-    start('BaseDB Tauron', tauron.client.connect(), c => c.s.url),
+    start('BaseDB Aerilon', aerilon.client.connect(), filterDsn),
+    start('BaseDB Caprica', caprica.client.connect(), filterDsn),
+    start('BaseDB Picon', picon.client.connect(), filterDsn),
+    start('BaseDB Gemenon', gemenon.client.connect(), filterDsn),
+    start('BaseDB Leonis', leonis.client.connect(), filterDsn),
+    start('BaseDB Tauron', tauron.client.connect(), filterDsn),
   ]),
   stop: () => Promise.all([
     stop('BaseDB Aerilon', aerilon.client.close()),


### PR DESCRIPTION
This PR adds & implements a utility that filters the connection password from the MongoDB URI, preventing the raw password from being stored unencrypted in container logs.