### PR TITLE
Fix syntax error for NR extension

### DIFF
--- a/services/graphql-server/src/routes/graphql.js
+++ b/services/graphql-server/src/routes/graphql.js
@@ -32,7 +32,7 @@ const config = {
   tracing: GRAPHQL_TRACING_ENABLED,
   cacheControl: GRAPHQL_CACHE_CONTROL_ENABLED,
   extensions: [
-    ...(NEW_RELIC_ENABLED && [() => new ApolloNewrelicExtension()]),
+    ...(NEW_RELIC_ENABLED ? [() => ApolloNewrelicExtension()] : []),
   ],
   engine: APOLLO_ENGINE_ENABLED ? { apiKey: APOLLO_ENGINE_API_KEY } : false,
   introspection: GRAPHQL_INTROSPECTION_ENABLED,


### PR DESCRIPTION
Fixes #486

While objects support conditional spreads, spreading an array with a conditional returning `false` will result in a syntax error. Update to return an empty array when the NR flag is disabled.