### PR TITLE
GDPR/Privacy Compliance added to inquiry form

### DIFF
--- a/packages/marko-web-inquiry/browser/default-form.vue
+++ b/packages/marko-web-inquiry/browser/default-form.vue
@@ -190,6 +190,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    gdprCountryCodes: {
+      type: Array,
+      default: () => ['AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR', 'DE', 'GR', 'HU', 'IS', 'IE', 'IT', 'LV', 'LI', 'LT', 'LU', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'SK', 'ES', 'SE', 'GB'],
+    },
     gdprMessage: {
       type: String,
       default: null,
@@ -213,7 +217,6 @@ export default {
   }),
   computed: {
     gdpr() {
-      const gdprCountries = ['AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR', 'DE', 'GR', 'HU', 'IS', 'IE', 'IT', 'LV', 'LI', 'LT', 'LU', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'SK', 'ES', 'SE', 'GB'];
       if (this.country && this.gdprMessage) {
         for (let i = 0; i < gdprCountries.length; i += 1) {
           if (this.country === gdprCountries[i]) {

--- a/packages/marko-web-inquiry/browser/default-form.vue
+++ b/packages/marko-web-inquiry/browser/default-form.vue
@@ -130,7 +130,7 @@
         </div>
       </div>
     </div>
-    <div v-if="gdpr" class="row">
+    <div v-if="isGdprCountrySelected" class="row">
       <div class="col-12 form-group">
         <input
           id="inquiry-form.gdprOptIn"
@@ -154,7 +154,7 @@
     <button type="submit" class="btn btn-primary mb-3" :disabled="loading">
       Submit
     </button>
-    <div v-if="getPrivacyMessage" class="row">
+    <div v-if="privacyMessage" class="row">
       <p class="col-12">
         {{ privacyMessage }}
       </p>
@@ -216,18 +216,11 @@ export default {
     gdprOptIn: false,
   }),
   computed: {
-    gdpr() {
-      if (this.country && this.gdprMessage) {
-        for (let i = 0; i < gdprCountries.length; i += 1) {
-          if (this.country === gdprCountries[i]) {
-            return true;
-          }
-        }
+    isGdprCountrySelected() {
+      if (this.country && this.isGdprEnabled) {
+        return this.gdprCountryCodes.includes(this.country);
       }
       return false;
-    },
-    getPrivacyMessage() {
-      return this.privacyMessage;
     },
   },
   methods: {

--- a/packages/marko-web-inquiry/browser/default-form.vue
+++ b/packages/marko-web-inquiry/browser/default-form.vue
@@ -130,6 +130,18 @@
         </div>
       </div>
     </div>
+    <div v-if="gdpr" class="row">
+      <div class="col-12 form-group">
+        <input
+          id="inquiry-form.gdprOptIn"
+          v-model="gdprOptIn"
+          type="checkbox"
+        >
+        <label for="inquiry-form.gdprOptIn" class="d-inline">
+          {{ gdprMessage }}
+        </label>
+      </div>
+    </div>
     <pre v-if="error" class="alert alert-danger text-danger">An error occurred: {{ error }}</pre>
     <vue-recaptcha
       ref="invisibleRecaptcha"
@@ -139,9 +151,14 @@
       @verify="onVerify"
       @expired="onExpired"
     />
-    <button type="submit" class="btn btn-primary" :disabled="loading">
+    <button type="submit" class="btn btn-primary form-group" :disabled="loading">
       Submit
     </button>
+    <div v-if="getPrivacyMessage" class="row">
+      <p class="col-12">
+        {{ privacyMessage }}
+      </p>
+    </div>
   </form>
   <div v-else>
     Thanks for your inquiry! We'll reach out shortly.
@@ -169,6 +186,14 @@ export default {
       type: String,
       required: true,
     },
+    gdprMessage: {
+      type: String,
+      default: null,
+    },
+    privacyMessage: {
+      type: String,
+      default: null,
+    },
   },
   data: () => ({
     firstName: '',
@@ -180,7 +205,24 @@ export default {
     country: '',
     postalCode: '',
     comments: '',
+    gdprOptIn: false,
   }),
+  computed: {
+    gdpr() {
+      const gdprCountries = ['AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR', 'DE', 'GR', 'HU', 'IS', 'IE', 'IT', 'LV', 'LI', 'LT', 'LU', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'SK', 'ES', 'SE', 'GB'];
+      if (this.country && this.gdprMessage) {
+        for (let i = 0; i < gdprCountries.length; i += 1) {
+          if (this.country === gdprCountries[i]) {
+            return true;
+          }
+        }
+      }
+      return false;
+    },
+    getPrivacyMessage() {
+      return this.privacyMessage;
+    },
+  },
   methods: {
     onSubmit() {
       this.$refs.invisibleRecaptcha.execute();
@@ -205,6 +247,7 @@ export default {
         country,
         postalCode,
         comments,
+        gdprOptIn,
       } = this;
 
       const payload = {
@@ -218,6 +261,7 @@ export default {
         country,
         postalCode,
         comments,
+        gdprOptIn,
         token,
       };
 

--- a/packages/marko-web-inquiry/browser/default-form.vue
+++ b/packages/marko-web-inquiry/browser/default-form.vue
@@ -196,7 +196,7 @@ export default {
     },
     gdprMessage: {
       type: String,
-      default: null,
+      default: 'This website may use my contact information to communicate with me about other offerings that may be of interest.',
     },
     privacyMessage: {
       type: String,

--- a/packages/marko-web-inquiry/browser/default-form.vue
+++ b/packages/marko-web-inquiry/browser/default-form.vue
@@ -186,6 +186,10 @@ export default {
       type: String,
       required: true,
     },
+    isGdprEnabled: {
+      type: Boolean,
+      default: false,
+    },
     gdprMessage: {
       type: String,
       default: null,

--- a/packages/marko-web-inquiry/browser/default-form.vue
+++ b/packages/marko-web-inquiry/browser/default-form.vue
@@ -151,7 +151,7 @@
       @verify="onVerify"
       @expired="onExpired"
     />
-    <button type="submit" class="btn btn-primary form-group" :disabled="loading">
+    <button type="submit" class="btn btn-primary mb-3" :disabled="loading">
       Submit
     </button>
     <div v-if="getPrivacyMessage" class="row">

--- a/packages/marko-web-inquiry/components/form.marko
+++ b/packages/marko-web-inquiry/components/form.marko
@@ -39,8 +39,9 @@ $ const { RECAPTCHA_SITE_KEY } = require('../env');
       contentType: content.type,
       sitekey: RECAPTCHA_SITE_KEY,
       gdprMessage: inquiry.gdprMessage,
-      privacyMessage: inquiry.privacyMessage
       isGdprEnabled: Boolean(inquiry.isGdprEnabled),
+      gdprCountryCodes: inquiry.gdprCountryCodes,
+      privacyMessage: inquiry.privacyMessage,
     } />
   </marko-web-block>
 </if>

--- a/packages/marko-web-inquiry/components/form.marko
+++ b/packages/marko-web-inquiry/components/form.marko
@@ -40,6 +40,7 @@ $ const { RECAPTCHA_SITE_KEY } = require('../env');
       sitekey: RECAPTCHA_SITE_KEY,
       gdprMessage: inquiry.gdprMessage,
       privacyMessage: inquiry.privacyMessage
+      isGdprEnabled: Boolean(inquiry.isGdprEnabled),
     } />
   </marko-web-block>
 </if>

--- a/packages/marko-web-inquiry/components/form.marko
+++ b/packages/marko-web-inquiry/components/form.marko
@@ -37,7 +37,9 @@ $ const { RECAPTCHA_SITE_KEY } = require('../env');
       formClass: `${blockName}__form`,
       contentId: content.id,
       contentType: content.type,
-      sitekey: RECAPTCHA_SITE_KEY
+      sitekey: RECAPTCHA_SITE_KEY,
+      gdprMessage: inquiry.gdprMessage,
+      privacyMessage: inquiry.privacyMessage
     } />
   </marko-web-block>
 </if>

--- a/services/example-website-lfw/config/site.js
+++ b/services/example-website-lfw/config/site.js
@@ -49,6 +49,7 @@ module.exports = {
     sendBcc: 'emailactivity@cygnus.com',
     logo: 'https://img.laserfocusworld.com/files/base/pennwell/lfw/logo.png?h=60',
     bgColor: '#164f77',
+    isGdprEnabled: true,
     gdprMessage: "Yes, Endeavor Business Media may use my contact information consistent with Endeavor's Privacy Policy to communicate with me by email or telephone about other offerings by Endeavor, its brands, affiliates and/or third-party partners that may be of interest to businesses and individual participants in my industry.",
     privacyMessage: "By clicking above, I acknowledge and agree to Endeavor Business Media’s Terms of Service and to Endeavor Business Media's use of my contact information to communicate with me about offerings by Endeavor, its brands, affiliates and/or third-party partners, consistent with Endeavor's Privacy Policy. In addition, I understand that my personal information will be shared with any sponsor(s) of the resource, so they can contact me directly about their products or services. Please refer to the privacy policies of such sponsor(s) for more details on how your information will be used by them. You may unsubscribe at any time.",
   },

--- a/services/example-website-lfw/config/site.js
+++ b/services/example-website-lfw/config/site.js
@@ -49,5 +49,7 @@ module.exports = {
     sendBcc: 'emailactivity@cygnus.com',
     logo: 'https://img.laserfocusworld.com/files/base/pennwell/lfw/logo.png?h=60',
     bgColor: '#164f77',
+    gdprMessage: "Yes, Endeavor Business Media may use my contact information consistent with Endeavor's Privacy Policy to communicate with me by email or telephone about other offerings by Endeavor, its brands, affiliates and/or third-party partners that may be of interest to businesses and individual participants in my industry.",
+    privacyMessage: "By clicking above, I acknowledge and agree to Endeavor Business Media’s Terms of Service and to Endeavor Business Media's use of my contact information to communicate with me about offerings by Endeavor, its brands, affiliates and/or third-party partners, consistent with Endeavor's Privacy Policy. In addition, I understand that my personal information will be shared with any sponsor(s) of the resource, so they can contact me directly about their products or services. Please refer to the privacy policies of such sponsor(s) for more details on how your information will be used by them. You may unsubscribe at any time.",
   },
 };


### PR DESCRIPTION
EBM sites need a privacy compliance checkbox added to the inquiry forms, so if the user selects one of the affected countries, a checkbox will appear with a custom label set in site.js (`gdprMessage`).  By default, the message will be null and the checkbox (`gdprOptIn`) will be set to false.

Additionally, a second message is being added at the bottom of the form, regardless of country, which can also be set in site.js (`privacyMessage`). 

I'm still a vue noob, so if there's a better way of doing handling this, just let me know and I'd be happy to make any changes. :) 

<img width="1909" alt="Screen Shot 2020-12-02 at 4 45 17 PM" src="https://user-images.githubusercontent.com/12496550/100941505-58507d80-34bf-11eb-8ee9-eb75fd6a6354.png">

<img width="1911" alt="Screen Shot 2020-12-02 at 4 45 02 PM" src="https://user-images.githubusercontent.com/12496550/100941501-571f5080-34bf-11eb-82a4-083cf64706ea.png">

