### PR TITLE
Optionally disable `linkUrl` in `siteContext`; add custom redirectTo/path generators to `withContent`

### DIFF
--- a/packages/canonical-path/src/platform/content.js
+++ b/packages/canonical-path/src/platform/content.js
@@ -55,8 +55,14 @@ const handleDynamicPage = async (content, context) => {
   return `/page/${path}`;
 };
 
-
-module.exports = async (content, context) => {
+/**
+ *
+ * @param {object} content The content object
+ * @param {object} context The canonical path context (including rules, etc)
+ * @param {object} [options]
+ * @param {boolean} [options.enableLinkUrl=true] Whether to use the `linkUrl` field, if present.
+ */
+module.exports = async (content, context, { enableLinkUrl = true } = {}) => {
   const { canonicalRules } = context;
   const { content: contentRules } = canonicalRules;
   const { parts, prefix } = contentRules;
@@ -65,7 +71,7 @@ module.exports = async (content, context) => {
   if (type === 'Page') return handleDynamicPage(content, context);
 
   const types = ['Promotion', 'TextAd'];
-  if (types.includes(type) && linkUrl) return linkUrl;
+  if (enableLinkUrl && types.includes(type) && linkUrl) return linkUrl;
 
   const values = await Promise.all(parts.map((key) => {
     const fn = pathResolvers[key];

--- a/packages/marko-web/middleware/with-content.js
+++ b/packages/marko-web/middleware/with-content.js
@@ -11,14 +11,18 @@ module.exports = ({
   queryFragment,
   idResolver,
   redirectOnPathMismatch = true,
+  loaderQueryFragment,
+  redirectToFn,
+  pathFn,
 } = {}) => asyncRoute(async (req, res) => {
   const id = isFn(idResolver) ? await idResolver(req, res) : req.params.id;
   const { apollo, query } = req;
 
   const additionalInput = buildContentInput({ req });
-  const content = await loader(apollo, { id, additionalInput });
-  const { redirectTo } = content;
-  const path = get(content, 'siteContext.path');
+  const content = await loader(apollo, { id, additionalInput, queryFragment: loaderQueryFragment });
+  const redirectTo = isFn(redirectToFn) ? redirectToFn({ content }) : content.redirectTo;
+  const path = isFn(pathFn) ? pathFn({ content }) : get(content, 'siteContext.path');
+
   if (redirectTo) {
     return res.redirect(301, applyQueryParams({ path: redirectTo, query }));
   }

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -262,6 +262,11 @@ input ContentHashQueryInput {
   hash: String!
 }
 
+input ContentSiteContextInput {
+  "Determines whether to use the \`content.linkUrl\` field for generating paths and URLs. If \`false\`, the \`linkUrl\` will be ignored."
+  enableLinkUrl: Boolean = true
+}
+
 input ContentSitemapUrlsQueryInput {
   siteId: ObjectID
   since: Date

--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
@@ -70,7 +70,7 @@ interface Content @requiresProject(fields: ["type"]) {
   websiteUrl: String! @deprecated(reason: "Use \`siteContext.url\` instead.") @projection(localField: "_id", needs: ["type", "linkUrl", "mutations.Website.slug", "mutations.Website.primarySection", "mutations.Website.primaryCategory", "mutations.Website.alias"])
 
   # Fields that require site context
-  siteContext: ContentSiteContext! @projection(localField: "_id", needs: ["type", "linkUrl", "mutations.Website.slug", "mutations.Website.primarySection", "mutations.Website.primaryCategory", "mutations.Website.alias", "mutations.Website.canonicalUrl"])
+  siteContext(input: ContentSiteContextInput = {}): ContentSiteContext! @projection(localField: "_id", needs: ["type", "linkUrl", "mutations.Website.slug", "mutations.Website.primarySection", "mutations.Website.primaryCategory", "mutations.Website.alias", "mutations.Website.canonicalUrl"])
 
   # Determines if this content item should redirect to another location.
   redirectTo: String @projection(localField: "type", needs: ["linkUrl"])

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -230,10 +230,11 @@ module.exports = {
       return links;
     },
 
-    siteContext: async (content, _, ctx) => {
+    siteContext: async (content, { input }, ctx) => {
+      const { enableLinkUrl } = input;
       const { site, load, basedb } = ctx;
       if (!site.exists()) throw new UserInputError('A website context must be set to generate `Content.siteContext` fields.');
-      const path = await canonicalPathFor(content, ctx);
+      const path = await canonicalPathFor(content, ctx, { enableLinkUrl });
       return {
         path: () => path,
         url: () => {


### PR DESCRIPTION
## GraphQL Server
Add ability to ignore the external `content.linkUrl` when generating the `siteContext.path` and `siteContext.url`. By default, if an external `linkUrl` is present on `Promotion` or `TextAd` content types, this value is used to generate the URL used by the website. By setting `{ enableLinkUrl: false }` in the `ContentSiteContextInput`, the field will return the internal URL/path of the content. Because external URLs are enabled by default, this feature is opt-in and does _not_ cause any backward compatibility issues.

### Default Example
This query (which is the default behavior) will return the external URL.

```graphql
query {
  content(input: { id: 21114516 }) {
    id
    type
    siteContext {
      path
    }
  }
}
```
Response:
```json
{
  "data": {
    "content": {
      "id": 21114516,
      "type": "promotion",
      "siteContext": {
        "path": "https://storyscape.electronicdesign.com/texas-instruments-achieving-low-noise-and-low-emi-performance-with-power-switching-devices/"
      }
    }
  }
}
```

### Using `{ enableLinkUrl: false }`
When `siteContext(input: { enableLinkUrl: false })` is used, the internal/website `siteContext.path` will be generated.
```graphql
query {
  content(input: { id: 21114516 }) {
    id
    type
    siteContext(input: { enableLinkUrl: false }) {
      path
    }
  }
}
```
Response
```json
{
  "data": {
    "content": {
      "id": 21114516,
      "type": "promotion",
      "siteContext": {
        "path": "/home/promotion/21114516/texas-instruments-595x335-ed-analogpowersource-nl-121619-jh-low-emi"
      }
    }
  }
}
```

## Marko Web
Add `loaderQueryFragment`, `redirectToFn` and `pathFn` parameters to the `withContent` middleware. All of these new parameters are optional and, as such, do not cause any BC issues.

### loaderQueryFragment
Passing a GraphQL fragment via `loaderQueryFragment` will append the fragment fields to the content loader. This allows one to change the shape of the content object that is returned. For example:

```js
// some-website-route.js
const gql = require('graphql-tag');
const { withContent } = require('@base-cms/marko-web/middleware');
const content = require('./some-content-template');
const queryFragment = require('./some-page-fragment');

module.exports = (app) => {
  app.get('/*?:id(\\d{8})*', withContent({
    template: content,
    queryFragment,
    loaderQueryFragment: gql`
      fragment MyCustomWithContentFragment on Content {
        labels
      }
    `,
  });
};
```
The content response returned by the middleware will now include the `labels` field. This is useful when used in conjunction with either the `redirectToFn` or `pathFn` generators, as you can leverage additional content fields when determining how to generate the `redirectTo` and/or `path` values.

### redirectToFn
A function that allows you to generate the `redirectTo` value. By default, when no function is provided, the `withContent` middleware will use the `content.redirectTo` value. Returning a `falsey` value will result in no redirect, while returning a path or URL will redirect the content to that destination. Note: if a value is provided, the middleware will redirect using a standard `301` response with the `Location` header set to the provided value.

For example, to redirect all content with the `Google` label to `https://google.com`:
```js
// some-website-route.js
const gql = require('graphql-tag');
const { withContent } = require('@base-cms/marko-web/middleware');
const content = require('./some-content-template');
const queryFragment = require('./some-page-fragment');

module.exports = (app) => {
  app.get('/*?:id(\\d{8})*', withContent({
    template: content,
    queryFragment,
    loaderQueryFragment: gql`
      fragment MyCustomWithContentFragment on Content {
        labels
      }
    `,
    redirectToFn: ({ content: node }) => {
      if (node.labels.includes('Google')) return 'https://google.com';
      return node.redirectTo;
    },
  });
};
```

### pathFn
A function that allows you to generate the `path` value. By default, when no function is provided, the `withContent` middleware will use the `content.siteContext.path` value.

For example, to prevent `Promotions` from returning an external URL:
```js
// some-website-route.js
const { get } = require('@base-cms/object-path');
const gql = require('graphql-tag');
const { withContent } = require('@base-cms/marko-web/middleware');
const content = require('./some-content-template');
const queryFragment = require('./some-page-fragment');

module.exports = (app) => {
  app.get('/*?:id(\\d{8})*', withContent({
    template: content,
    queryFragment,
    loaderQueryFragment: gql`
      fragment MyCustomWithContentFragment on Content {
         # Must use a field alias here, since siteContext is already used by the default loader fragment.
        promotionContext: siteContext(input: { enableLinkUrl: false }) {
          path
        }
      }
    `,
    redirectToFn: ({ content: node }) => {
      if (node.type === 'promotion') return null; // prevent promotion redirect.
      return node.redirectTo;
    },
    pathFn: ({ content: node }) => {
      const path = get(node, 'siteContext.path');
      const promotionPath = get(node, 'promotionContext.path');
      if (node.type === 'promotion') return promotionPath;
      return path;
    },
  });
};
```
