### PR TITLE
Display custom questions on profile form and related components

### DIFF
--- a/packages/marko-web-identity-x/api/fragments/active-user.js
+++ b/packages/marko-web-identity-x/api/fragments/active-user.js
@@ -19,6 +19,26 @@ fragment ActiveUserFragment on AppUser {
     given
     date
   }
+  customSelectFieldAnswers(input: {
+    onlyActive: true
+    sort: { field: label, order: asc }
+  }) {
+    id
+    hasAnswered
+    answers {
+      id
+    }
+    field {
+      id
+      label
+      multiple
+      required
+      options {
+        id
+        label
+      }
+    }
+  }
 }
 
 `;

--- a/packages/marko-web-identity-x/browser/authenticate.vue
+++ b/packages/marko-web-identity-x/browser/authenticate.vue
@@ -92,6 +92,7 @@ export default {
     isRedirecting: false,
     isProfileComplete: true,
     activeUser: null,
+    requiresCustomFieldAnswers: false,
   }),
 
   /**
@@ -124,6 +125,7 @@ export default {
      *
      */
     showProfileForm() {
+      if (this.requiresCustomFieldAnswers) return true;
       return !this.hasRequiredFields || (this.isUserRedirect && !this.isProfileComplete);
     },
   },
@@ -161,6 +163,9 @@ export default {
         this.isProfileComplete = this.hasRequiredFields
           ? this.requiredFields.every(key => !isEmpty(this.activeUser[key]))
           : true;
+
+        this.requiresCustomFieldAnswers = this.activeUser.customSelectFieldAnswers
+          .some(({ hasAnswered, field }) => field.required && !hasAnswered);
 
         this.$emit('authenticate');
         if (!this.showProfileForm) this.redirect();

--- a/packages/marko-web-identity-x/browser/form/common/checkbox-group.vue
+++ b/packages/marko-web-identity-x/browser/form/common/checkbox-group.vue
@@ -93,13 +93,10 @@ export default {
 
   watch: {
     /**
-     * Emit the selected options when the checked array changes.
+     * Emit the selected option IDs when the checked array changes.
      */
     checked(ids) {
-      const selected = this.options
-        .filter(option => ids.includes(option.id))
-        .map(({ id, label }) => ({ id, label }));
-      this.$emit('change', selected);
+      this.$emit('change', ids);
     },
   },
 

--- a/packages/marko-web-identity-x/browser/form/common/checkbox-group.vue
+++ b/packages/marko-web-identity-x/browser/form/common/checkbox-group.vue
@@ -1,0 +1,112 @@
+<template>
+  <div>
+    <div
+      v-for="option in options"
+      :key="option.id"
+      class="custom-control custom-checkbox"
+    >
+      <input
+        :id="createId(option.id)"
+        v-model="checked"
+        :required="isRequired"
+        :value="option.id"
+        type="checkbox"
+        class="custom-control-input"
+      >
+      <label
+        :for="createId(option.id)"
+        class="custom-control-label"
+      >
+        {{ option.label }}
+      </label>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    /**
+     * The wrapping field group identifier.
+     */
+    groupId: {
+      type: String,
+      required: true,
+    },
+
+    /**
+     * Whether the checkbox group is required.
+     */
+    required: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * An array of option objects:
+     * [
+     *   { id: 'some-id', label: 'Some label' },
+     * ]
+     */
+    options: {
+      type: Array,
+      default: () => [],
+    },
+
+    /**
+     * An array of selected option IDs.
+     * ['some-id']
+     */
+    selected: {
+      type: Array,
+      default: () => [],
+    },
+  },
+
+  data() {
+    return {
+      /**
+       * Clone the selected value to the checked array.
+       * This is used internally as the `v-model` for the checkboxes.
+       * The value is then watched to emit the change event.
+       */
+      checked: [...this.selected],
+    };
+  },
+
+  computed: {
+    /**
+     * Determines if the checkboxes are required from a
+     * validation perspective. Because HTML5 doesn't support
+     * checkbox groups out-of-the-box, this will make all the boxes
+     * required when none are checked, but optional when at least one
+     * is checked.
+     *
+     * This only applies when the overall group `required` prop is set to true.
+     */
+    isRequired() {
+      if (!this.required) return false;
+      if (this.selected.length) return false;
+      return true;
+    },
+  },
+
+  watch: {
+    /**
+     * Emit the selected options when the checked array changes.
+     */
+    checked(ids) {
+      const selected = this.options
+        .filter(option => ids.includes(option.id))
+        .map(({ id, label }) => ({ id, label }));
+      this.$emit('change', selected);
+    },
+  },
+
+  methods: {
+    createId(optionId) {
+      return `checkbox-${this.groupId}-${optionId}`;
+    },
+  },
+};
+</script>

--- a/packages/marko-web-identity-x/browser/form/fields/custom-select.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/custom-select.vue
@@ -1,0 +1,114 @@
+<template>
+  <form-group>
+    <form-label :for="fieldId" :required="required">
+      {{ label }}
+    </form-label>
+    <checkbox-group
+      v-if="multiple"
+      :group-id="id"
+      :options="options"
+      :selected="selectedOptionIds"
+      :required="required"
+      @change="$emit('change', $event)"
+    />
+    <select
+      v-else
+      :id="fieldId"
+      class="custom-select"
+      :required="required"
+      @change="$emit('change', [$event.target.value])"
+    >
+      <option value="">
+        Please select...
+      </option>
+      <option
+        v-for="option in options"
+        :key="option.id"
+        :value="option.id"
+        :selected="option.id === selectedOptionId"
+      >
+        {{ option.label }}
+      </option>
+    </select>
+  </form-group>
+</template>
+
+<script>
+import CheckboxGroup from '../common/checkbox-group.vue';
+import FormGroup from '../common/form-group.vue';
+import FormLabel from '../common/form-label.vue';
+
+export default {
+  components: {
+    CheckboxGroup,
+    FormGroup,
+    FormLabel,
+  },
+
+  props: {
+    /**
+     * The unique field id.
+     */
+    id: {
+      type: String,
+      required: true,
+    },
+
+    /**
+     * The field display label.
+     */
+    label: {
+      type: String,
+      required: true,
+    },
+
+    /**
+     * Whether the field is required.
+     */
+    required: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Whether the custom question supports multiple answers.
+     */
+    multiple: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * The field options (the possible answers).
+     */
+    options: {
+      type: Array,
+      default: () => [],
+    },
+
+    /**
+     * Since all custom select answers are arrays mimic this behavior.
+     */
+    selected: {
+      type: Array,
+      default: () => [],
+    },
+  },
+
+  computed: {
+    fieldId() {
+      return `custom-select-${this.id}`;
+    },
+
+    selectedOptionIds() {
+      return this.selected.map(item => item.id);
+    },
+
+    selectedOptionId() {
+      const { selectedOptionIds, multiple } = this;
+      if (!multiple) return selectedOptionIds[0] || '';
+      return selectedOptionIds.slice();
+    },
+  },
+};
+</script>

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -58,6 +58,21 @@
           </div>
         </div>
 
+        <div v-if="customSelectFieldAnswers.length" class="row">
+          <custom-select
+            v-for="fieldAnswer in customSelectFieldAnswers"
+            :id="fieldAnswer.field.id"
+            :key="fieldAnswer.id"
+            class="col-md-6"
+            :label="fieldAnswer.field.label"
+            :required="fieldAnswer.field.required"
+            :multiple="fieldAnswer.field.multiple"
+            :selected="fieldAnswer.answers"
+            :options="fieldAnswer.field.options"
+            @change="onCustomSelectChange(fieldAnswer.answers, $event)"
+          />
+        </div>
+
         <div v-if="emailConsentRequest" class="row mt-3">
           <div class="col-md-6">
             <receive-email
@@ -112,6 +127,7 @@ import post from './utils/post';
 import cookiesEnabled from './utils/cookies-enabled';
 import regionCountryCodes from './utils/region-country-codes';
 
+import CustomSelect from './form/fields/custom-select.vue';
 import GivenName from './form/fields/given-name.vue';
 import FamilyName from './form/fields/family-name.vue';
 import Organization from './form/fields/organization.vue';
@@ -126,8 +142,11 @@ import Login from './login.vue';
 import FeatureError from './errors/feature';
 import FormError from './errors/form';
 
+const { isArray } = Array;
+
 export default {
   components: {
+    CustomSelect,
     GivenName,
     FamilyName,
     Organization,
@@ -254,6 +273,14 @@ export default {
         return countryCodes.includes(countryCode);
       });
     },
+
+    /**
+     *
+     */
+    customSelectFieldAnswers() {
+      const { customSelectFieldAnswers } = this.user;
+      return isArray(customSelectFieldAnswers) ? customSelectFieldAnswers : [];
+    },
   },
 
   /**
@@ -306,6 +333,11 @@ export default {
       } else {
         this.user.regionalConsentAnswers.push({ id: policyId, given });
       }
+    },
+
+    onCustomSelectChange(answers, ids) {
+      answers.splice(0);
+      answers.push(...ids.map(id => ({ id })));
     },
 
     /**

--- a/packages/marko-web-identity-x/service.js
+++ b/packages/marko-web-identity-x/service.js
@@ -41,7 +41,12 @@ class IdentityX {
     if (access.isLoggedIn && requiredFields.length) {
       // Check if the user requires additonal input.
       const { user, application } = await this.loadActiveContext();
+
       access.requiresUserInput = user ? requiredFields.some(key => isEmpty(user[key])) : false;
+      if (!access.requiresUserInput) {
+        // Check if user needs to answer any globally required custom fields.
+        access.requiresUserInput = user.customSelectFieldAnswers.some(({ hasAnswered, field }) => field.required && !hasAnswered);
+      }
 
       if (user && !access.requiresUserInput) {
         const { regionalConsentPolicies } = application.organization;

--- a/packages/marko-web-identity-x/service.js
+++ b/packages/marko-web-identity-x/service.js
@@ -45,7 +45,8 @@ class IdentityX {
       access.requiresUserInput = user ? requiredFields.some(key => isEmpty(user[key])) : false;
       if (!access.requiresUserInput) {
         // Check if user needs to answer any globally required custom fields.
-        access.requiresUserInput = user.customSelectFieldAnswers.some(({ hasAnswered, field }) => field.required && !hasAnswered);
+        access.requiresUserInput = user.customSelectFieldAnswers
+          .some(({ hasAnswered, field }) => field.required && !hasAnswered);
       }
 
       if (user && !access.requiresUserInput) {


### PR DESCRIPTION
Adds support for displaying custom questions on the user profile form and any gated content items.

When the user's profile is displayed (either when initially authenticating, via the profile page, or within a gate) all _active_ custom questions will be visible within the form. There is _zero_ configuration required for this: if a custom question is active for a site it will automatically display on the form.

If a custom question is set as _globally required_, the user will be forced to answer it before proceeding past a content gate.

**Note:** websites using the `@base-cms/marko-web-identity-x` package _must_ update their dependencies (once this PR is merged and published) in order to take advantage of these features.

## Examples

### On initial login
When a user initially authenticates, if active+required questions are enabled for the site, the user will be prompted to answer them:
![image](https://user-images.githubusercontent.com/3289485/106177156-c763ee80-615d-11eb-9941-c35966d60860.png)

### On gated content
When a user encounters a content gate, if active+required questions are enabled for the site, the user will be required to answer them before moving past the gate:
![image](https://user-images.githubusercontent.com/3289485/106177402-1742b580-615e-11eb-9dc2-27b2246931da.png)


### On the user profile page
The user can also manage their answers by visiting the profile page:
![image](https://user-images.githubusercontent.com/3289485/106177567-4e18cb80-615e-11eb-89c7-ff5c367c33c3.png)

### Multi-answer questions
Questions that are configured to support multiple answers will appear as checkboxes:
![image](https://user-images.githubusercontent.com/3289485/106178476-71904600-615f-11eb-82df-ba3b2f393545.png)


Requires base-cms/id-me#79 to be merged and deployed.