### PR TITLE
added server side validation for rmi payload

### DIFF
--- a/packages/marko-web-inquiry/routers/submit.js
+++ b/packages/marko-web-inquiry/routers/submit.js
@@ -51,6 +51,15 @@ module.exports = ({ queryFragment, notification, confirmation }) => asyncRoute(a
     return true;
   };
 
+  const validatePayload = async () => {
+    if (!payload || !payload.email === '') {
+      error('Form validation failed!', payload);
+      throw exception('Invalid form submission');
+    }
+    return true;
+  };
+
+  await validatePayload();
   await validateRecaptcha();
 
   await Promise.all([

--- a/packages/marko-web-inquiry/routers/submit.js
+++ b/packages/marko-web-inquiry/routers/submit.js
@@ -51,15 +51,11 @@ module.exports = ({ queryFragment, notification, confirmation }) => asyncRoute(a
     return true;
   };
 
-  const validatePayload = async () => {
-    if (!payload || !payload.email === '') {
-      error('Form validation failed!', payload);
-      throw exception('Invalid form submission');
-    }
-    return true;
-  };
+  if (!payload || payload.email === '') {
+    error('Form validation failed!', payload);
+    throw exception('Invalid form submission');
+  }
 
-  await validatePayload();
   await validateRecaptcha();
 
   await Promise.all([


### PR DESCRIPTION
We're getting infrequent (but common enough) RMI submissions with empty payloads.  It looks to have started around mid august when the token was removed from the payload prior to its storage in mongo and email, but that may be circumstantial.
    
The rest of the client side validation requirements (email/name/etc) are being bypassed for certain (all empty fields in email and totally empty payload mongo).  The recapthca seems to be in place, and if google does not return success will prevent submission, but the storage of the token was removed from payload so I can't confirm if its being bypassed or just beaten.

This will at least prevent clients/internal users from getting emails with no data in them, although it doesn't get at the exact problem of how if the client-side validation is being bypassed via script or whatever, why is google siteverify returning success for the recaptca token.