### PR TITLE
Correct spacing in name/title on leaders callout

### DIFF
--- a/packages/leaders-program/src/components/card/blocks/key-executive.vue
+++ b/packages/leaders-program/src/components/card/blocks/key-executive.vue
@@ -4,9 +4,12 @@
       <img :src="imageSrc" :alt="imageAlt">
     </div>
     <div class="leaders-key-executive__details">
-      <span class="leaders-key-executive__name">
+      <span v-if="title" class="leaders-key-executive__name">
+        {{ name }},
+        <span class="leaders-key-executive__title">{{ title }}</span>
+      </span>
+      <span v-else class="leaders-key-executive__name">
         {{ name }}
-        <span v-if="title" class="leaders-key-executive__title">{{ title }}</span>
       </span>
     </div>
   </div>

--- a/packages/leaders-program/src/scss/components/_key-executive.scss
+++ b/packages/leaders-program/src/scss/components/_key-executive.scss
@@ -18,9 +18,4 @@
     font-weight: $leaders-key-executive-font-weight;
   }
 
-  &__title {
-    &::before {
-      content: ", ";
-    }
-  }
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/174074761

Issue: There is a spacing after the name before the comma
Code changes "Robert Lee , Product Marketing & Strategy" --> "Robert Lee, Product Marketing & Strategy"

Current:
![Screen Shot 2020-08-03 at 3 49 35 PM](https://user-images.githubusercontent.com/6343242/89221245-f4fe1f80-d5a0-11ea-8816-100cbb8b63b4.png)


New w/ Title:
![Screen Shot 2020-08-03 at 3 45 33 PM](https://user-images.githubusercontent.com/6343242/89221199-df88f580-d5a0-11ea-862c-89b69555d7d2.png)


w/o Title (stays the same):
![Screen Shot 2020-08-03 at 3 46 17 PM](https://user-images.githubusercontent.com/6343242/89221186-dbf56e80-d5a0-11ea-8354-4bcd0aa6941b.png)
