### PR TITLE
Add support for external links on all content

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -245,6 +245,10 @@ input ContentQueryInput {
   since: Date
 }
 
+input ContentExternalLinksInput {
+  keys: [String]
+}
+
 input ContentAliasQueryInput {
   siteId: ObjectID
   status: ModelStatus = active

--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
@@ -24,6 +24,9 @@ interface Content @requiresProject(fields: ["type"]) {
   company(input: ContentCompanyInput = {}): ContentCompany @projection @refOne(loader: "platformContent", criteria: "contentCompany")
   gating: ContentGating @projection(localField: "mutations.Website.gating") @value(localField: "mutations.Website.gating")
 
+  # This field name conflicts with ContentCompany.externalLinks, which has been deprecated. When a major version is released with BC breaks, rename this field.
+  externalUrls(input: ContentExternalLinksInput = {}): [EntityStubExternalLink]! @projection(localField: "externalLinks")
+
   # fields from platform.trait::StatusEnabled
   status: Int @projection
 

--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
@@ -23,9 +23,7 @@ interface Content @requiresProject(fields: ["type"]) {
   deck: String @projection(localField: "mutations.Magazine.deck") @value(localField: "mutations.Magazine.deck")
   company(input: ContentCompanyInput = {}): ContentCompany @projection @refOne(loader: "platformContent", criteria: "contentCompany")
   gating: ContentGating @projection(localField: "mutations.Website.gating") @value(localField: "mutations.Website.gating")
-
-  # This field name conflicts with ContentCompany.externalLinks, which has been deprecated. When a major version is released with BC breaks, rename this field.
-  externalUrls(input: ContentExternalLinksInput = {}): [EntityStubExternalLink]! @projection(localField: "externalLinks")
+  externalLinks(input: ContentExternalLinksInput = {}): [EntityStubExternalLink]! @projection
 
   # fields from platform.trait::StatusEnabled
   status: Int @projection

--- a/services/graphql-server/src/graphql/definitions/platform/content/types/company.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/types/company.js
@@ -35,7 +35,7 @@ type ContentCompany implements Content & PrimaryCategory & Contactable & Address
 
   youtube: ContentCompanyYoutube! @projection
   youtubeVideos(input: ContentCompanyYoutubeVideosInput = {}): YoutubePlaylistConnection! @projection(needs: ["youtube"])
-  externalLinks(input: ContentCompanyExternalLinksInput = {}): [EntityStubExternalLink]! @projection
+  externalLinks(input: ContentCompanyExternalLinksInput = {}): [EntityStubExternalLink]! @projection @deprecated(reason: "Use \`content.externalLinks\` instead.")
 
   # fields directly on platform.model::Content\Company from mutations
   featuredCategories(input: ContentCompanyFeaturedCategoriesInput = {}): TaxonomyConnection! @projection(localField: "mutations.Website.featuredCategories") @refMany(model: "platform.Taxonomy", localField: "mutations.Website.featuredCategories", criteria: "taxonomyCategory")
@@ -179,6 +179,7 @@ input ContentCompanyYoutubeVideosInput {
 }
 
 input ContentCompanyExternalLinksInput {
+  # @deprecated. Use \`ContentExternalLinksInput\` instead.
   keys: [String]
 }
 

--- a/services/graphql-server/src/graphql/definitions/platform/content/types/company.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/types/company.js
@@ -35,7 +35,6 @@ type ContentCompany implements Content & PrimaryCategory & Contactable & Address
 
   youtube: ContentCompanyYoutube! @projection
   youtubeVideos(input: ContentCompanyYoutubeVideosInput = {}): YoutubePlaylistConnection! @projection(needs: ["youtube"])
-  externalLinks(input: ContentCompanyExternalLinksInput = {}): [EntityStubExternalLink]! @projection @deprecated(reason: "Use \`content.externalLinks\` instead.")
 
   # fields directly on platform.model::Content\Company from mutations
   featuredCategories(input: ContentCompanyFeaturedCategoriesInput = {}): TaxonomyConnection! @projection(localField: "mutations.Website.featuredCategories") @refMany(model: "platform.Taxonomy", localField: "mutations.Website.featuredCategories", criteria: "taxonomyCategory")
@@ -176,11 +175,6 @@ input ContentCompanySortInput {
 
 input ContentCompanyYoutubeVideosInput {
   pagination: PaginationInput = {}
-}
-
-input ContentCompanyExternalLinksInput {
-  # @deprecated. Use \`ContentExternalLinksInput\` instead.
-  keys: [String]
 }
 
 input UpdateContentCompanyPublicContactsMutationInput {

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -138,20 +138,6 @@ const loadSitemapImages = ({ content, basedb }) => {
   return basedb.find('platform.Asset', query, { projection });
 };
 
-/**
- * This resolver provides reusable logic for filtering and returning external links.
- * The original `ContentCompany.externalLinks` field contains conflicting input types, which
- * without input polymorphism, cannot be resolved without creating a new field.
- * When a major version is released and BC breaking changes are introduced, the externalLinks
- * field and input types should be used in favor of the deprecated ContentCompany versions.
- */
-const externalLinksResolver = (content, { input }) => {
-  const keys = getAsArray(input, 'keys');
-  const links = getAsArray(content, 'externalLinks');
-  if (keys.length) return links.filter(({ key }) => keys.includes(key));
-  return links;
-};
-
 module.exports = {
   /**
    *
@@ -237,7 +223,12 @@ module.exports = {
   Content: {
     __resolveType: resolveType,
 
-    externalUrls: externalLinksResolver,
+    externalLinks: (content, { input }) => {
+      const keys = getAsArray(input, 'keys');
+      const links = getAsArray(content, 'externalLinks');
+      if (keys.length) return links.filter(({ key }) => keys.includes(key));
+      return links;
+    },
 
     siteContext: async (content, _, ctx) => {
       const { site, load, basedb } = ctx;
@@ -548,10 +539,6 @@ module.exports = {
    *
    */
   ContentCompany: {
-    /**
-     * @deprecated use `Content.externalUrls` instead
-     */
-    externalLinks: externalLinksResolver,
     youtube: ({ youtube = {} }) => youtube,
     youtubeVideos: async (content, { input }, { basedb }) => {
       const maxResults = get(input, 'pagination.limit', 10);


### PR DESCRIPTION
Move `externalLinks` field from `ContentCompany` to `Content` to match BASE modeling change.

Equivalent queries:
```gql
# Write your query or mutation here
query CompanyById {
  content(input:{ id: 13320872}) {
    id
    name
    externalLinks(input: { keys: ["company-products"] }) {
      key
      label
      url
    }
    ... on ContentCompany {
      externalLinks(input: { keys: ["company-products"] }) {
        key
        label
        url
      }
    }
  }
}
```