### PR TITLE
Add console error logging for un-renderable errors

### DIFF
--- a/packages/marko-web/express/error-handlers.js
+++ b/packages/marko-web/express/error-handlers.js
@@ -6,6 +6,7 @@ const findContentAlias = require('./find-content-alias');
 const applyQueryParams = require('../utils/apply-query-params');
 
 const { isArray } = Array;
+const { error } = console;
 
 const renderError = (res, { statusCode, err, template }) => {
   res.status(statusCode);
@@ -47,7 +48,13 @@ const redirectOrError = ({
     } else {
       render(res, { statusCode, err, template });
     }
-  }).catch(() => render(res, { statusCode, err, template }));
+  }).catch(async () => {
+    try {
+      render(res, { statusCode, err, template });
+    } catch (e) {
+      error('Unable to render error template for', err);
+    }
+  });
 };
 
 module.exports = (app, { template, redirectHandler }) => {

--- a/packages/marko-web/express/error-handlers.js
+++ b/packages/marko-web/express/error-handlers.js
@@ -48,7 +48,7 @@ const redirectOrError = ({
     } else {
       render(res, { statusCode, err, template });
     }
-  }).catch(async () => {
+  }).catch(() => {
     try {
       render(res, { statusCode, err, template });
     } catch (e) {

--- a/packages/marko-web/start-server.js
+++ b/packages/marko-web/start-server.js
@@ -33,6 +33,7 @@ module.exports = async ({
   fragments, // fragments to register globally
   embeddedMediaHandlers,
   onAsyncBlockError,
+  onFatalError,
   redirectHandler,
   sitemapsHeaders,
 
@@ -63,6 +64,7 @@ module.exports = async ({
     tenantKey,
     siteId,
     onAsyncBlockError,
+    onFatalError,
     document,
     components,
     fragments,
@@ -82,7 +84,11 @@ module.exports = async ({
   routes(app);
 
   // Apply error handlers.
-  errorHandlers(app, { template: errorTemplate, redirectHandler });
+  errorHandlers(app, {
+    template: errorTemplate,
+    redirectHandler,
+    onFatalError: onFatalError || onAsyncBlockError,
+  });
 
   const server = http.createServer(app);
 


### PR DESCRIPTION
When encountering an error within the error template, the root cause of the error isn't displayed. Usually you'll only see the truly fatal uncaught error (headers already sent). This wraps the error template render in another try/catch with console output. The result is twofold:
- The running process is no longer hung (on dev/gulp a white screen crash followed by express no longer listening, and in prod the container will be restarted because the healthcheck will fail)
- The underlying error object that _would_ have been rendered within a template will be displayed in the compose or docker container logs.

Current behavior (dev):
![image](https://user-images.githubusercontent.com/1778222/100824413-b9267a00-341b-11eb-8cde-b38de9285bb7.png)

New behavior (dev):
![image](https://user-images.githubusercontent.com/1778222/100824354-9ac07e80-341b-11eb-97d4-24b7d2ca8136.png)
