### PR TITLE
Prevent inclusion of url params for direct share

### DIFF
--- a/packages/marko-web-social-sharing/browser/share-button.vue
+++ b/packages/marko-web-social-sharing/browser/share-button.vue
@@ -171,8 +171,7 @@ export default {
       }).filter(({ value }) => value).map(({ key, value }) => `${this.encode(key)}=${this.encode(value)}`);
       // Return direct URLs without appending new parameters
       if (this.type === 'direct') return this.href;
-      const url = `${this.href}?${kvs.join('&')}`;
-      return url;
+      return `${this.href}?${kvs.join('&')}`;
     },
 
     emitOpenEvent() {

--- a/packages/marko-web-social-sharing/browser/share-button.vue
+++ b/packages/marko-web-social-sharing/browser/share-button.vue
@@ -168,11 +168,9 @@ export default {
         }
         // Return value as is
         return { key, value };
-      }).filter(({ key, value }) => {
-        // Do not double append URL to email body!
-        if (this.action === 'Email' && key === 'url') return false;
-        return value;
-      }).map(({ key, value }) => `${this.encode(key)}=${this.encode(value)}`);
+      }).filter(({ value }) => value).map(({ key, value }) => `${this.encode(key)}=${this.encode(value)}`);
+      // Return direct URLs without appending new parameters
+      if (this.type === 'direct') return this.href;
       const url = `${this.href}?${kvs.join('&')}`;
       return url;
     },

--- a/packages/marko-web-social-sharing/browser/share-button.vue
+++ b/packages/marko-web-social-sharing/browser/share-button.vue
@@ -168,8 +168,13 @@ export default {
         }
         // Return value as is
         return { key, value };
-      }).filter(({ value }) => value).map(({ key, value }) => `${this.encode(key)}=${this.encode(value)}`);
-      return `${this.href}?${kvs.join('&')}`;
+      }).filter(({ key, value }) => {
+        // Do not double append URL to email body!
+        if (this.action === 'Email' && key === 'url') return false;
+        return value;
+      }).map(({ key, value }) => `${this.encode(key)}=${this.encode(value)}`);
+      const url = `${this.href}?${kvs.join('&')}`;
+      return url;
     },
 
     emitOpenEvent() {


### PR DESCRIPTION
Ref #479 -- When `direct` is the sharing provider type, don't append the parameters to the href. By default most mail clients will just include plaintext any URL parameters they don't understand, so they need to be removed from the URL. Since we're already modifying the href to replace the existing `@keys` with the content-specific values, just return the href without appending new parameters.

Current behavior:
![image](https://user-images.githubusercontent.com/1778222/100638788-09a5b680-32fa-11eb-982a-ab8fba876d28.png)

New behavior:
![image](https://user-images.githubusercontent.com/1778222/100641259-d9134c00-32fc-11eb-8783-d5c4abd3802e.png)
