### PR TITLE
Use Yargs default option

### DIFF
--- a/packages/dependency-tool/bin/cli.js
+++ b/packages/dependency-tool/bin/cli.js
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-
-require('../src')();

--- a/packages/dependency-tool/package.json
+++ b/packages/dependency-tool/package.json
@@ -5,7 +5,7 @@
   "author": "Jacob Bare <jacob@limit0.io>",
   "main": "src/index.js",
   "bin": {
-    "basecms-dependencies": "bin/cli.js"
+    "basecms-dependencies": "src/index.js"
   },
   "license": "MIT",
   "repository": "https://github.com/base-cms/base-cms/tree/master/packages/dependency-tool",

--- a/packages/dependency-tool/src/commands/index.js
+++ b/packages/dependency-tool/src/commands/index.js
@@ -13,5 +13,5 @@ const upgradeOptions = yargs => yargs
  */
 module.exports = (program) => {
   program
-    .command('upgrade [path]', 'Upgrade @base-cms dependencies in the specified folder/project', upgradeOptions, argv => require('./upgrade')(argv));
+    .command(['upgrade [path]', '$0'], 'Upgrade @base-cms dependencies in the specified folder/project', upgradeOptions, argv => require('./upgrade')(argv));
 };

--- a/packages/dependency-tool/src/index.js
+++ b/packages/dependency-tool/src/index.js
@@ -1,15 +1,11 @@
-const program = require('yargs');
+#!/usr/bin/env node
+
+const yargs = require('yargs');
 const log = require('fancy-log');
 const commands = require('./commands');
 
+log('Dependency tool starting...');
 process.on('unhandledRejection', (e) => { throw e; });
 
-log('Dependency tool starting...');
-program
-  .usage('Usage: $0 <command> [options]')
-  .help()
-  .demandCommand();
-
-commands(program);
-
-module.exports = () => program.argv;
+commands(yargs);
+yargs.demandCommand().help().parse();


### PR DESCRIPTION
Update dependency tool implementation to use the Yargs default option, so `basecms-dependencies` (with no arguments) works in addition to `basecms-dependencies upgrade`

Additionally, add better error messaging when a user tries to run `basecms-dependencies update` by accident ;)