### PR TITLE
Create `marko-newsletters-omail` package and DPM comments component

### DIFF
--- a/packages/marko-newsletters-omail/components/dpm.marko
+++ b/packages/marko-newsletters-omail/components/dpm.marko
@@ -1,4 +1,4 @@
-$ const attrs = ["ln", "lc", "lcv", "lkw"].filter((k) => input[k]).map((k) => `${k}="${input[k]}"`);
+$ const attrs = ["ln", "lc", "lcv", "lkw"].filter((k) => input[k]).map((k) => `${k}="${input[k].replace(/"/g, "&quot;")}"`);
 $ const comments = `<!--DPM: ${attrs.join(' ')} -->`;
 
 <if(attrs.length)>

--- a/packages/marko-newsletters-omail/components/dpm.marko
+++ b/packages/marko-newsletters-omail/components/dpm.marko
@@ -1,0 +1,6 @@
+$ const attrs = ["ln", "lc", "lcv", "lkw"].filter((k) => input[k]).map((k) => `${k}="${input[k]}"`);
+$ const comments = `<!--DPM: ${attrs.join(' ')} -->`;
+
+<if(attrs.length)>
+  $!{`<!--DPM: ${attrs.join(' ')} -->`}
+</if>

--- a/packages/marko-newsletters-omail/components/marko.json
+++ b/packages/marko-newsletters-omail/components/marko.json
@@ -1,0 +1,9 @@
+{
+  "<marko-newsletters-omail-dpm>": {
+    "template": "./dpm.marko",
+    "@ln": "string",
+    "@lc": "string",
+    "@lcv": "string",
+    "@lkw": "string"
+  }
+}

--- a/packages/marko-newsletters-omail/marko.json
+++ b/packages/marko-newsletters-omail/marko.json
@@ -1,0 +1,6 @@
+{
+  "taglib-id": "@base-cms/marko-newsletters-omail",
+  "taglib-imports": [
+    "./components/marko.json"
+  ]
+}

--- a/packages/marko-newsletters-omail/package.json
+++ b/packages/marko-newsletters-omail/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@base-cms/marko-newsletters-omail",
+  "version": "0.0.0",
+  "description": "Omail (Omeda) Marko components for BaseCMS newsletters.",
+  "author": "Jacob Bare <jacob@parameter1.com>",
+  "license": "MIT",
+  "repository": "https://github.com/base-cms/base-cms/tree/master/packages/marko-newsletters-omail",
+  "scripts": {
+    "compile": "basecms-marko-compile compile --dir ./ --silent true",
+    "test": "yarn compile"
+  },
+  "peerDependencies": {
+    "@base-cms/marko-core": "^1.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
Usage:

```marko
<marko-newsletters-omail-dpm ln="Some link name" lcv="Some Advertiser" lc="Advertising" />
```

Would render in HTML:

```html
<!--DPM: ln="Some link name" lc="Advertising" lcv="Some Advertiser" -->
```

The component accepts four args: `ln`, `lc`, `lcv` and `lkw` per the Omail link tracking docs: https://main.omeda.com/knowledge-base/email-assigning-link-tracking-categories/

Note: values with double-quotes will entity encode the quote value, i.e., `<marko-newsletters-omail-dpm ln='f"o"o' />` becomes `<!--DPM: ln="f&quote;o&quote;o" -->`