### PR TITLE
Pass `active` modifier to nav container `li`

### DIFF
--- a/packages/marko-web-theme-default/components/site-navbar/item.marko
+++ b/packages/marko-web-theme-default/components/site-navbar/item.marko
@@ -9,12 +9,17 @@ $ const linkMods = (href) => {
   if (isActiveLink(req.path, href)) mods.push('active');
   return mods;
 };
+$ const containerMods = (href) => {
+  const mods = [...getAsArray(input, "modifiers")];
+  if (isActiveLink(req.path, href)) mods.push('active');
+  return mods;
+};
 
 <marko-web-element
   block-name=blockName
   name="item"
   tag=(input.tag || "li")
-  modifiers=input.modifiers
+  modifiers=containerMods(input.href)
 >
   $ const elementName = `${blockName}__link`;
   $ const classNames = [elementName, ...linkMods(input.href).map(mod => `${elementName}--${mod}`)];


### PR DESCRIPTION
Allows the entire `li` element to be targeted, not just the `a`