### PR TITLE
Algolia Set unpublished date 100 years in future

### DIFF
--- a/services/algolia-sync/src/components/algolia/helpers.js
+++ b/services/algolia-sync/src/components/algolia/helpers.js
@@ -26,8 +26,8 @@ const boostResult = (node) => {
 const buildObj = (nodes, tenant) => nodes.map((node) => {
   const content = node;
   // Set unpublished date 100 years into the future.
-  if (content.unpublishedDate === null) {
-    content.unpublishedDate = 4753607469000;
+  if (content.unpublished) {
+    content.unpublished = 4753607469000;
   }
   return {
     action: 'updateObject',

--- a/services/algolia-sync/src/components/algolia/helpers.js
+++ b/services/algolia-sync/src/components/algolia/helpers.js
@@ -26,7 +26,7 @@ const boostResult = (node) => {
 const buildObj = (nodes, tenant) => nodes.map((node) => {
   const content = node;
   // Set unpublished date 100 years into the future.
-  if (content.unpublished) {
+  if (!content.unpublished) {
     content.unpublished = 4753607469000;
   }
   return {

--- a/services/algolia-sync/src/components/algolia/helpers.js
+++ b/services/algolia-sync/src/components/algolia/helpers.js
@@ -23,16 +23,23 @@ const boostResult = (node) => {
 };
 
 // Formats the object for Algolia's bulk update
-const buildObj = (nodes, tenant) => nodes.map(node => ({
-  action: 'updateObject',
-  indexName: tenant,
-  body: {
-    objectID: node.id,
-    sections: buildSections(node),
-    ...node,
-    boost: boostResult(node),
-  },
-}));
+const buildObj = (nodes, tenant) => nodes.map((node) => {
+  const content = node;
+  // Set unpublished date 100 years into the future.
+  if (content.unpublishedDate === null) {
+    content.unpublishedDate = 4753607469000;
+  }
+  return {
+    action: 'updateObject',
+    indexName: tenant,
+    body: {
+      objectID: content.id,
+      sections: buildSections(content),
+      ...content,
+      boost: boostResult(content),
+    },
+  };
+});
 
 module.exports = {
   buildObj,

--- a/services/algolia-sync/src/components/algolia/message-sync.js
+++ b/services/algolia-sync/src/components/algolia/message-sync.js
@@ -15,6 +15,7 @@ const query = message => (gql`
         type
         created
         published
+        unpublishedDate
         updated
         status
         websiteSchedules { section { hierarchy {fullName} }}
@@ -36,6 +37,11 @@ const upsertToIndex = async (message) => {
     }
 
     c.boost = boostResult(c);
+
+    // Set unpublished date to 100 years in the future if it's null
+    if (c.unpublishedDate === null) {
+      c.unpublishedDate = 4753607469000;
+    }
 
     const index = client.initIndex(message.tenant);
     await index.saveObject({

--- a/services/algolia-sync/src/components/algolia/message-sync.js
+++ b/services/algolia-sync/src/components/algolia/message-sync.js
@@ -39,7 +39,7 @@ const upsertToIndex = async (message) => {
     c.boost = boostResult(c);
 
     // Set unpublished date to 100 years in the future if it's null
-    if (c.unpublished) {
+    if (!c.unpublished) {
       c.unpublished = 4753607469000;
     }
 

--- a/services/algolia-sync/src/components/algolia/message-sync.js
+++ b/services/algolia-sync/src/components/algolia/message-sync.js
@@ -15,7 +15,7 @@ const query = message => (gql`
         type
         created
         published
-        unpublishedDate
+        unpublished
         updated
         status
         websiteSchedules { section { hierarchy {fullName} }}
@@ -39,8 +39,8 @@ const upsertToIndex = async (message) => {
     c.boost = boostResult(c);
 
     // Set unpublished date to 100 years in the future if it's null
-    if (c.unpublishedDate === null) {
-      c.unpublishedDate = 4753607469000;
+    if (c.unpublished) {
+      c.unpublished = 4753607469000;
     }
 
     const index = client.initIndex(message.tenant);

--- a/services/algolia-sync/src/components/algolia/site-sync.js
+++ b/services/algolia-sync/src/components/algolia/site-sync.js
@@ -21,6 +21,7 @@ const query = gql`
           type
           created
           published
+          unpublishedDate
           updated
           status
           websiteSchedules { section { hierarchy { fullName } }}

--- a/services/algolia-sync/src/components/algolia/site-sync.js
+++ b/services/algolia-sync/src/components/algolia/site-sync.js
@@ -21,7 +21,7 @@ const query = gql`
           type
           created
           published
-          unpublishedDate
+          unpublished
           updated
           status
           websiteSchedules { section { hierarchy { fullName } }}


### PR DESCRIPTION
Algolia's date range feature doesn't work with null. It needs to be a timestamp, so I update the code to set the expires date to 100 years in the future. 