### PR TITLE
Add support for (optional) custom comment streams

### DIFF
--- a/packages/marko-web-identity-x/browser/index.js
+++ b/packages/marko-web-identity-x/browser/index.js
@@ -9,11 +9,13 @@ export default (Browser, {
   CustomAuthenticateComponent,
   CustomLogoutComponent,
   CustomProfileComponent,
+  CustomCommentStreamComponent,
 } = {}) => {
   const LoginComponent = CustomLoginComponent || Login;
   const AuthenticateComponent = CustomAuthenticateComponent || Authenticate;
   const LogoutComponent = CustomLogoutComponent || Logout;
   const ProfileComponent = CustomProfileComponent || Profile;
+  const CommentStreamComponent = CustomCommentStreamComponent || CommentStream;
 
   const { EventBus } = Browser;
   Browser.register('IdentityXAuthenticate', AuthenticateComponent, {
@@ -28,5 +30,5 @@ export default (Browser, {
   Browser.register('IdentityXProfile', ProfileComponent, {
     on: { action: (...args) => EventBus.$emit('identity-x-profile', ...args) },
   });
-  Browser.register('IdentityXCommentStream', CommentStream);
+  Browser.register('IdentityXCommentStream', CommentStreamComponent);
 };


### PR DESCRIPTION
Passing a `CustomCommentStreamComponent` Vue component will allow for the default comment stream to be overridden, just like the other IdentityX components. This is completely optional and is opt-in only. As such, no BC issues are present.