### PR TITLE
Add Authorable to Podcasts

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/types/podcast.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/types/podcast.js
@@ -6,7 +6,7 @@ extend type Query {
   contentPodcast(input: ContentPodcastQueryInput!): ContentPodcast @findOne(model: "platform.Content", using: { id: "_id" }, criteria: "contentPodcast")
 }
 
-type ContentPodcast implements Content & Media @applyInterfaceFields {
+type ContentPodcast implements Content & Authorable & Media @applyInterfaceFields {
   # fields directly on platform.model::Content\Podcast
   duration: Int @projection
 }


### PR DESCRIPTION
Relates to: https://github.com/cygnusb2b/base-platform/pull/4435

Trying to add Authors to Podcasts content types, but I think the fields need to be added to graphql somehow, maybe something as simple as this but I'm not sure.  

In the `base-cms-websites/endeavor-business-media` repo, the attributes for almost all content types, excluding only Contacts.  Therefore, by default, it should work for Podcasts.  However, when I dump `content`, there are no `authors` for Podcasts, `authors` only returns on other content, such as Articles.   It's at least being saved correctly to the model, as I see the added authors in mongo.  

I created a podcast on LFW and tried loading the LFW example site on dev, but there's still no author displaying.  

Is there anywhere else that Authorable this needs to be added for Podcasts?  I'm at a loss...

Example Podcast: https://manage.laserfocusworld.com/content/edit/podcast/14182701
No author appearing by date:
![image](https://user-images.githubusercontent.com/12496550/91895733-55928200-ec5d-11ea-8604-9c95183df42b.png)
