### PR TITLE
fix login for non-NorthAmerica countries when region is required field

### DIFF
--- a/packages/marko-web-identity-x/routes/login.js
+++ b/packages/marko-web-identity-x/routes/login.js
@@ -63,11 +63,17 @@ module.exports = asyncRoute(async (req, res) => {
   const { data } = await identityX.client.query({ query, variables });
   let { appUser } = data;
 
-
   if (!appUser) {
     // Create the user.
     const { data: newUser } = await identityX.client.mutate({ mutation: createUser, variables });
     appUser = newUser.createAppUser;
+  }
+
+  // Don't require regionCode if not supported based on country selection
+  if (appUser.countryCode) {
+    if (!['US', 'CA', 'MX'].includes(appUser.countryCode)) {
+      requiredFields = requiredFields.filter((item) => item !== 'regionCode');
+    }
   }
 
   // determine if the user is missing fields that are required before sending the login link


### PR DESCRIPTION
country and region are statically required for all users (based on site config but same for all our sites ATM) but region dropdown is only supported and available in the form for North America so other countries cannot pass validation.