### PR TITLE
Add `Content.customAttribute` field

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -338,6 +338,11 @@ input ContentEndingInput {
   after: Date
 }
 
+input ContentCustomAttributeInput {
+  "The custom attribute field path."
+  path: String!
+}
+
 input AllContentQueryInput {
   siteId: ObjectID
   status: ModelStatus = active

--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
@@ -81,6 +81,9 @@ interface Content @requiresProject(fields: ["type"]) {
   websiteSchedules: [ContentWebsiteSchedule]! @projection(localField: "sectionQuery") @arrayValue(localField: "sectionQuery")
 
   hasWebsiteSchedule(input: ContentHasWebsiteScheduleInput!): Boolean! @projection(localField: "sectionQuery")
+
+  # Allows custom field values to be returned from the \`customAttributes\` model field. Currently all values are cast as strings.
+  customAttribute(input: ContentCustomAttributeInput!): String @projection(localField: "customAttributes")
 }
 
 `;

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -406,6 +406,14 @@ module.exports = {
 
     metadata: content => content,
 
+    customAttribute: (content, { input }) => {
+      const { path } = input;
+      if (!path) return null;
+      const value = get(content, `customAttributes.${path}`);
+      if (!value) return null;
+      return `${value}`;
+    },
+
     /**
      * @deprecated use `siteContext.url` instead
      */


### PR DESCRIPTION
Add support for retrieving custom data from content models. Given the following database record:

```json
{
  "_id": 13081488,
  "name": "Some content name",
  "type": "Article",
  "customAttributes": {
    "someFieldA": "foo",
    "anotherFieldB": "bar",
    "deep": {
      "field": "baz"
    }
  }
}
```

The following GraphQL query could be executed: 
```graphql
query {
  content(input: { id: 13081488 }) {
    name
    aliasA: customAttribute(input: { path: "someFieldA" })
    aliasB: customAttribute(input: { path: "deep.field" })
  }
}
```

Which would return the following result:
```json
{
  "data": {
    "content": {
      "name": "Some content name",
      "aliasA": "foo",
      "aliasB": "baz" 
    }
  }
}
```