### PR TITLE
Add `subscribe` to EmailThemeAlphaConfig

### DIFF
--- a/services/graphql-server/src/graphql/definitions/configuration/email.js
+++ b/services/graphql-server/src/graphql/definitions/configuration/email.js
@@ -42,6 +42,7 @@ type EmailThemeAlphaConfig {
   dateToggle: String @projection
   footerColor: String @projection
   footerTextColor: String @projection
+  subscribe: String @projection
   manageSubscriptions: String @projection
   contactUs: String @projection
   advertise: String @projection


### PR DESCRIPTION
Relates to: https://github.com/base-cms/base-cms/pull/465
I didn't noticed it was missing in the first PR, but there's supposed to be a 'subscribe', as well as a 'manageSubscriptions', since they have different links.