### PR TITLE
Append template name to ad unit

### DIFF
--- a/packages/marko-web-gam/config.js
+++ b/packages/marko-web-gam/config.js
@@ -40,7 +40,12 @@ class GAMConfiguration {
   } = {}) {
     if (!name || !alias || !path) throw new Error('Unable to create GAM ad unit: the name, alias, and path are required');
     const template = templateName ? this.templates[templateName] : {};
-    const adUnit = { ...template, ...options, path: this.createAdUnitPath(path) };
+    const adUnit = {
+      ...template,
+      ...options,
+      path: this.createAdUnitPath(path),
+      templateName,
+    };
     set(this.adUnits, `${alias}.${name}`, adUnit);
     return this;
   }


### PR DESCRIPTION
Sets the `templateName` along with the ad unit path and options