### PR TITLE
Support passing custom newsletter query fragment to template router

### DIFF
--- a/packages/marko-newsletters/express/template-router.js
+++ b/packages/marko-newsletters/express/template-router.js
@@ -8,73 +8,51 @@ const moment = require('moment-timezone');
 const pretty = require('pretty');
 const cleanResponse = require('@base-cms/marko-core/middleware/clean-marko-response');
 const siteContextFragment = require('@base-cms/web-common/graphql/website-context-fragment');
+const { extractFragmentData } = require('@base-cms/web-common/utils');
 const websiteFactory = require('../utils/website-factory');
 
-const query = gql`
-
-query WithMarkoNewsletter($input: EmailNewsletterAliasQueryInput!) {
-  emailNewsletterAlias(input: $input) {
-    id
-    name
-    teaser
-    alias
-    description
-    status
-    site {
-      ...MarkoWebsiteContextFragment
-    }
-    alphaThemeConfigs {
-      edges {
-        node {
-          id
-          status
-          accentFontColor
-          headerLink
-          socialIcons
-          facebook
-          linkedin
-          twitter
-          youtube
-          instagram
-          pinterest
-          headerBgColor
-          headerTextColor
-          headerTemplate
-          dateToggle
-          footerColor
-          footerTextColor
-          manageSubscriptions
-          contactUs
-          advertise
-          headerLeft {
-            id
-            src
-          }
-          headerRight {
-            id
-            src
-          }
+const buildQuery = ({ queryFragment }) => {
+  const { spreadFragmentName, processedFragment } = extractFragmentData(queryFragment);
+  return gql`
+    query WithMarkoNewsletter($input: EmailNewsletterAliasQueryInput!) {
+      emailNewsletterAlias(input: $input) {
+        id
+        name
+        teaser
+        alias
+        description
+        status
+        site {
+          ...MarkoWebsiteContextFragment
         }
+        ${spreadFragmentName}
       }
     }
-  }
-}
 
-${siteContextFragment}
-
-`;
+    ${siteContextFragment}
+    ${processedFragment}
+  `;
+};
 
 module.exports = ({ templates }) => {
   const router = Router();
 
   router.use(cleanResponse());
 
-  templates.forEach(({ route, template, alias }) => {
+  templates.forEach(({
+    route,
+    template,
+    alias,
+    queryFragment,
+  }) => {
     router.get(route, asyncRoute(async (req, res) => {
       const { apollo } = res.locals;
       const input = { alias, status: 'any' };
 
-      const { data } = await apollo.query({ query, variables: { input } });
+      const { data } = await apollo.query({
+        query: buildQuery({ queryFragment }),
+        variables: { input },
+      });
       const { emailNewsletterAlias: newsletter } = data;
 
       // Load the current newsletter and associated website.

--- a/packages/marko-newsletters/express/template-router.js
+++ b/packages/marko-newsletters/express/template-router.js
@@ -23,6 +23,40 @@ query WithMarkoNewsletter($input: EmailNewsletterAliasQueryInput!) {
     site {
       ...MarkoWebsiteContextFragment
     }
+    alphaThemeConfigs {
+      edges {
+        node {
+          id
+          status
+          accentFontColor
+          headerLink
+          socialIcons
+          facebook
+          linkedin
+          twitter
+          youtube
+          instagram
+          pinterest
+          headerBgColor
+          headerTextColor
+          headerTemplate
+          dateToggle
+          footerColor
+          footerTextColor
+          manageSubscriptions
+          contactUs
+          advertise
+          headerLeft {
+            id
+            src
+          }
+          headerRight {
+            id
+            src
+          }
+        }
+      }
+    }
   }
 }
 

--- a/packages/marko-newsletters/start-server.js
+++ b/packages/marko-newsletters/start-server.js
@@ -19,6 +19,7 @@ const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
 module.exports = async ({
   rootDir,
   templatePath = 'templates', // Where templates will be resolved from.
+  newsletterQueryFragment, // An optional query fragment to use when loading the newsletter.
   customConfig,
   coreConfig,
   port = env.PORT || 5008,
@@ -48,7 +49,11 @@ module.exports = async ({
   const sitePackage = require(path.resolve(rootDir, 'package.json'));
 
   // Load newsletter marko templates.
-  const templates = await loadTemplates({ rootDir, templatePath });
+  const templates = await loadTemplates({
+    rootDir,
+    templatePath,
+    queryFragment: newsletterQueryFragment,
+  });
 
   const app = express({
     rootDir,

--- a/packages/marko-newsletters/utils/load-templates.js
+++ b/packages/marko-newsletters/utils/load-templates.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 let promise;
 
-const load = async ({ rootDir, templatePath }) => {
+const load = async ({ rootDir, templatePath, queryFragment }) => {
   const templateDir = path.resolve(rootDir, templatePath);
   if (!fs.existsSync(templateDir)) throw new Error(`The template directory ${templateDir} does not exist.`);
 
@@ -22,12 +22,13 @@ const load = async ({ rootDir, templatePath }) => {
       alias,
       file,
       template,
+      queryFragment,
     });
   });
   return templates;
 };
 
-module.exports = ({ rootDir, templatePath }) => {
-  if (!promise) promise = load({ rootDir, templatePath });
+module.exports = ({ rootDir, templatePath, queryFragment }) => {
+  if (!promise) promise = load({ rootDir, templatePath, queryFragment });
   return promise;
 };


### PR DESCRIPTION
Adding this will allow for you to get the alpha configs inside the eNL something like this:
```
import { getAsArray } from "@base-cms/object-path";

$ const { newsletter, date } = data;
$ const alphaThemeConfigs = getAsArray(newsletter, 'alphaThemeConfigs.edges');
```

The configs object looks like:

```
alphaThemeConfigs {
  edges {
    node {
      id
      status
      accentFontColor
      headerLink
      socialIcons
      facebook
      linkedin
      twitter
      youtube
      instagram
      pinterest
      headerBgColor
      headerTextColor
      headerTemplate
      dateToggle
      footerColor
      footerTextColor
      manageSubscriptions
      contactUs
      advertise
      headerLeft {
        id
        src
      }
      headerRight {
        id
        src
      }
    }
  }
}
```