### PR TITLE
Create EmailThemeAlphaConfig type

### DIFF
--- a/services/graphql-server/src/dataloaders/index.js
+++ b/services/graphql-server/src/dataloaders/index.js
@@ -27,4 +27,5 @@ module.exports = basedb => ({
   magazineIssue: createProjectLoader({ basedb, modelName: 'magazine.Issue' }),
   magazineSection: createProjectLoader({ basedb, modelName: 'magazine.Section' }),
   emailSection: createProjectLoader({ basedb, modelName: 'email.Section' }),
+  configEmail: createProjectLoader({ basedb, modelName: 'configuration.Email' }),
 });

--- a/services/graphql-server/src/graphql/definitions/configuration/email.js
+++ b/services/graphql-server/src/graphql/definitions/configuration/email.js
@@ -1,0 +1,89 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+extend type Query {
+  "Loads a single alpha email config by ID."
+  emailThemeAlphaConfig(input: EmailThemeAlphaConfigQueryInput!): EmailThemeAlphaConfig @findOne(
+    model: "configuration.Email"
+    using: { id: "_id" }
+    criteria: "emailThemeAlphaConfig"
+  )
+
+  "Loads all alpha theme email configs."
+  emailThemeAlphaConfigs(input: EmailThemeAlphaConfigsQueryInput = {}): EmailThemeAlphaConfigConnection! @findMany(
+    model: "configuration.Email"
+    criteria: "emailThemeAlphaConfig"
+  )
+}
+
+enum EmailThemeAlphaConfigSortField {
+  id
+}
+
+type EmailThemeAlphaConfig {
+  id: ObjectID! @projection(localField: "_id") @value(localField: "_id")
+  type: String @projection
+  status: Int @projection
+  accentFontColor: String @projection
+  # add additional config fields here...
+
+  headerLink: String @projection
+  socialIcons: String @projection
+  facebook: String @projection
+  linkedin: String @projection
+  twitter: String @projection
+  youtube: String @projection
+  instagram: String @projection
+  pinterest: String @projection
+  headerBgColor: String @projection
+  headerTextColor: String @projection
+  headerTemplate: String @projection
+  dateToggle: String @projection
+  footerColor: String @projection
+  footerTextColor: String @projection
+
+  headerLeft: AssetImage @projection @refOne(
+    loader: "platformAsset"
+    criteria: "assetImage"
+  )
+  headerRight: AssetImage @projection @refOne(
+    loader: "platformAsset"
+    criteria: "assetImage"
+  )
+  newsletter(input: EmailThemeAlphaConfigNewsletterInput = {}): EmailNewsletter @projection @refOne(
+    loader: "platformProduct"
+    criteria: "emailNewsletter"
+  )
+}
+
+type EmailThemeAlphaConfigConnection @projectUsing(type: "EmailThemeAlphaConfig") {
+  totalCount: Int!
+  edges: [EmailThemeAlphaConfigEdge]!
+  pageInfo: PageInfo!
+}
+
+type EmailThemeAlphaConfigEdge {
+  node: EmailThemeAlphaConfig!
+  cursor: String!
+}
+
+input EmailThemeAlphaConfigNewsletterInput {
+  status: ModelStatus = active
+}
+
+input EmailThemeAlphaConfigQueryInput {
+  id: ObjectID!
+}
+
+input EmailThemeAlphaConfigsQueryInput {
+  status: ModelStatus = active
+  sort: EmailThemeAlphaConfigSortInput = {}
+}
+
+input EmailThemeAlphaConfigSortInput {
+  field: EmailThemeAlphaConfigSortField = id
+  order: SortOrder = desc
+}
+
+`;

--- a/services/graphql-server/src/graphql/definitions/configuration/email.js
+++ b/services/graphql-server/src/graphql/definitions/configuration/email.js
@@ -42,6 +42,9 @@ type EmailThemeAlphaConfig {
   dateToggle: String @projection
   footerColor: String @projection
   footerTextColor: String @projection
+  manageSubscriptions: String @projection
+  contactUs: String @projection
+  advertise: String @projection
 
   headerLeft: AssetImage @projection @refOne(
     loader: "platformAsset"

--- a/services/graphql-server/src/graphql/definitions/configuration/index.js
+++ b/services/graphql-server/src/graphql/definitions/configuration/index.js
@@ -1,8 +1,10 @@
 const gql = require('graphql-tag');
+const email = require('./email');
 const theme = require('./theme');
 
 module.exports = gql`
 
+${email}
 ${theme}
 
 `;

--- a/services/graphql-server/src/graphql/definitions/email/newsletter.js
+++ b/services/graphql-server/src/graphql/definitions/email/newsletter.js
@@ -45,13 +45,15 @@ type EmailNewsletter {
   defaultSubjectLine: String @projection
 
   # fields directly on email.model::Product\Newsletter
-  # ToDo: headerLeft, headerRight image references
   parent(input: EmailNewsletterParentInput = {}): EmailNewsletter @projection @refOne(loader: "platformProducts", criteria: "emailNewsletter")
   sections(input: EmailNewsletterSectionsInput = {}): EmailSectionConnection! @projection(localField: "_id") @refMany(model: "email.Section", localField: "_id", foreignField: "deployment.$id")
   alias: String @projection
   usesDeploymentDates: Boolean @projection
   teaser: String @projection
+  headerleft: AssetImage @projection @refOne(loader: "platformAsset", criteria: "assetImage")
+  headerRight: AssetImage @projection @refOne(loader: "platformAsset", criteria: "assetImage")
   headerLink: String @projection
+  socialIcons: String @projection
   facebook: String @projection
   linkedin: String @projection
   twitter: String @projection

--- a/services/graphql-server/src/graphql/definitions/email/newsletter.js
+++ b/services/graphql-server/src/graphql/definitions/email/newsletter.js
@@ -50,25 +50,17 @@ type EmailNewsletter {
   alias: String @projection
   usesDeploymentDates: Boolean @projection
   teaser: String @projection
-  headerleft: AssetImage @projection @refOne(loader: "platformAsset", criteria: "assetImage")
-  headerRight: AssetImage @projection @refOne(loader: "platformAsset", criteria: "assetImage")
-  headerLink: String @projection
-  socialIcons: String @projection
-  facebook: String @projection
-  linkedin: String @projection
-  twitter: String @projection
-  youtube: String @projection
-  instagram: String @projection
-  pinterest: String @projection
-  headerBgColor: String @projection
-  headerTextColor: String @projection
-  headerTemplate: String @projection
-  dateToggle: String @projection
-  footerColor: String @projection
-  footerTextColor: String @projection
 
   # GraphQL-only fields.
   site(input: EmailNewsletterSiteInput = {}): WebsiteSite @projection(localField: "siteId") @refOne(loader: "platformProduct", localField: "siteId", criteria: "websiteSite")
+
+  "Loads all alpha configuration objects for this newsletter, if present."
+  alphaThemeConfigs(input: EmailNewsletterAlphaConfigInput = {}): EmailThemeAlphaConfigConnection @projection @refMany(
+    model: "configuration.Email",
+    criteria: "emailThemeAlphaConfig",
+    localField: "_id",
+    foreignField: "newsletter"
+  )
 }
 
 type EmailNewsletterConnection @projectUsing(type: "EmailNewsletter") {
@@ -99,6 +91,11 @@ enum EmailNewsletterSortField {
   name
   fullName
   sequence
+}
+
+input EmailNewsletterAlphaConfigInput {
+  status: ModelStatus = active
+  sort: EmailThemeAlphaConfigSortInput = {}
 }
 
 input EmailNewsletterQueryInput {

--- a/services/graphql-server/src/graphql/definitions/email/newsletter.js
+++ b/services/graphql-server/src/graphql/definitions/email/newsletter.js
@@ -45,11 +45,25 @@ type EmailNewsletter {
   defaultSubjectLine: String @projection
 
   # fields directly on email.model::Product\Newsletter
+  # ToDo: headerLeft, headerRight image references
   parent(input: EmailNewsletterParentInput = {}): EmailNewsletter @projection @refOne(loader: "platformProducts", criteria: "emailNewsletter")
   sections(input: EmailNewsletterSectionsInput = {}): EmailSectionConnection! @projection(localField: "_id") @refMany(model: "email.Section", localField: "_id", foreignField: "deployment.$id")
   alias: String @projection
   usesDeploymentDates: Boolean @projection
   teaser: String @projection
+  headerLink: String @projection
+  facebook: String @projection
+  linkedin: String @projection
+  twitter: String @projection
+  youtube: String @projection
+  instagram: String @projection
+  pinterest: String @projection
+  headerBgColor: String @projection
+  headerTextColor: String @projection
+  headerTemplate: String @projection
+  dateToggle: String @projection
+  footerColor: String @projection
+  footerTextColor: String @projection
 
   # GraphQL-only fields.
   site(input: EmailNewsletterSiteInput = {}): WebsiteSite @projection(localField: "siteId") @refOne(loader: "platformProduct", localField: "siteId", criteria: "websiteSite")

--- a/services/graphql-server/src/graphql/definitions/email/newsletter.js
+++ b/services/graphql-server/src/graphql/definitions/email/newsletter.js
@@ -55,7 +55,7 @@ type EmailNewsletter {
   site(input: EmailNewsletterSiteInput = {}): WebsiteSite @projection(localField: "siteId") @refOne(loader: "platformProduct", localField: "siteId", criteria: "websiteSite")
 
   "Loads all alpha configuration objects for this newsletter, if present."
-  alphaThemeConfigs(input: EmailNewsletterAlphaConfigInput = {}): EmailThemeAlphaConfigConnection @projection @refMany(
+  alphaThemeConfigs(input: EmailNewsletterAlphaConfigInput = {}): EmailThemeAlphaConfigConnection! @projection @refMany(
     model: "configuration.Email",
     criteria: "emailThemeAlphaConfig",
     localField: "_id",

--- a/services/graphql-server/src/graphql/utils/criteria-for.js
+++ b/services/graphql-server/src/graphql/utils/criteria-for.js
@@ -8,6 +8,7 @@ const criterion = {
   brevityCollection: () => ({ type: 'Collection' }),
   configurationThemeIcarus: () => ({ type: 'Icarus' }),
   content: () => ({ type: { $in: contentTypes } }),
+  emailThemeAlphaConfig: () => ({ type: 'ThemeAlpha' }),
   taxonomy: () => ({ type: { $in: taxonomyTypes } }),
   emailNewsletter: () => ({ type: 'Newsletter' }),
   entityOrganization: () => ({ type: 'Organization' }),


### PR DESCRIPTION
https://southcomm.atlassian.net/browse/DEV-29

Examples from `ebm_ee`

Direct query of a config:
```graphql
query {
  emailThemeAlphaConfig(input: { id: "5c9d1dde6e705634008b459a" }) {
    id
    status
    accentFontColor
    newsletter {
      id
      name
    }
    # additional fields to return...
  }
}
```
```json
{
  "data": {
    "emailThemeAlphaConfig": {
      "id": "5c9d1dde6e705634008b459a",
      "status": 1,
      "accentFontColor": "#000000",
      "newsletter": {
        "id": "5c9d1dd36e705634008b4598",
        "name": "Evaluation Engineering Weekly Update"
      }
    }
  }
}
```

Accessing configs directly off a newsletter:
```graphql
query {
  emailNewsletter(input: { id: "5c9d1dd36e705634008b4598" }) {
    id
    name
    alphaThemeConfigs {
      edges {
        node {
          id
          status
          accentFontColor
        }
      }
    }
  }
}
```
```json
{
  "data": {
    "emailNewsletter": {
      "id": "5c9d1dd36e705634008b4598",
      "name": "Evaluation Engineering Weekly Update",
      "alphaThemeConfigs": {
        "edges": [
          {
            "node": {
              "id": "5c9d1dde6e705634008b459a",
              "status": 1,
              "accentFontColor": "#000000"
            }
          }
        ]
      }
    }
  }
}
```