### PR TITLE
Support returning advertiser data with EmailX requests

### DIFF
--- a/packages/marko-newsletters-email-x/components/data.marko
+++ b/packages/marko-newsletters-email-x/components/data.marko
@@ -8,7 +8,12 @@ $ const params = getAsObject(input, "params");
 $ const decodedParams = getAsArray(input, "decodedParams");
 
 $ const { uri, id } = adUnit;
-$ const { email, date, send } = params;
+$ const {
+  email,
+  date,
+  send,
+  includeAdvertiser,
+} = params;
 
 $ const promise = fetchData({
   serveUri: uri,
@@ -16,6 +21,7 @@ $ const promise = fetchData({
   date,
   email,
   send,
+  includeAdvertiser,
   decodedParams,
 });
 

--- a/packages/marko-newsletters-email-x/components/marko.json
+++ b/packages/marko-newsletters-email-x/components/marko.json
@@ -29,7 +29,8 @@
     "<params>": {
       "@email": "string",
       "@date": "date",
-      "@send": "string"
+      "@send": "string",
+      "@include-advertiser": "boolean"
     },
     "@decoded-params":  "array"
   }

--- a/packages/marko-newsletters-email-x/utils/build-query.js
+++ b/packages/marko-newsletters-email-x/utils/build-query.js
@@ -5,13 +5,21 @@
  * @param {moment} params.momentDate The moment date of the deployment
  * @param {string} params.email The email address query var
  * @param {string} [param.send] The send corrlator var
+ * @param {bool}   [param.includeAdvertiser] Flag indicating if the advertiser data should be
+ *                 returned in the response. Defaults to false.
  */
-module.exports = ({ momentDate, email, send } = {}) => {
+module.exports = ({
+  momentDate,
+  email,
+  send,
+  includeAdvertiser = false,
+} = {}) => {
   const rand = Math.floor(Math.random() * 100000000);
   return {
     date: momentDate.format('YYYY-MM-DDTHH:mm:ssZ'),
     rand,
     email,
     send,
+    incAdv: Boolean(includeAdvertiser),
   };
 };

--- a/packages/marko-newsletters-email-x/utils/build-query.js
+++ b/packages/marko-newsletters-email-x/utils/build-query.js
@@ -20,6 +20,6 @@ module.exports = ({
     rand,
     email,
     send,
-    incAdv: Boolean(includeAdvertiser),
+    incAdv: includeAdvertiser || undefined,
   };
 };

--- a/packages/marko-newsletters-email-x/utils/build-query.js
+++ b/packages/marko-newsletters-email-x/utils/build-query.js
@@ -20,6 +20,6 @@ module.exports = ({
     rand,
     email,
     send,
-    incAdv: includeAdvertiser || undefined,
+    ...(includeAdvertiser && { incAdv: true }),
   };
 };

--- a/packages/marko-newsletters-email-x/utils/fetch-data.js
+++ b/packages/marko-newsletters-email-x/utils/fetch-data.js
@@ -22,6 +22,7 @@ module.exports = async ({
   date,
   email,
   send,
+  includeAdvertiser = false,
   decodedParams,
   fetchOptions,
 } = {}) => {
@@ -31,7 +32,12 @@ module.exports = async ({
   const momentDate = moment(date);
   if (!momentDate.isValid()) throw new Error(`The provided EmailX date '${date}' is invalid.`);
 
-  const query = buildQuery({ momentDate, email, send });
+  const query = buildQuery({
+    momentDate,
+    email,
+    send,
+    includeAdvertiser,
+  });
 
   const buildParams = {
     uri: serveUri,


### PR DESCRIPTION
Allows consuming applications to include a flag to return detailed advertiser information (such as for use with DPM comments) via the email-x-data component.

Will require future partial rebase to bring the advertiser data feature support into EmailX, but won't have any negative effect in the meantime.