### PR TITLE
Detect embeds when injecting ads and adjust accordingly

### DIFF
--- a/packages/marko-web-gam/browser/inject-ads.vue
+++ b/packages/marko-web-gam/browser/inject-ads.vue
@@ -19,6 +19,10 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    detectEmbeds: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   data: () => ({
@@ -62,12 +66,22 @@ export default {
               // eslint-disable-next-line consistent-return
               $child.nextAll(childSelector).each(function handleBefore() {
                 if ($(this).text().length > 1) {
-                  $(this).before(cleaned);
+                  const $previous = $(this).prev();
+                  if (component.detectEmbeds && $previous.attr('data-embed-type')) {
+                    $(this).after(cleaned);
+                  } else {
+                    $(this).before(cleaned);
+                  }
                   return false;
                 }
               });
             } else {
-              $child.after(cleaned);
+              const $next = $(this).next();
+              if (component.detectEmbeds && $next.attr('data-embed-type')) {
+                $child.before(cleaned);
+              } else {
+                $child.after(cleaned);
+              }
             }
           }
           component.hasInjected[targetLength] = true;

--- a/packages/marko-web-gam/components/inject-ads.marko
+++ b/packages/marko-web-gam/components/inject-ads.marko
@@ -4,6 +4,7 @@ import DefineDisplayAd from "./define-display-ad";
 $ const props = {
   selector: input.selector,
   childSelector: input.childSelector,
+  detectEmbeds: input.detectEmbeds,
 };
 
 $ const inject = getAsArray(input, "inject").filter(o => o && o.at);

--- a/packages/marko-web-gam/components/marko.json
+++ b/packages/marko-web-gam/components/marko.json
@@ -130,7 +130,9 @@
       "@block-name": {
         "type": "string",
         "default-value": "ad-container"
-      }
+      },
+      "@collapse-before-ad-fetch": "boolean",
+      "@with-wrapper": "boolean"
     },
     "@detect-embeds": "boolean",
     "@selector": "string",

--- a/packages/marko-web-gam/components/marko.json
+++ b/packages/marko-web-gam/components/marko.json
@@ -132,6 +132,7 @@
         "default-value": "ad-container"
       }
     },
+    "@detect-embeds": "boolean",
     "@selector": "string",
     "@child-selector": "string"
   }


### PR DESCRIPTION
When `detect-embeds` is true, the ad injector component will adjust the ad injection based on whether an embed was detected either before or after the target element. This ensures that the injected ad does not become a direct sibling of the embed, allowing the ad to properly clear left/right aligned embeds.

This feature is _disabled by default_ and requires opt-in by passing `detect-embeds=true` to the component.