### PR TITLE
Strip `$MC` marko javascript from body chunks

### DIFF
--- a/packages/marko-core/utils/clean-marko-chunk.js
+++ b/packages/marko-core/utils/clean-marko-chunk.js
@@ -1,5 +1,6 @@
 const stripComponentJS = chunk => chunk.replace(/<script>\(function\(\){var w=window;w\.\$components=.*w\.\$components}\)\(\)<\/script>/, '');
+const stripMCJS = chunk => chunk.replace(/<script>\$MC=\(window\.\$MC.+?<\/script>/, '');
 const stripAppendedJS = chunk => chunk.replace(/<script>\$components=.*\$components<\/script>/, '');
 const stripComments = chunk => chunk.replace(/<!--[A-Z][#/].*?-->/g, '');
 
-module.exports = chunk => stripAppendedJS(stripComponentJS(stripComments(chunk)));
+module.exports = chunk => stripMCJS(stripAppendedJS(stripComponentJS(stripComments(chunk))));


### PR DESCRIPTION
Marko versions higher than `4.18.33` inject (yet another) component javascript tag in the HTML response body. Since Marko is strictly used on the server, this script pattern will be stripped when cleaning the Marko response body (as there is no need for this code to be processed by the browser). 

It also prevents the unwanted `<script>` element from appearing in newsletter bodies.

Example script removed:
```html
<script>$MC=(window.$MC||[]).concat(/* various injected data here */)</script>
```