### PR TITLE
Optionally control ad requests based on media queries

### DIFF
--- a/packages/marko-web-gam/components/define-display-ad.marko
+++ b/packages/marko-web-gam/components/define-display-ad.marko
@@ -13,6 +13,7 @@ $ const {
   sizeMapping,
   withWrapper,
   collapseBeforeAdFetch,
+  requestOnMediaMatch,
 } = input;
 $ const id = input.id || generateId({ inc });
 
@@ -35,7 +36,6 @@ $ const slots = {
   },
 };
 $ calls.push(...buildSlots(slots));
-$ calls.push(`googletag.display('${id}');`);
 
 $ const attrs = {
   ...getAsObject(input.attrs),
@@ -50,6 +50,24 @@ $ const attrs = {
 
 $ const blockName = input.blockName || "ad-container";
 $ const classNames = [blockName, ...BEM.applyModifiers(blockName, input.modifiers), input.class];
+
+$ const debugMediaQuery = Boolean(defaultValue(input.debugMediaQuery, false));
+$ if (requestOnMediaMatch) calls.push(`
+  var hasRequested = false; var debugMediaQuery = ${debugMediaQuery};
+  var handler = function(media) {
+    if (hasRequested) return;
+    if (media.matches) {
+      googletag.display('${id}'); hasRequested = true;
+      if (debugMediaQuery) console.log('GAM ad request sent based on media query', '${id}', '${requestOnMediaMatch}');
+    } else {
+      if (debugMediaQuery) console.log('GAM ad request ineligble based on media query', '${id}', '${requestOnMediaMatch}');
+    }
+  };
+  var mql = window.matchMedia('${requestOnMediaMatch}');
+  mql.addEventListener('change', function(event) { handler(event); });
+  handler(mql);
+`);
+$ if (!requestOnMediaMatch) calls.push(`googletag.display('${id}');`);
 
 <if(path)>
   <div

--- a/packages/marko-web-gam/components/marko.json
+++ b/packages/marko-web-gam/components/marko.json
@@ -56,6 +56,8 @@
     "@targeting": "object",
     "@collapse": "boolean",
     "@collapse-before-ad-fetch": "boolean",
+    "@request-on-media-match": "string",
+    "@debug-media-query": "boolean",
     "@oop": "boolean",
     "@apply-style": {
       "type": "boolean",


### PR DESCRIPTION
Passing a media query string to the `request-on-media-match` property will instruct the component to only fire an ad request when the media query matches. The media query state is checked on initialization and on change (e.g. when the browser is resized). For example, to only allow an ad request to be fired when the minimum viewport with is 1068 pixels:

```marko
<!-- some input values -->
$ const adInputValues = {};
<marko-web-gam-define-display-ad ...adInputValues request-on-media-match="(min-width: 1068px)" />
```

If the ad was previously requested, the media query handler bails out early. This ensures that the ad is only requested once if/when the user continually resizes their browser.

Finally, passing `debug-media-query=true` to the component will output debug info to the browser console.