### PR TITLE
Use root image width/height when calculating rectangle

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/asset.js
+++ b/services/graphql-server/src/graphql/definitions/platform/asset.js
@@ -42,9 +42,9 @@ type AssetImage {
   approvedMagazine: Boolean @projection(localField: "mutations.Magazine.approved") @value(localField: "mutations.Magazine.approved")
 
   # GraphQL specific fields
-  src(input: AssetImageSrcInput = {}): String! @projection(localField: "fileName", needs: ["filePath", "cropDimensions", "isLogo", "source.width", "source.height"])
+  src(input: AssetImageSrcInput = {}): String! @projection(localField: "fileName", needs: ["filePath", "cropDimensions", "isLogo", "width", "height"])
   alt: String! @projection(localField: "name", needs: ["caption", "fileName"])
-  cropRectangle: AssetImageCropRectangle! @projection(localField: "cropDimensions", needs: ["source.width", "source.height", "fileName", "filePath"])
+  cropRectangle: AssetImageCropRectangle! @projection(localField: "cropDimensions", needs: ["width", "height", "fileName", "filePath"])
 }
 
 type AssetImageConnection @projectUsing(type: "AssetImage") {

--- a/services/graphql-server/src/graphql/utils/get-image-dimensions.js
+++ b/services/graphql-server/src/graphql/utils/get-image-dimensions.js
@@ -10,16 +10,18 @@ module.exports = async ({
   host,
   basedb,
 }) => {
-  const { source, filePath, fileName } = image;
-  if (source && source.width && source.height) {
-    return { width: source.width, height: source.height };
-  }
-
+  const {
+    width,
+    height,
+    filePath,
+    fileName,
+  } = image;
+  if (width && height) return { width, height };
   const url = `https://${host}/${filePath}/${fileName}?fm=json`;
   const res = await fetch(url);
   if (!res.ok) throw new Error(res.statusText);
-  const { PixelWidth: width, PixelHeight: height } = await res.json();
-  const $set = { 'source.width': width, 'source.height': height };
+  const { PixelWidth, PixelHeight } = await res.json();
+  const $set = { width: PixelWidth, height: PixelHeight };
   await basedb.updateOne('platform.Asset', { _id: image._id }, { $set });
-  return { width, height };
+  return { width: PixelWidth, height: PixelHeight };
 };


### PR DESCRIPTION
Because Base sets a max-width of converted images to 1920 pixels, the crop rectangle must be calculated using the root/actual web dimensions, not the original source dimensions. This will not affect the `ImageAsset.src` field unless the `useCropRectangle` input is set to `true` (which it isn't by default)